### PR TITLE
feat: restrict channel member management to channel owners only

### DIFF
--- a/web-app/code/src/infrastructure/trpc/channels.ts
+++ b/web-app/code/src/infrastructure/trpc/channels.ts
@@ -63,13 +63,16 @@ export const channelsRouter = router({
   addMember: authedProcedure
     .input(z.object({ channelId: z.string(), userId: z.string() }))
     .mutation(async ({ ctx, input }) => {
-      // Fetch channel to get buildunit_id
+      // Fetch channel to get buildunit_id and owner_id
       const [channel] = await ctx.db
-        .select({ buildunit_id: channelsTable.buildunit_id })
+        .select({ buildunit_id: channelsTable.buildunit_id, owner_id: channelsTable.owner_id })
         .from(channelsTable)
         .where(eq(channelsTable.id, input.channelId))
       if (!channel) {
         throw new TRPCError({ code: `NOT_FOUND`, message: `Channel not found` })
+      }
+      if (channel.owner_id !== ctx.session.user.id) {
+        throw new TRPCError({ code: `FORBIDDEN`, message: `Only the channel owner can add members` })
       }
 
       // Fetch build unit to get project_id
@@ -129,6 +132,16 @@ export const channelsRouter = router({
   removeMember: authedProcedure
     .input(z.object({ channelId: z.string(), userId: z.string() }))
     .mutation(async ({ ctx, input }) => {
+      const [channel] = await ctx.db
+        .select({ owner_id: channelsTable.owner_id })
+        .from(channelsTable)
+        .where(eq(channelsTable.id, input.channelId))
+      if (!channel) {
+        throw new TRPCError({ code: `NOT_FOUND`, message: `Channel not found` })
+      }
+      if (channel.owner_id !== ctx.session.user.id) {
+        throw new TRPCError({ code: `FORBIDDEN`, message: `Only the channel owner can remove members` })
+      }
       const result = await ctx.db.transaction(async (tx) => {
         const txid = await generateTxId(tx)
         await tx

--- a/web-app/code/src/presentation/pages/ChannelPage.tsx
+++ b/web-app/code/src/presentation/pages/ChannelPage.tsx
@@ -161,6 +161,7 @@ export function ChannelPage({
   };
 
   const channelOwnerId = channelData?.[0]?.owner_id;
+  const isOwner = session?.user?.id === channelOwnerId;
 
   return (
     <>
@@ -207,7 +208,7 @@ export function ChannelPage({
             <div className="relative">
               <AddTaskButton
                 onClick={() => setTaskFormOpen(true)}
-                onAddPeople={() => setAddPeopleOpen((v) => !v)}
+                onAddPeople={isOwner ? () => setAddPeopleOpen((v) => !v) : undefined}
               />
               {addPeopleOpen && (
                 <>
@@ -359,7 +360,7 @@ export function ChannelPage({
                           </div>
                           <span className="text-sm text-[#1e1e1e] truncate">{u.name || u.email}</span>
                         </div>
-                        {u.id !== channelOwnerId && (
+                        {isOwner && u.id !== channelOwnerId && (
                           <button
                             onClick={() => { setRemovingMember({ id: u.id, name: u.name || u.email || u.id }); setConfirmStep(1); }}
                             className="opacity-0 group-hover:opacity-100 text-red-400 hover:text-red-600 text-xs transition-opacity"


### PR DESCRIPTION
Only the channel owner can now add or remove members. The backend (tRPC) enforces this with a FORBIDDEN error; the frontend hides the Add People button and remove controls for non-owners. Closes #6 