### PR TITLE
feat: restrict teams to project owners and fix member visibility

### DIFF
--- a/web-app/code/drizzle/0014_teams_owner_project_members.sql
+++ b/web-app/code/drizzle/0014_teams_owner_project_members.sql
@@ -1,0 +1,3 @@
+ALTER TABLE "teams" ADD COLUMN "owner_id" text NOT NULL REFERENCES "public"."users"("id") ON DELETE CASCADE;--> statement-breakpoint
+ALTER TABLE "teams" ADD COLUMN "project_id" text NOT NULL REFERENCES "public"."projects"("id") ON DELETE CASCADE;--> statement-breakpoint
+ALTER TABLE "teams" ADD COLUMN "member_ids" text[] NOT NULL DEFAULT '{}';

--- a/web-app/code/src/infrastructure/database/schema/admin-schema.ts
+++ b/web-app/code/src/infrastructure/database/schema/admin-schema.ts
@@ -33,6 +33,13 @@ export const teamsTable = pgTable('teams', {
   id: text('id').primaryKey(),
   name: text('name').notNull(),
   description: text('description'),
+  owner_id: text('owner_id')
+    .notNull()
+    .references(() => users.id, { onDelete: 'cascade' }),
+  project_id: text('project_id')
+    .notNull()
+    .references(() => projectsTable.id, { onDelete: 'cascade' }),
+  member_ids: text('member_ids').array().notNull(),
   created_at: timestamp({ withTimezone: true }).notNull().defaultNow(),
 })
 
@@ -165,11 +172,13 @@ export const resourcesRawTable = pgTable(`resources_raw`, {
 
 export const selectTeamSchema = createSelectSchema(teamsTable).extend({
   description: z.string().nullish(),
+  member_ids: z.array(z.string()).default([]),
 })
 export const createTeamSchema = createInsertSchema(teamsTable).omit({
   created_at: true,
 }).extend({
   description: z.string().nullish(),
+  member_ids: z.array(z.string()).default([]),
 })
 export const updateTeamSchema = createUpdateSchema(teamsTable)
 

--- a/web-app/code/src/infrastructure/database/tanstack-db-electric/admincollections.ts
+++ b/web-app/code/src/infrastructure/database/tanstack-db-electric/admincollections.ts
@@ -386,6 +386,13 @@ export const propertiesCollection = createCollection(
   })
 )
 
+const electricTeamSchema = selectTeamSchema.extend({
+  member_ids: z.preprocess(
+    (v) => (typeof v === "string" ? JSON.parse(v) : v),
+    z.array(z.string()).default([])
+  ),
+})
+
 export const teamsCollection = createCollection(
   electricCollectionOptions({
     id: `teams`,
@@ -396,7 +403,7 @@ export const teamsCollection = createCollection(
         timestamptz: (date: string) => new Date(date),
       },
     },
-    schema: selectTeamSchema,
+    schema: electricTeamSchema,
     getKey: (item) => item.id,
     onInsert: async ({ transaction }) => {
       const { modified: newTeam } = transaction.mutations[0]
@@ -404,6 +411,9 @@ export const teamsCollection = createCollection(
         id: newTeam.id,
         name: newTeam.name,
         description: newTeam.description,
+        owner_id: newTeam.owner_id,
+        project_id: newTeam.project_id,
+        member_ids: newTeam.member_ids ?? [],
       })
       return { txid: result.txid }
     },

--- a/web-app/code/src/infrastructure/trpc/teams.ts
+++ b/web-app/code/src/infrastructure/trpc/teams.ts
@@ -1,9 +1,10 @@
 import { router, authedProcedure, generateTxId } from "./lib/trpc"
 import { z } from "zod"
 import { TRPCError } from "@trpc/server"
-import { eq } from "drizzle-orm"
+import { eq, and } from "drizzle-orm"
 import {
   teamsTable,
+  projectsTable,
   createTeamSchema,
   updateTeamSchema,
 } from "../database/schema/admin-schema"
@@ -12,11 +13,23 @@ export const teamsRouter = router({
   create: authedProcedure
     .input(createTeamSchema)
     .mutation(async ({ ctx, input }) => {
+      // Only project owners can create teams
+      const [project] = await ctx.db
+        .select({ owner_id: projectsTable.owner_id })
+        .from(projectsTable)
+        .where(eq(projectsTable.id, input.project_id))
+      if (!project) {
+        throw new TRPCError({ code: `NOT_FOUND`, message: `Project not found` })
+      }
+      if (project.owner_id !== ctx.session.user.id) {
+        throw new TRPCError({ code: `FORBIDDEN`, message: `Only project owners can create teams` })
+      }
+
       const result = await ctx.db.transaction(async (tx) => {
         const txid = await generateTxId(tx)
         const [newItem] = await tx
           .insert(teamsTable)
-          .values(input)
+          .values({ ...input, owner_id: ctx.session.user.id })
           .returning()
         return { item: newItem, txid }
       })

--- a/web-app/code/src/presentation/components/buildInlime/Sidebar.tsx
+++ b/web-app/code/src/presentation/components/buildInlime/Sidebar.tsx
@@ -62,6 +62,7 @@ export function Sidebar({ projectId }: SidebarProps) {
     [projectId]
   );
   const projectName = currentProject?.[0]?.name ?? "";
+  const isProjectOwner = !!currentUserId && currentProject?.[0]?.owner_id === currentUserId;
 
   const getChannelsForBuildUnit = (buildUnitId: string) =>
     (allChannels ?? []).filter((c) => c.buildunit_id === buildUnitId);
@@ -84,7 +85,7 @@ export function Sidebar({ projectId }: SidebarProps) {
 
   const handleCreate = async (e: React.FormEvent) => {
     e.preventDefault();
-    if (!teamName.trim() || !currentUserId) return;
+    if (!teamName.trim() || !currentUserId || !projectId) return;
     setIsSubmitting(true);
     const memberIds = selectedMemberIds.includes(currentUserId)
       ? selectedMemberIds
@@ -94,6 +95,9 @@ export function Sidebar({ projectId }: SidebarProps) {
         id: crypto.randomUUID(),
         name: teamName.trim(),
         description: teamDesc.trim() || null,
+        owner_id: currentUserId,
+        project_id: projectId,
+        member_ids: memberIds,
         created_at: new Date(),
       });
       setCreateOpen(false);
@@ -265,8 +269,8 @@ export function Sidebar({ projectId }: SidebarProps) {
             </div>
           )}
 
-          {/* Teams — only when inside a project */}
-          {projectId && <div className="mb-4">
+          {/* Teams — only when inside a project and user is the project owner */}
+          {projectId && isProjectOwner && <div className="mb-4">
             <div className="flex items-center gap-1 px-2 py-1 mb-1">
               <button
                 onClick={() => setExpandedTeams(!expandedTeams)}
@@ -293,14 +297,19 @@ export function Sidebar({ projectId }: SidebarProps) {
                 {(allTeams ?? []).length === 0 ? (
                   <p className="px-3 py-1 text-xs text-[#717182]">No teams yet</p>
                 ) : (
-                  (allTeams ?? []).map((team) => (
-                    <TeamSection
-                      key={team.id}
-                      name={team.name}
-                      description={team.description}
-                      members={[]}
-                    />
-                  ))
+                  (allTeams ?? []).map((team) => {
+                    const members = (allUsers ?? [])
+                      .filter((u) => team.member_ids.includes(u.id))
+                      .map((u) => ({ id: u.id, name: u.name ?? "", email: u.email }));
+                    return (
+                      <TeamSection
+                        key={team.id}
+                        name={team.name}
+                        description={team.description}
+                        members={members}
+                      />
+                    );
+                  })
                 )}
               </div>
             )}

--- a/web-app/code/src/presentation/routes/api/teams.ts
+++ b/web-app/code/src/presentation/routes/api/teams.ts
@@ -13,6 +13,7 @@ const serve = async ({ request }: { request: Request }) => {
 
   const originUrl = prepareElectricUrl(request.url)
   originUrl.searchParams.set("table", "teams")
+  originUrl.searchParams.set("where", `owner_id = '${session.user.id}'`)
 
   return proxyElectricRequest(originUrl)
 }


### PR DESCRIPTION
## Summary
- **Teams visibility**: The Teams section in the sidebar is now hidden for non-project-owners — only the project owner sees it
- **Create restriction**: Only project owners can create teams, enforced both in the UI (button only shown to owners) and backend (tRPC returns `FORBIDDEN` if caller is not the project owner)
- **Fix team members not showing**: Added `member_ids` (text array) to the teams table; members are now persisted on creation and resolved from `usersCollection` when rendering `TeamSection`
- **Data model**: Added `owner_id`, `project_id`, and `member_ids` columns to `teams` table with migration `0014`
- **API filtering**: `/api/teams` Electric shape now filters with `WHERE owner_id = '<user_id>'` so users only receive their own teams

## Files changed
| File | Change |
|------|--------|
| `admin-schema.ts` | Added `owner_id`, `project_id`, `member_ids` to `teamsTable`; updated Zod schemas |
| `admincollections.ts` | Updated `teamsCollection` schema + `onInsert` to pass new fields |
| `teams.ts` (tRPC) | Added project ownership check before insert |
| `Sidebar.tsx` | Gated Teams section on `isProjectOwner`; resolved members from `member_ids` |
| `api/teams.ts` | Added `WHERE owner_id` filter to Electric shape |
| `0014_teams_owner_project_members.sql` | Migration adding the 3 new columns |

## Test plan
- [ ] Log in as a project owner — verify Teams section is visible and "+ Create team" button works
- [ ] Log in as a non-owner project member — verify Teams section is not visible
- [ ] Create a team with members selected — expand the team in the sidebar and verify members are listed
- [ ] Attempt to create a team via API as a non-owner — verify `FORBIDDEN` error is returned
- [ ] Run migration `0014` against the database

Closes #4 
🤖 Generated with [Claude Code](https://claude.com/claude-code)