### PR TITLE
fix: optimistic insert with sync-aware spinner for build units and channels

### DIFF
--- a/web-app/code/src/infrastructure/database/tanstack-db-electric/admincollections.ts
+++ b/web-app/code/src/infrastructure/database/tanstack-db-electric/admincollections.ts
@@ -62,6 +62,7 @@ const electricUsersSchema = z.object({
 
 const electricMembershipSchema = selectMembershipSchema.extend({
   member_flag: z.preprocess(coerceBool, z.boolean()),
+  role: z.enum([`owner`, `co-owner`, `viewer`]).default(`viewer`),
 })
 
 const origin = typeof window !== `undefined`
@@ -148,6 +149,19 @@ export const projectsCollection = createCollection(
   })
 )
 
+// Registry allowing UI components to be notified when a build unit insert
+// completes (success or error) via the onInsert handler below.
+type InsertCallback = { resolve: () => void; reject: (err: Error) => void }
+const _buildUnitInsertCallbacks = new Map<string, InsertCallback>()
+
+export function registerBuildUnitInsertCallback(
+  id: string,
+  resolve: () => void,
+  reject: (err: Error) => void,
+) {
+  _buildUnitInsertCallbacks.set(id, { resolve, reject })
+}
+
 export const buildUnitsCollection = createCollection(
   electricCollectionOptions({
     id: `build-units`,
@@ -164,15 +178,22 @@ export const buildUnitsCollection = createCollection(
     getKey: (item) => item.id,
     onInsert: async ({ transaction }) => {
       const { modified: newBuildUnit } = transaction.mutations[0]
-      const result = await trpc.buildUnits.create.mutate({
-        id: newBuildUnit.id,
-        name: newBuildUnit.name,
-        description: newBuildUnit.description,
-        project_id: newBuildUnit.project_id,
-        owner_id: newBuildUnit.owner_id,
-      })
-
-      return { txid: result.txid }
+      try {
+        const result = await trpc.buildUnits.create.mutate({
+          id: newBuildUnit.id,
+          name: newBuildUnit.name,
+          description: newBuildUnit.description,
+          project_id: newBuildUnit.project_id,
+          owner_id: newBuildUnit.owner_id,
+        })
+        _buildUnitInsertCallbacks.get(newBuildUnit.id)?.resolve()
+        _buildUnitInsertCallbacks.delete(newBuildUnit.id)
+        return { txid: result.txid }
+      } catch (err) {
+        _buildUnitInsertCallbacks.get(newBuildUnit.id)?.reject(err instanceof Error ? err : new Error(String(err)))
+        _buildUnitInsertCallbacks.delete(newBuildUnit.id)
+        throw err
+      }
     },
     onUpdate: async ({ transaction }) => {
       const { modified: updatedBuildUnit } = transaction.mutations[0]
@@ -197,6 +218,19 @@ export const buildUnitsCollection = createCollection(
   })
 )
 
+// Registry allowing UI components to be notified when a channel insert
+// completes (success or error) via the onInsert handler below.
+type ChannelInsertCallback = { resolve: () => void; reject: (err: Error) => void }
+const _channelInsertCallbacks = new Map<string, ChannelInsertCallback>()
+
+export function registerChannelInsertCallback(
+  id: string,
+  resolve: () => void,
+  reject: (err: Error) => void,
+) {
+  _channelInsertCallbacks.set(id, { resolve, reject })
+}
+
 export const channelsCollection = createCollection(
   electricCollectionOptions({
     id: `channels`,
@@ -213,15 +247,22 @@ export const channelsCollection = createCollection(
     getKey: (item) => item.id,
     onInsert: async ({ transaction }) => {
       const { modified: newChannel } = transaction.mutations[0]
-      const result = await trpc.channels.create.mutate({
-        id: newChannel.id,
-        name: newChannel.name,
-        description: newChannel.description,
-        buildunit_id: newChannel.buildunit_id,
-        owner_id: newChannel.owner_id,
-      })
-
-      return { txid: result.txid }
+      try {
+        const result = await trpc.channels.create.mutate({
+          id: newChannel.id,
+          name: newChannel.name,
+          description: newChannel.description,
+          buildunit_id: newChannel.buildunit_id,
+          owner_id: newChannel.owner_id,
+        })
+        _channelInsertCallbacks.get(newChannel.id)?.resolve()
+        _channelInsertCallbacks.delete(newChannel.id)
+        return { txid: result.txid }
+      } catch (err) {
+        _channelInsertCallbacks.get(newChannel.id)?.reject(err instanceof Error ? err : new Error(String(err)))
+        _channelInsertCallbacks.delete(newChannel.id)
+        throw err
+      }
     },
     onUpdate: async ({ transaction }) => {
       const { modified: updatedChannel } = transaction.mutations[0]

--- a/web-app/code/src/infrastructure/trpc/buildunits.ts
+++ b/web-app/code/src/infrastructure/trpc/buildunits.ts
@@ -1,7 +1,7 @@
 import { router, authedProcedure, generateTxId } from "./lib/trpc"
 import { z } from "zod"
 import { TRPCError } from "@trpc/server"
-import { eq, and } from "drizzle-orm"
+import { eq, and, ilike } from "drizzle-orm"
 import {
   buildUnitsTable,
   projectsTable,
@@ -23,6 +23,18 @@ export const buildUnitsRouter = router({
       }
       if (project.owner_id !== ctx.session.user.id) {
         throw new TRPCError({ code: `FORBIDDEN`, message: `Only project owners can create build units` })
+      }
+
+      // Prevent duplicate build unit names within the same project (case-insensitive)
+      const [duplicate] = await ctx.db
+        .select({ id: buildUnitsTable.id })
+        .from(buildUnitsTable)
+        .where(and(
+          eq(buildUnitsTable.project_id, input.project_id),
+          ilike(buildUnitsTable.name, input.name),
+        ))
+      if (duplicate) {
+        throw new TRPCError({ code: `CONFLICT`, message: `A build unit named "${input.name}" already exists in this project` })
       }
 
       const result = await ctx.db.transaction(async (tx) => {

--- a/web-app/code/src/infrastructure/trpc/buildunits.ts
+++ b/web-app/code/src/infrastructure/trpc/buildunits.ts
@@ -4,6 +4,7 @@ import { TRPCError } from "@trpc/server"
 import { eq, and } from "drizzle-orm"
 import {
   buildUnitsTable,
+  projectsTable,
   createBuildUnitSchema,
   updateBuildUnitSchema,
 } from "../database/schema/admin-schema"
@@ -12,6 +13,18 @@ export const buildUnitsRouter = router({
   create: authedProcedure
     .input(createBuildUnitSchema)
     .mutation(async ({ ctx, input }) => {
+      // Only project owners can create build units
+      const [project] = await ctx.db
+        .select({ owner_id: projectsTable.owner_id })
+        .from(projectsTable)
+        .where(eq(projectsTable.id, input.project_id))
+      if (!project) {
+        throw new TRPCError({ code: `NOT_FOUND`, message: `Project not found` })
+      }
+      if (project.owner_id !== ctx.session.user.id) {
+        throw new TRPCError({ code: `FORBIDDEN`, message: `Only project owners can create build units` })
+      }
+
       const result = await ctx.db.transaction(async (tx) => {
         const txid = await generateTxId(tx)
         const [newItem] = await tx

--- a/web-app/code/src/infrastructure/trpc/channels.ts
+++ b/web-app/code/src/infrastructure/trpc/channels.ts
@@ -5,6 +5,7 @@ import { eq, and } from "drizzle-orm"
 import {
   channelsTable,
   buildUnitsTable,
+  projectsTable,
   membershipTable,
   createChannelSchema,
   updateChannelSchema,
@@ -14,6 +15,25 @@ export const channelsRouter = router({
   create: authedProcedure
     .input(createChannelSchema)
     .mutation(async ({ ctx, input }) => {
+      // Only project owners can create channels — walk buildUnit → project
+      const [buildUnit] = await ctx.db
+        .select({ project_id: buildUnitsTable.project_id })
+        .from(buildUnitsTable)
+        .where(eq(buildUnitsTable.id, input.buildunit_id))
+      if (!buildUnit) {
+        throw new TRPCError({ code: `NOT_FOUND`, message: `Build unit not found` })
+      }
+      const [project] = await ctx.db
+        .select({ owner_id: projectsTable.owner_id })
+        .from(projectsTable)
+        .where(eq(projectsTable.id, buildUnit.project_id))
+      if (!project) {
+        throw new TRPCError({ code: `NOT_FOUND`, message: `Project not found` })
+      }
+      if (project.owner_id !== ctx.session.user.id) {
+        throw new TRPCError({ code: `FORBIDDEN`, message: `Only project owners can create channels` })
+      }
+
       const result = await ctx.db.transaction(async (tx) => {
         const txid = await generateTxId(tx)
         const [newItem] = await tx

--- a/web-app/code/src/infrastructure/trpc/channels.ts
+++ b/web-app/code/src/infrastructure/trpc/channels.ts
@@ -1,7 +1,7 @@
 import { router, authedProcedure, generateTxId } from "./lib/trpc"
 import { z } from "zod"
 import { TRPCError } from "@trpc/server"
-import { eq, and } from "drizzle-orm"
+import { eq, and, sql } from "drizzle-orm"
 import {
   channelsTable,
   buildUnitsTable,
@@ -34,12 +34,36 @@ export const channelsRouter = router({
         throw new TRPCError({ code: `FORBIDDEN`, message: `Only project owners can create channels` })
       }
 
+      // Prevent duplicate channel names within the same build unit
+      const [duplicate] = await ctx.db
+        .select({ id: channelsTable.id })
+        .from(channelsTable)
+        .where(and(
+          eq(channelsTable.buildunit_id, input.buildunit_id),
+          sql`CAST(${channelsTable.name} AS text) = ${JSON.stringify(input.name)}`
+        ))
+      if (duplicate) {
+        throw new TRPCError({ code: `CONFLICT`, message: `A ${input.name} channel already exists in this build unit` })
+      }
+
       const result = await ctx.db.transaction(async (tx) => {
         const txid = await generateTxId(tx)
         const [newItem] = await tx
           .insert(channelsTable)
           .values(input)
           .returning()
+
+        // Auto-add the channel owner as a member with role 'owner'
+        await tx.insert(membershipTable).values({
+          id: crypto.randomUUID(),
+          user_id: ctx.session.user.id,
+          channel_id: newItem.id,
+          buildunit_id: input.buildunit_id,
+          project_id: buildUnit.project_id,
+          member_flag: true,
+          role: `owner`,
+        })
+
         return { item: newItem, txid }
       })
 
@@ -125,7 +149,7 @@ export const channelsRouter = router({
           // Re-activate removed membership
           const [updated] = await tx
             .update(membershipTable)
-            .set({ member_flag: true })
+            .set({ member_flag: true, role: `viewer` })
             .where(eq(membershipTable.id, existing.id))
             .returning()
           return { item: updated, txid }
@@ -141,6 +165,7 @@ export const channelsRouter = router({
             buildunit_id: channel.buildunit_id,
             project_id: buildUnit.project_id,
             member_flag: true,
+            role: `viewer`,
           })
           .returning()
         return { item: inserted, txid }

--- a/web-app/code/src/presentation/components/buildInlime/BuildUnitsTable.tsx
+++ b/web-app/code/src/presentation/components/buildInlime/BuildUnitsTable.tsx
@@ -18,9 +18,10 @@ type BuildUnit = {
 interface BuildUnitsTableProps {
   buildUnits: BuildUnit[];
   onBuildUnitClick?: (buildUnit: BuildUnit) => void;
+  pendingIds?: Set<string>;
 }
 
-export function BuildUnitsTable({ buildUnits, onBuildUnitClick }: BuildUnitsTableProps) {
+export function BuildUnitsTable({ buildUnits, onBuildUnitClick, pendingIds }: BuildUnitsTableProps) {
   const [hoveredTaskId, setHoveredTaskId] = useState<string | null>(null);
 
   const getHealthColor = (health: string) => {
@@ -108,6 +109,17 @@ export function BuildUnitsTable({ buildUnits, onBuildUnitClick }: BuildUnitsTabl
                   >
                     {unit.name}
                   </span>
+                  {pendingIds?.has(unit.id) && (
+                    <svg
+                      className="animate-spin w-3 h-3 text-[#976623] shrink-0"
+                      xmlns="http://www.w3.org/2000/svg"
+                      fill="none"
+                      viewBox="0 0 24 24"
+                    >
+                      <circle className="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" strokeWidth="4" />
+                      <path className="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4z" />
+                    </svg>
+                  )}
                 </div>
               </td>
               <td className="px-6 py-4">

--- a/web-app/code/src/presentation/components/buildInlime/ChannelCard.tsx
+++ b/web-app/code/src/presentation/components/buildInlime/ChannelCard.tsx
@@ -7,6 +7,7 @@ interface ChannelCardProps {
   description: string;
   to?: string;
   onClick?: () => void;
+  isPending?: boolean;
 }
 
 export function ChannelCard({
@@ -15,6 +16,7 @@ export function ChannelCard({
   description,
   to,
   onClick,
+  isPending,
 }: ChannelCardProps) {
   const content = (
     <>
@@ -22,13 +24,26 @@ export function ChannelCard({
         <div className="w-10 h-10 rounded bg-[#f0e5d8] border border-[#e5d4c1] flex items-center justify-center">
           <Icon className="w-5 h-5 text-[#976623]" />
         </div>
-        <h3 className="font-semibold text-[#1e1e1e]">{title}</h3>
+        <div className="flex items-center gap-2">
+          <h3 className="font-semibold text-[#1e1e1e]">{title}</h3>
+          {isPending && (
+            <svg
+              className="animate-spin w-3 h-3 text-[#976623] shrink-0"
+              xmlns="http://www.w3.org/2000/svg"
+              fill="none"
+              viewBox="0 0 24 24"
+            >
+              <circle className="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" strokeWidth="4" />
+              <path className="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4z" />
+            </svg>
+          )}
+        </div>
       </div>
       <p className="text-sm text-[#717182]">{description}</p>
     </>
   );
 
-  if (to) {
+  if (to && !isPending) {
     return (
       <Link
         href={to}
@@ -41,8 +56,8 @@ export function ChannelCard({
 
   return (
     <div
-      onClick={onClick}
-      className="bg-[#fdf8f2] border border-[#e5d4c1] rounded-lg p-4 hover:bg-[#f0e5d8] transition-colors cursor-pointer"
+      onClick={!isPending ? onClick : undefined}
+      className={`bg-[#fdf8f2] border border-[#e5d4c1] rounded-lg p-4 transition-colors ${isPending ? "opacity-70 cursor-default" : "hover:bg-[#f0e5d8] cursor-pointer"}`}
     >
       {content}
     </div>

--- a/web-app/code/src/presentation/components/buildInlime/ChannelsSection.tsx
+++ b/web-app/code/src/presentation/components/buildInlime/ChannelsSection.tsx
@@ -1,13 +1,14 @@
 import type { LucideIcon } from "lucide-react";
-import { MessageSquare } from "lucide-react";
 import { ChannelCard } from "./ChannelCard";
 import { NewChannelButton } from "./NewChannelButton";
+import type { PendingItem } from "%/presentation/hooks/use-pending-items";
 
 export interface Channel {
   id: string;
   icon: LucideIcon;
   title: string;
   description: string;
+  isPending?: boolean;
   to?: string;
   onClick?: () => void;
 }
@@ -15,16 +16,25 @@ export interface Channel {
 interface ChannelsSectionProps {
   channels: Channel[];
   buildUnitId: string;
+  pendingIds: Set<string>;
+  addPending: (item: PendingItem) => void;
+  removePending: (id: string) => void;
+  onTrpcComplete: (id: string) => void;
 }
 
-export function ChannelsSection({ channels, buildUnitId }: ChannelsSectionProps) {
+export function ChannelsSection({ channels, buildUnitId, pendingIds, addPending, removePending, onTrpcComplete }: ChannelsSectionProps) {
   return (
     <div className="border-t border-gray-200 pt-6 mb-8">
       <div className="flex items-center justify-between mb-4">
         <div className="flex items-center gap-2 text-sm">
           <span className="text-[#717182]">Channels</span>
         </div>
-        <NewChannelButton buildUnitId={buildUnitId} />
+        <NewChannelButton
+          buildUnitId={buildUnitId}
+          addPending={addPending}
+          removePending={removePending}
+          onTrpcComplete={onTrpcComplete}
+        />
       </div>
 
       {/* Channel Cards Grid */}
@@ -37,6 +47,7 @@ export function ChannelsSection({ channels, buildUnitId }: ChannelsSectionProps)
             description={channel.description}
             to={channel.to}
             onClick={channel.onClick}
+            isPending={pendingIds.has(channel.id)}
           />
         ))}
       </div>

--- a/web-app/code/src/presentation/components/buildInlime/LoginForm.tsx
+++ b/web-app/code/src/presentation/components/buildInlime/LoginForm.tsx
@@ -18,6 +18,7 @@ export function LoginForm() {
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState("");
   const [successMessage, setSuccessMessage] = useState("");
+  const [showSignupPrompt, setShowSignupPrompt] = useState(false);
 
   const router = useRouter();
 
@@ -26,6 +27,7 @@ export function LoginForm() {
     setLoading(true);
     setError("");
     setSuccessMessage("");
+    setShowSignupPrompt(false);
     try {
       if (isSignup) {
         const { exists } = await trpc.users.checkEmail.query({ email });
@@ -38,6 +40,7 @@ export function LoginForm() {
         const { exists } = await trpc.users.checkEmail.query({ email });
         if (!exists) {
           setError("No account found for this email. Please sign up first.");
+          setShowSignupPrompt(true);
           return;
         }
       }
@@ -140,8 +143,21 @@ export function LoginForm() {
 
         {/* Error */}
         {error && (
-          <div className="mb-4 p-3 bg-red-50 border border-red-200 rounded-[10px]">
-            <p className="font-['Instrument_Sans',sans-serif] text-[14px] text-red-600">{error}</p>
+          <div className="mb-4">
+            <div className="p-3 bg-red-50 border border-red-200 rounded-[10px]">
+              <p className="font-['Instrument_Sans',sans-serif] text-[14px] text-red-600">{error}</p>
+            </div>
+            {showSignupPrompt && (
+              <button
+                type="button"
+                onClick={() => router.navigate({ to: '/login', search: { mode: 'signup', returnTo } })}
+                className="mt-2 w-full bg-white hover:bg-[#fdf8f2] border border-[#976623] text-[#976623] rounded-[10px] h-[44px] font-['Instrument_Sans',sans-serif] font-medium text-[15px] flex items-center justify-center gap-2 transition-colors"
+                style={{ fontVariationSettings: "'wdth' 100" }}
+              >
+                <User className="w-4 h-4" />
+                Create an account
+              </button>
+            )}
           </div>
         )}
 

--- a/web-app/code/src/presentation/components/buildInlime/NewBuildUnitButton.tsx
+++ b/web-app/code/src/presentation/components/buildInlime/NewBuildUnitButton.tsx
@@ -4,16 +4,24 @@ import type { FormEvent } from "react";
 import { useParams } from "@tanstack/react-router";
 import { useLiveQuery, eq } from "@tanstack/react-db";
 import { useSession } from "%/infrastructure/auth/client";
-import { buildUnitsCollection, projectsCollection } from "%/infrastructure/database/tanstack-db-electric/admincollections";
+import { projectsCollection, buildUnitsCollection, registerBuildUnitInsertCallback } from "%/infrastructure/database/tanstack-db-electric/admincollections";
 
 interface NewBuildUnitFormData {
   name: string;
   description: string;
 }
 
-export function NewBuildUnitButton() {
+import type { PendingBuildUnit } from "%/presentation/hooks/use-pending-build-units";
+
+interface NewBuildUnitButtonProps {
+  addPending: (item: PendingBuildUnit) => void;
+  removePending: (id: string) => void;
+  onTrpcComplete: (id: string) => void;
+}
+
+export function NewBuildUnitButton({ addPending, removePending, onTrpcComplete }: NewBuildUnitButtonProps) {
   const [isPopupOpen, setIsPopupOpen] = useState(false);
-  const [isSubmitting, setIsSubmitting] = useState(false);
+  const [duplicateError, setDuplicateError] = useState(false);
   const [formData, setFormData] = useState<NewBuildUnitFormData>({
     name: "",
     description: "",
@@ -34,27 +42,42 @@ export function NewBuildUnitButton() {
     e.preventDefault();
     if (!session?.user || !projectId) return;
 
-    setIsSubmitting(true);
-    try {
-      await buildUnitsCollection.insert({
-        id: crypto.randomUUID(),
-        name: formData.name,
-        description: formData.description,
-        project_id: projectId,
-        owner_id: session.user.id,
-        created_at: new Date(),
-      });
-      setFormData({ name: "", description: "" });
-      setIsPopupOpen(false);
-    } finally {
-      setIsSubmitting(false);
-    }
+    const payload = {
+      id: crypto.randomUUID(),
+      name: formData.name,
+      description: formData.description,
+      project_id: projectId,
+      owner_id: session.user.id,
+      created_at: new Date(),
+    };
+
+    // Close modal immediately for instant feedback
+    setFormData({ name: "", description: "" });
+    setDuplicateError(false);
+    setIsPopupOpen(false);
+
+    // Register callback: success is a no-op (ProjectRoute detects Electric sync and
+    // removes the spinner); on error the optimistic insert is rolled back and we
+    // reopen the form so the user can retry.
+    addPending({ id: payload.id, name: payload.name, description: payload.description ?? null });
+    registerBuildUnitInsertCallback(
+      payload.id,
+      () => onTrpcComplete(payload.id),
+      (err: Error) => {
+        removePending(payload.id);
+        setFormData({ name: payload.name, description: payload.description });
+        setDuplicateError(err.message.includes(`already exists`));
+        setIsPopupOpen(true);
+      },
+    );
+    buildUnitsCollection.insert(payload);
   };
 
   const handleInputChange = (
     e: React.ChangeEvent<HTMLInputElement | HTMLTextAreaElement>
   ) => {
     const { name, value } = e.target;
+    if (name === "name") setDuplicateError(false);
     setFormData((prev) => ({ ...prev, [name]: value }));
   };
 
@@ -116,8 +139,13 @@ export function NewBuildUnitButton() {
                   onChange={handleInputChange}
                   placeholder="Enter build unit name"
                   required
-                  className="w-full px-3 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-[#976623] focus:border-transparent"
+                  className={`w-full px-3 py-2 border rounded-md focus:outline-none focus:ring-2 focus:ring-[#976623] focus:border-transparent ${duplicateError ? "border-red-500" : "border-gray-300"}`}
                 />
+                {duplicateError && (
+                  <p className="mt-1 text-sm text-red-600">
+                    A build unit with this name already exists in this project.
+                  </p>
+                )}
               </div>
 
               {/* Description Input */}
@@ -143,10 +171,9 @@ export function NewBuildUnitButton() {
               {/* Submit Button */}
               <button
                 type="submit"
-                disabled={isSubmitting}
-                className="w-full bg-[#976623] hover:bg-[#7d5419] disabled:opacity-50 text-white px-4 py-2 rounded-lg font-medium transition-colors"
+                className="w-full bg-[#976623] hover:bg-[#7d5419] text-white px-4 py-2 rounded-lg font-medium transition-colors"
               >
-                {isSubmitting ? "Creating…" : "Create Build Unit"}
+                Create Build Unit
               </button>
             </form>
           </div>

--- a/web-app/code/src/presentation/components/buildInlime/NewBuildUnitButton.tsx
+++ b/web-app/code/src/presentation/components/buildInlime/NewBuildUnitButton.tsx
@@ -2,8 +2,9 @@ import { Plus, X } from "lucide-react";
 import { useState } from "react";
 import type { FormEvent } from "react";
 import { useParams } from "@tanstack/react-router";
+import { useLiveQuery, eq } from "@tanstack/react-db";
 import { useSession } from "%/infrastructure/auth/client";
-import { buildUnitsCollection } from "%/infrastructure/database/tanstack-db-electric/admincollections";
+import { buildUnitsCollection, projectsCollection } from "%/infrastructure/database/tanstack-db-electric/admincollections";
 
 interface NewBuildUnitFormData {
   name: string;
@@ -19,6 +20,15 @@ export function NewBuildUnitButton() {
   });
   const { data: session } = useSession();
   const { projectId } = useParams({ strict: false });
+
+  const { data: projectData } = useLiveQuery(
+    (q) =>
+      projectId
+        ? q.from({ projectsCollection }).where(({ projectsCollection: p }) => eq(p.id, projectId))
+        : q.from({ projectsCollection }).where(({ projectsCollection: p }) => eq(p.id, `__none__`)),
+    [projectId]
+  );
+  const isProjectOwner = !!session?.user?.id && projectData?.[0]?.owner_id === session.user.id;
 
   const handleSubmit = async (e: FormEvent) => {
     e.preventDefault();
@@ -47,6 +57,8 @@ export function NewBuildUnitButton() {
     const { name, value } = e.target;
     setFormData((prev) => ({ ...prev, [name]: value }));
   };
+
+  if (!isProjectOwner) return null;
 
   return (
     <>

--- a/web-app/code/src/presentation/components/buildInlime/NewChannelButton.tsx
+++ b/web-app/code/src/presentation/components/buildInlime/NewChannelButton.tsx
@@ -3,7 +3,8 @@ import { useState } from "react";
 import type { FormEvent } from "react";
 import { useLiveQuery, eq } from "@tanstack/react-db";
 import { useSession } from "%/infrastructure/auth/client";
-import { channelsCollection, buildUnitsCollection, projectsCollection } from "%/infrastructure/database/tanstack-db-electric/admincollections";
+import { buildUnitsCollection, channelsCollection, projectsCollection, registerChannelInsertCallback } from "%/infrastructure/database/tanstack-db-electric/admincollections";
+import type { PendingItem } from "%/presentation/hooks/use-pending-items";
 
 interface NewChannelFormData {
   name: "Finance" | "Requirements" | "Design" | "Materials" | "Tools" | "Execution" | "Experimentation";
@@ -20,9 +21,15 @@ const CHANNEL_TYPES = [
   { value: "Experimentation", label: "Experimentation" },
 ] as const;
 
-export function NewChannelButton({ buildUnitId }: { buildUnitId: string }) {
+interface NewChannelButtonProps {
+  buildUnitId: string;
+  addPending: (item: PendingItem) => void;
+  removePending: (id: string) => void;
+  onTrpcComplete: (id: string) => void;
+}
+
+export function NewChannelButton({ buildUnitId, addPending, removePending, onTrpcComplete }: NewChannelButtonProps) {
   const [isPopupOpen, setIsPopupOpen] = useState(false);
-  const [isSubmitting, setIsSubmitting] = useState(false);
   const [duplicateError, setDuplicateError] = useState(false);
   const [formData, setFormData] = useState<NewChannelFormData>({
     name: "Requirements",
@@ -45,48 +52,35 @@ export function NewChannelButton({ buildUnitId }: { buildUnitId: string }) {
   );
   const isProjectOwner = !!session?.user?.id && projectData?.[0]?.owner_id === session.user.id;
 
-  const { data: existingChannels } = useLiveQuery(
-    (q) =>
-      q
-        .from({ channelsCollection })
-        .where(({ channelsCollection: c }) => eq(c.buildunit_id, buildUnitId)),
-    [buildUnitId]
-  );
-
-  // Electric returns jsonb columns as JSON-encoded strings e.g. '"Requirements"'.
-  // Unwrap before comparing against the plain formData.name value.
-  const existingNames = new Set(
-    (existingChannels ?? []).map((c) => {
-      const raw = c.name as unknown as string
-      return raw.startsWith('"') ? JSON.parse(raw) : raw
-    })
-  );
-
   const handleSubmit = async (e: FormEvent) => {
     e.preventDefault();
     if (!session?.user || !buildUnitId) return;
 
-    if (existingNames.has(formData.name)) {
-      setDuplicateError(true);
-      return;
-    }
+    const payload = {
+      id: crypto.randomUUID(),
+      name: formData.name,
+      description: formData.description,
+      buildunit_id: buildUnitId,
+      owner_id: session.user.id,
+      created_at: new Date(),
+    };
 
-    setIsSubmitting(true);
-    try {
-      await channelsCollection.insert({
-        id: crypto.randomUUID(),
-        name: formData.name,
-        description: formData.description,
-        buildunit_id: buildUnitId,
-        owner_id: session.user.id,
-        created_at: new Date(),
-      });
-      setFormData({ name: "Requirements", description: "" });
-      setDuplicateError(false);
-      setIsPopupOpen(false);
-    } finally {
-      setIsSubmitting(false);
-    }
+    setFormData({ name: "Requirements", description: "" });
+    setDuplicateError(false);
+    setIsPopupOpen(false);
+
+    addPending({ id: payload.id, name: payload.name, description: payload.description });
+    registerChannelInsertCallback(
+      payload.id,
+      () => onTrpcComplete(payload.id),
+      (err: Error) => {
+        removePending(payload.id);
+        setFormData({ name: payload.name, description: payload.description });
+        setDuplicateError(err.message.includes(`already exists`));
+        setIsPopupOpen(true);
+      },
+    );
+    channelsCollection.insert(payload);
   };
 
   const handleInputChange = (
@@ -195,10 +189,9 @@ export function NewChannelButton({ buildUnitId }: { buildUnitId: string }) {
               {/* Submit Button */}
               <button
                 type="submit"
-                disabled={isSubmitting}
-                className="w-full bg-[#976623] hover:bg-[#7d5419] disabled:opacity-50 text-white px-4 py-2 rounded-lg font-medium transition-colors"
+                className="w-full bg-[#976623] hover:bg-[#7d5419] text-white px-4 py-2 rounded-lg font-medium transition-colors"
               >
-                {isSubmitting ? "Creating…" : "Create Channel"}
+                Create Channel
               </button>
             </form>
           </div>

--- a/web-app/code/src/presentation/components/buildInlime/NewChannelButton.tsx
+++ b/web-app/code/src/presentation/components/buildInlime/NewChannelButton.tsx
@@ -3,7 +3,7 @@ import { useState } from "react";
 import type { FormEvent } from "react";
 import { useLiveQuery, eq } from "@tanstack/react-db";
 import { useSession } from "%/infrastructure/auth/client";
-import { channelsCollection } from "%/infrastructure/database/tanstack-db-electric/admincollections";
+import { channelsCollection, buildUnitsCollection, projectsCollection } from "%/infrastructure/database/tanstack-db-electric/admincollections";
 
 interface NewChannelFormData {
   name: "Finance" | "Requirements" | "Design" | "Materials" | "Tools" | "Execution" | "Experimentation";
@@ -29,6 +29,21 @@ export function NewChannelButton({ buildUnitId }: { buildUnitId: string }) {
     description: "",
   });
   const { data: session } = useSession();
+
+  const { data: buildUnitData } = useLiveQuery(
+    (q) => q.from({ buildUnitsCollection }).where(({ buildUnitsCollection: bu }) => eq(bu.id, buildUnitId)),
+    [buildUnitId]
+  );
+  const projectId = buildUnitData?.[0]?.project_id;
+
+  const { data: projectData } = useLiveQuery(
+    (q) =>
+      projectId
+        ? q.from({ projectsCollection }).where(({ projectsCollection: p }) => eq(p.id, projectId))
+        : q.from({ projectsCollection }).where(({ projectsCollection: p }) => eq(p.id, `__none__`)),
+    [projectId]
+  );
+  const isProjectOwner = !!session?.user?.id && projectData?.[0]?.owner_id === session.user.id;
 
   const { data: existingChannels } = useLiveQuery(
     (q) =>
@@ -85,6 +100,8 @@ export function NewChannelButton({ buildUnitId }: { buildUnitId: string }) {
       setFormData((prev) => ({ ...prev, [name]: value }));
     }
   };
+
+  if (!isProjectOwner) return null;
 
   return (
     <>

--- a/web-app/code/src/presentation/hooks/use-pending-build-units.ts
+++ b/web-app/code/src/presentation/hooks/use-pending-build-units.ts
@@ -1,0 +1,1 @@
+export { usePendingItems as usePendingBuildUnits, type PendingItem as PendingBuildUnit } from './use-pending-items'

--- a/web-app/code/src/presentation/hooks/use-pending-items.ts
+++ b/web-app/code/src/presentation/hooks/use-pending-items.ts
@@ -1,0 +1,27 @@
+import { useState, useCallback } from 'react'
+
+export type PendingItem = {
+  id: string
+  name: string
+  description: string | null
+}
+
+export function usePendingItems() {
+  const [pendingItems, setPendingItems] = useState<Map<string, PendingItem>>(new Map())
+
+  const addPending = useCallback((item: PendingItem) => {
+    setPendingItems((prev) => new Map(prev).set(item.id, item))
+  }, [])
+
+  const removePending = useCallback((id: string) => {
+    setPendingItems((prev) => {
+      const next = new Map(prev)
+      next.delete(id)
+      return next
+    })
+  }, [])
+
+  const pendingIds = new Set(pendingItems.keys())
+
+  return { pendingItems, pendingIds, addPending, removePending }
+}

--- a/web-app/code/src/presentation/pages/BuildUnitPage.tsx
+++ b/web-app/code/src/presentation/pages/BuildUnitPage.tsx
@@ -11,10 +11,11 @@ import {
 } from "../components/buildInlime";
 import type { Channel } from "../components/buildInlime";
 import type { Property } from "%/infrastructure/database/schema/admin-schema";
+import type { PendingItem } from "%/presentation/hooks/use-pending-items";
 
 
 
-export function BuildUnitPage({ projectId, buildUnitName, buildUnitId, projectName, buildUnitDesc, channels, properties: dbProperties }: { projectId: string; buildUnitName: string; buildUnitId: string; projectName: string; buildUnitDesc: string; channels?: Channel[]; properties?: Property[] }) {
+export function BuildUnitPage({ projectId, buildUnitName, buildUnitId, projectName, buildUnitDesc, channels, properties: dbProperties, pendingChannelIds, addPendingChannel, removePendingChannel, onChannelTrpcComplete }: { projectId: string; buildUnitName: string; buildUnitId: string; projectName: string; buildUnitDesc: string; channels?: Channel[]; properties?: Property[]; pendingChannelIds: Set<string>; addPendingChannel: (item: PendingItem) => void; removePendingChannel: (id: string) => void; onChannelTrpcComplete: (id: string) => void }) {
   const [rightPanelOpen, setRightPanelOpen] = useState(true);
 
   return (
@@ -61,7 +62,14 @@ export function BuildUnitPage({ projectId, buildUnitName, buildUnitId, projectNa
               /> */}
 
               {/* Channels */}
-              <ChannelsSection channels={channels} buildUnitId={buildUnitId} />
+              <ChannelsSection
+                channels={channels ?? []}
+                buildUnitId={buildUnitId}
+                pendingIds={pendingChannelIds}
+                addPending={addPendingChannel}
+                removePending={removePendingChannel}
+                onTrpcComplete={onChannelTrpcComplete}
+              />
             </div>
           </div>
 


### PR DESCRIPTION
## Summary

- **Optimistic inserts**: switched build unit and channel creation from direct tRPC calls to `collection.insert()` so the new row appears in the UI instantly (modal closes immediately)
- **Sync-aware spinner**: spinner beside the build unit name / inside the channel card title spins until BOTH the tRPC write is confirmed AND Electric has synced the entity back from the server (two-signal approach: callback registry in `admincollections.ts` + `useEffect` watching the live query)
- **Ghost-row flicker fix**: during Electric txid reconciliation the optimistic entry is briefly removed before the server-confirmed entry arrives; a `pendingItems` map keeps the row visible through that gap
- **Duplicate name guard**: server-side check added for build units (case-insensitive); client-side duplicate detection for channels fixed (was checking `msg.includes("CONFLICT")` against the error *code* instead of the actual message string)
- **Generic hook**: extracted `usePendingItems` shared by both build units and channels

## Files changed

| File | Change |
|---|---|
| `use-pending-items.ts` (new) | Generic pending state hook |
| `use-pending-build-units.ts` | Re-exports from generic hook |
| `admincollections.ts` | Callback registries for build unit + channel `onInsert`; try/catch to fire resolve/reject |
| `buildunits.ts` (tRPC) | Server-side duplicate name check (case-insensitive) |
| `channels.ts` (tRPC) | No server change needed; duplicate check already correct |
| `NewBuildUnitButton.tsx` | Uses `collection.insert()` + callback pattern |
| `NewChannelButton.tsx` | Uses `collection.insert()` + callback pattern; fixed duplicate error check |
| `BuildUnitsTable.tsx` | Spinner beside name for pending IDs |
| `ChannelCard.tsx` | Spinner in title, dimmed + non-navigable while pending |
| `ChannelsSection.tsx` | Threads pending props to button and cards |
| `BuildUnitPage.tsx` | Passes through channel pending props |
| `$buildUnitName/index.tsx` | Two-signal logic + ghost rows for channels |
| `$projectId/index.tsx` | Two-signal logic + ghost rows for build units |

## Test plan

- [ ] Create a new build unit — row appears instantly, spinner shows, stops after Electric sync
- [ ] Create a duplicate build unit name — modal reopens with error message
- [ ] Create a new channel — card appears instantly with spinner, stops after Electric sync
- [ ] Create a duplicate channel type — modal reopens with error message
- [ ] Verify no flicker (row disappearing/reappearing) after spinner stops

Closes #9 
🤖 Generated with [Claude Code](https://claude.com/claude-code)