### PR TITLE
refactor: separate business logic into hooks and eliminate route query waterfalls

### DIFF
--- a/web-app/code/src/presentation/contexts/route-contexts.tsx
+++ b/web-app/code/src/presentation/contexts/route-contexts.tsx
@@ -1,0 +1,42 @@
+import { createContext, useContext } from 'react'
+import type React from 'react'
+
+// ── BuildUnit context ─────────────────────────────────────────────────────────
+// Provided by the $buildUnitName layout route. Gives all descendants immediate
+// access to the resolved buildUnitId without re-querying buildUnitsCollection.
+
+export type BuildUnitContextValue = {
+  buildUnitId: string
+  buildUnitDesc: string
+  projectName: string
+}
+
+const BuildUnitContext = createContext<BuildUnitContextValue | null>(null)
+
+export const BuildUnitContextProvider = BuildUnitContext.Provider
+
+export function useBuildUnitContext(): BuildUnitContextValue {
+  const ctx = useContext(BuildUnitContext)
+  if (!ctx) throw new Error('useBuildUnitContext must be used within the $buildUnitName layout route')
+  return ctx
+}
+
+// ── Channel context ───────────────────────────────────────────────────────────
+// Provided by the $channelName layout route. Gives all descendants immediate
+// access to the resolved channelId without re-querying channelsCollection.
+
+export type ChannelContextValue = {
+  channelId: string
+  channelDescription: string
+  channelIcon: React.ElementType
+}
+
+const ChannelContext = createContext<ChannelContextValue | null>(null)
+
+export const ChannelContextProvider = ChannelContext.Provider
+
+export function useChannelContext(): ChannelContextValue {
+  const ctx = useContext(ChannelContext)
+  if (!ctx) throw new Error('useChannelContext must be used within the $channelName layout route')
+  return ctx
+}

--- a/web-app/code/src/presentation/hooks/use-build-unit-channels.ts
+++ b/web-app/code/src/presentation/hooks/use-build-unit-channels.ts
@@ -1,0 +1,91 @@
+import { useEffect, useCallback, useRef } from 'react'
+import { useLiveQuery, eq } from "@tanstack/react-db"
+import { ClipboardCheck } from 'lucide-react'
+import { channelsCollection, propertiesCollection } from '%/infrastructure/database/tanstack-db-electric/admincollections'
+import { CHANNEL_NAMES } from '%/infrastructure/database/schema/admin-schema'
+import { CHANNEL_ICONS } from '%/presentation/lib/channelIcons'
+import { unwrapJsonb } from '%/presentation/lib/utils'
+import { usePendingItems } from './use-pending-items'
+import type { Channel } from '../components/buildInlime'
+import type { Property } from '%/infrastructure/database/schema/admin-schema'
+
+export type BuildUnitChannelsStatus = 'loading' | 'ready'
+
+// buildUnitId is pre-resolved by the $buildUnitName layout route via BuildUnitContext —
+// no need to re-query buildUnitsCollection or projectsCollection here.
+export function useBuildUnitChannels(buildUnitId: string, projectId: string, buildUnitName: string) {
+  const { pendingItems: pendingChannels, pendingIds: pendingChannelIds, addPending, removePending } = usePendingItems()
+  const pendingChannelIdsRef = useRef(pendingChannelIds)
+  pendingChannelIdsRef.current = pendingChannelIds
+  const channelTrpcDoneRef = useRef<Set<string>>(new Set())
+
+  const onChannelTrpcComplete = useCallback((id: string) => {
+    channelTrpcDoneRef.current.add(id)
+  }, [])
+
+  const { data: dbChannels } = useLiveQuery(
+    (q) => q.from({ channelsCollection }).where(({ channelsCollection: c }) => eq(c.buildunit_id, buildUnitId)),
+    [buildUnitId]
+  )
+
+  // Two-signal: stop spinner only when both tRPC is done AND Electric confirms the write
+  useEffect(() => {
+    if (!dbChannels) return
+    for (const id of pendingChannelIdsRef.current) {
+      if (channelTrpcDoneRef.current.has(id) && dbChannels.some((c) => c.id === id)) {
+        removePending(id)
+        channelTrpcDoneRef.current.delete(id)
+      }
+    }
+  }, [dbChannels])
+
+  const { data: dbProperties } = useLiveQuery(
+    (q) => q.from({ propertiesCollection }).where(({ propertiesCollection: p }) => eq(p.entity_id, buildUnitId)),
+    [buildUnitId]
+  )
+
+  if (dbChannels === undefined) return { status: 'loading' as const }
+
+  const dbChannelList: Channel[] = (dbChannels ?? []).map((channel) => {
+    const name = unwrapJsonb(channel.name as unknown as string) as typeof CHANNEL_NAMES[number]
+    return {
+      id: channel.id,
+      title: name,
+      description: channel.description ?? '',
+      icon: CHANNEL_ICONS[name] ?? ClipboardCheck,
+      to: `/projects/${projectId}/${buildUnitName}/${name}`,
+    }
+  })
+
+  // Ghost rows: keep pending channels visible during Electric txid reconciliation
+  const dbChannelIds = new Set(dbChannelList.map((c) => c.id))
+  const ghostChannels: Channel[] = [...pendingChannels.values()]
+    .filter((p) => !dbChannelIds.has(p.id))
+    .map((p) => ({
+      id: p.id,
+      title: p.name as typeof CHANNEL_NAMES[number],
+      description: p.description ?? '',
+      icon: CHANNEL_ICONS[p.name as typeof CHANNEL_NAMES[number]] ?? ClipboardCheck,
+      to: undefined,
+    }))
+
+  const channels = [...dbChannelList, ...ghostChannels]
+
+  const properties: Property[] = (dbProperties ?? []).map((p) => ({
+    ...p,
+    type: unwrapJsonb(p.type) as Property['type'],
+    entity: unwrapJsonb(p.entity) as Property['entity'],
+    status_value: unwrapJsonb(p.status_value) as Property['status_value'],
+    priority_value: unwrapJsonb(p.priority_value) as Property['priority_value'],
+  }))
+
+  return {
+    status: 'ready' as const,
+    channels,
+    properties,
+    pendingChannelIds,
+    addPending,
+    removePending,
+    onChannelTrpcComplete,
+  }
+}

--- a/web-app/code/src/presentation/hooks/use-channel-page.ts
+++ b/web-app/code/src/presentation/hooks/use-channel-page.ts
@@ -1,0 +1,151 @@
+import { useState } from "react"
+import type { FormEvent } from "react"
+import { useNavigate } from "@tanstack/react-router"
+import { useLiveQuery, eq } from "@tanstack/react-db"
+import { tasksCollection, channelsCollection, usersCollection, membershipsCollection } from "%/infrastructure/database/tanstack-db-electric/admincollections"
+import { trpc } from "%/infrastructure/trpc/lib/trpc-client"
+import { useSession } from "%/infrastructure/auth/client"
+import type { Task } from "../components/buildInlime"
+
+export function useChannelPage(channelId: string, buildUnitId: string, projectId: string, buildUnitName: string, channelName: string) {
+  const { data: session } = useSession()
+  const navigate = useNavigate()
+
+  // Member management state
+  const [isAddingMember, setIsAddingMember] = useState(false)
+  const [confirmRemoveId, setConfirmRemoveId] = useState<string | null>(null)
+  const [pendingRemovals, setPendingRemovals] = useState<Set<string>>(new Set())
+  const [removalError, setRemovalError] = useState<string | null>(null)
+  const [alreadyMemberName, setAlreadyMemberName] = useState<string | null>(null)
+
+  // Task form state
+  const [taskName, setTaskName] = useState("")
+  const [taskDesc, setTaskDesc] = useState("")
+  const [isSubmittingTask, setIsSubmittingTask] = useState(false)
+
+  // Queries
+  const { data: channelData } = useLiveQuery(
+    (q) => q.from({ channelsCollection }).where(({ channelsCollection: c }) => eq(c.id, channelId)),
+    [channelId]
+  )
+
+  const { data: allUsers } = useLiveQuery((q) => q.from({ usersCollection }), [])
+
+  const { data: channelMemberships } = useLiveQuery(
+    (q) => q.from({ membershipsCollection }).where(({ membershipsCollection: m }) => eq(m.channel_id, channelId)),
+    [channelId]
+  )
+
+  const { data: dbTasks } = useLiveQuery(
+    (q) => q.from({ tasksCollection }).where(({ tasksCollection: t }) => eq(t.channel_id, channelId)),
+    [channelId]
+  )
+
+  // Derived
+  const channelMemberIds = (channelMemberships ?? []).map((m) => m.user_id)
+  const channelMembers = (allUsers ?? []).filter((u) => channelMemberIds.includes(u.id) && !pendingRemovals.has(u.id))
+  const nonMembers = (allUsers ?? []).filter((u) => !channelMemberIds.includes(u.id) || pendingRemovals.has(u.id))
+  const channelOwnerId = channelData?.[0]?.owner_id
+  const isOwner = session?.user?.id === channelOwnerId
+
+  const tasks: Task[] = (dbTasks ?? []).map((t) => ({
+    id: t.id,
+    name: t.name,
+    completed: t.completed,
+  }))
+
+  // Handlers
+  const handleAddMember = async (userId: string, onSuccess: () => void) => {
+    const user = allUsers?.find((u) => u.id === userId)
+    setIsAddingMember(true)
+    try {
+      await trpc.channels.addMember.mutate({ channelId, userId })
+      onSuccess()
+    } catch (err: unknown) {
+      const msg = err instanceof Error ? err.message : String(err)
+      if (msg.includes("ALREADY_MEMBER")) {
+        setAlreadyMemberName(user?.name || user?.email || userId)
+        onSuccess()
+      }
+    } finally {
+      setIsAddingMember(false)
+    }
+  }
+
+  const handleRemoveMember = async (userId: string, userName: string) => {
+    setConfirmRemoveId(null)
+    setPendingRemovals((prev) => new Set(prev).add(userId))
+    try {
+      await trpc.channels.removeMember.mutate({ channelId, userId })
+    } catch (err: unknown) {
+      setPendingRemovals((prev) => { const s = new Set(prev); s.delete(userId); return s })
+      const msg = err instanceof Error ? err.message : String(err)
+      setRemovalError(`Failed to remove ${userName}: ${msg}`)
+    }
+  }
+
+  const handleAddTask = async (e: FormEvent) => {
+    e.preventDefault()
+    if (!session?.user || !channelId || !buildUnitId || !taskName.trim()) return
+    setIsSubmittingTask(true)
+    try {
+      await tasksCollection.insert({
+        id: crypto.randomUUID(),
+        name: taskName.trim(),
+        description: taskDesc.trim(),
+        completed: false,
+        opened_at: new Date(),
+        closed_at: new Date(),
+        channel_id: channelId,
+        buildunit_id: buildUnitId,
+        createdby_id: session.user.id,
+        assignee_id: null,
+      })
+      setTaskName("")
+      setTaskDesc("")
+    } finally {
+      setIsSubmittingTask(false)
+    }
+  }
+
+  const handleTaskClick = (taskId: string) => {
+    const task = dbTasks?.find((t) => t.id === taskId)
+    if (!task) return
+    navigate({
+      to: "/projects/$projectId/$buildUnitName/$channelName/$taskName",
+      params: { projectId, buildUnitName, channelName, taskName: task.name },
+    })
+  }
+
+  return {
+    // Auth
+    currentUserId: session?.user?.id ?? "",
+    // Ownership
+    isOwner,
+    channelOwnerId,
+    // Members
+    channelMembers,
+    nonMembers,
+    isAddingMember,
+    confirmRemoveId,
+    setConfirmRemoveId,
+    pendingRemovals,
+    removalError,
+    setRemovalError,
+    alreadyMemberName,
+    setAlreadyMemberName,
+    // Tasks
+    tasks,
+    dbTasksReady: dbTasks !== undefined,
+    taskName,
+    setTaskName,
+    taskDesc,
+    setTaskDesc,
+    isSubmittingTask,
+    // Handlers
+    handleAddMember,
+    handleRemoveMember,
+    handleAddTask,
+    handleTaskClick,
+  }
+}

--- a/web-app/code/src/presentation/hooks/use-channel-route.ts
+++ b/web-app/code/src/presentation/hooks/use-channel-route.ts
@@ -1,0 +1,32 @@
+import { useLiveQuery, eq } from "@tanstack/react-db"
+import { propertiesCollection } from '%/infrastructure/database/tanstack-db-electric/admincollections'
+import { unwrapJsonb } from '%/presentation/lib/utils'
+import type { Property } from '%/infrastructure/database/schema/admin-schema'
+
+// buildUnitId and channelId are pre-resolved by the layout routes via React context —
+// no need to re-query projects, buildUnits, or channels here.
+export function useChannelRoute(buildUnitId: string, channelId: string) {
+  const { data: dbChannelProperties } = useLiveQuery(
+    (q) => q.from({ propertiesCollection }).where(({ propertiesCollection: p }) => eq(p.entity_id, channelId)),
+    [channelId]
+  )
+
+  const { data: dbBuildUnitProperties } = useLiveQuery(
+    (q) => q.from({ propertiesCollection }).where(({ propertiesCollection: p }) => eq(p.entity_id, buildUnitId)),
+    [buildUnitId]
+  )
+
+  const mapProperties = (rawList: typeof dbChannelProperties): Property[] =>
+    (rawList ?? []).map((p) => ({
+      ...p,
+      type: unwrapJsonb(p.type) as Property['type'],
+      entity: unwrapJsonb(p.entity) as Property['entity'],
+      status_value: unwrapJsonb(p.status_value) as Property['status_value'],
+      priority_value: unwrapJsonb(p.priority_value) as Property['priority_value'],
+    }))
+
+  return {
+    properties: mapProperties(dbChannelProperties),
+    buildUnitProperties: mapProperties(dbBuildUnitProperties),
+  }
+}

--- a/web-app/code/src/presentation/hooks/use-inbox-page.ts
+++ b/web-app/code/src/presentation/hooks/use-inbox-page.ts
@@ -1,0 +1,70 @@
+import { useNavigate } from "@tanstack/react-router"
+import { useLiveQuery } from "@tanstack/react-db"
+import { useSession } from "%/infrastructure/auth/client"
+import {
+  messagesCollection,
+  usersCollection,
+  channelsCollection,
+  buildUnitsCollection,
+  projectsCollection,
+} from "%/infrastructure/database/tanstack-db-electric/admincollections"
+import { unwrapJsonb, parseTextArray } from "%/presentation/lib/utils"
+
+export function useInboxPage() {
+  const { data: session } = useSession()
+  const navigate = useNavigate()
+  const currentUserId = session?.user?.id ?? ""
+
+  const { data: allMessages } = useLiveQuery((q) => q.from({ messagesCollection }), [])
+  const { data: allUsers } = useLiveQuery((q) => q.from({ usersCollection }), [])
+  const { data: allChannels } = useLiveQuery((q) => q.from({ channelsCollection }), [])
+  const { data: allBuildUnits } = useLiveQuery((q) => q.from({ buildUnitsCollection }), [])
+  const { data: allProjects } = useLiveQuery((q) => q.from({ projectsCollection }), [])
+
+  const getChannel = (channelId: string) => (allChannels ?? []).find((c) => c.id === channelId)
+  const getBuildUnit = (buildunitId: string) => (allBuildUnits ?? []).find((b) => b.id === buildunitId)
+  const getProject = (projectId: string) => (allProjects ?? []).find((p) => p.id === projectId)
+
+  const getUserName = (userId: string) => {
+    const user = (allUsers ?? []).find((u) => u.id === userId)
+    return user?.name || user?.email || "Unknown"
+  }
+
+  const mentionedMessages = (allMessages ?? [])
+    .filter((m) => parseTextArray(m.mention_ids).includes(currentUserId))
+    .sort((a, b) => {
+      const aTime = a.created_at instanceof Date ? a.created_at.getTime() : new Date(a.created_at as string).getTime()
+      const bTime = b.created_at instanceof Date ? b.created_at.getTime() : new Date(b.created_at as string).getTime()
+      return bTime - aTime
+    })
+
+  const formatTime = (val: unknown) => {
+    const date = val instanceof Date ? val : new Date(val as string)
+    return date.toLocaleDateString("en-US", { month: "short", day: "numeric", hour: "2-digit", minute: "2-digit" })
+  }
+
+  const handleMessageClick = (msg: NonNullable<typeof allMessages>[number]) => {
+    const buildUnit = getBuildUnit(msg.buildunit_id)
+    const channel = getChannel(msg.channel_id)
+    if (!buildUnit || !channel) return
+    navigate({
+      to: "/projects/$projectId/$buildUnitName/$channelName/",
+      params: {
+        projectId: msg.project_id,
+        buildUnitName: buildUnit.name,
+        channelName: unwrapJsonb(channel.name),
+      },
+    })
+  }
+
+  return {
+    currentUserId,
+    mentionedMessages,
+    getUserName,
+    getChannel,
+    getBuildUnit,
+    getProject,
+    formatTime,
+    handleMessageClick,
+  }
+}

--- a/web-app/code/src/presentation/hooks/use-my-tasks-page.ts
+++ b/web-app/code/src/presentation/hooks/use-my-tasks-page.ts
@@ -1,0 +1,63 @@
+import { useNavigate } from "@tanstack/react-router"
+import { useLiveQuery, eq } from "@tanstack/react-db"
+import { useSession } from "%/infrastructure/auth/client"
+import {
+  tasksCollection,
+  channelsCollection,
+  buildUnitsCollection,
+  projectsCollection,
+} from "%/infrastructure/database/tanstack-db-electric/admincollections"
+import { unwrapJsonb } from "%/presentation/lib/utils"
+
+export function useMyTasksPage() {
+  const { data: session } = useSession()
+  const navigate = useNavigate()
+  const currentUserId = session?.user?.id ?? ""
+
+  const { data: myTasks } = useLiveQuery(
+    (q) => q.from({ tasksCollection }).where(({ tasksCollection: t }) => eq(t.assignee_id, currentUserId)),
+    [currentUserId]
+  )
+  const { data: allChannels } = useLiveQuery((q) => q.from({ channelsCollection }), [])
+  const { data: allBuildUnits } = useLiveQuery((q) => q.from({ buildUnitsCollection }), [])
+  const { data: allProjects } = useLiveQuery((q) => q.from({ projectsCollection }), [])
+
+  const getChannel = (channelId: string) => (allChannels ?? []).find((c) => c.id === channelId)
+  const getBuildUnit = (buildunitId: string) => (allBuildUnits ?? []).find((b) => b.id === buildunitId)
+  const getProject = (projectId: string) => (allProjects ?? []).find((p) => p.id === projectId)
+
+  const sorted = (myTasks ?? []).slice().sort((a, b) => {
+    if (a.completed !== b.completed) return a.completed ? 1 : -1
+    return 0
+  })
+
+  const openCount = sorted.filter((t) => !t.completed).length
+  const doneCount = sorted.filter((t) => t.completed).length
+
+  const handleTaskClick = (task: NonNullable<typeof myTasks>[number]) => {
+    const channel = getChannel(task.channel_id)
+    const buildUnit = getBuildUnit(task.buildunit_id)
+    if (!channel || !buildUnit) return
+    const channelName = unwrapJsonb(channel.name)
+    navigate({
+      to: "/projects/$projectId/$buildUnitName/$channelName/$taskName",
+      params: {
+        projectId: buildUnit.project_id,
+        buildUnitName: buildUnit.name,
+        channelName,
+        taskName: task.name,
+      },
+    })
+  }
+
+  return {
+    currentUserId,
+    sorted,
+    openCount,
+    doneCount,
+    getChannel,
+    getBuildUnit,
+    getProject,
+    handleTaskClick,
+  }
+}

--- a/web-app/code/src/presentation/hooks/use-project-build-units.ts
+++ b/web-app/code/src/presentation/hooks/use-project-build-units.ts
@@ -1,0 +1,91 @@
+import { useCallback, useEffect, useRef } from "react"
+import { useNavigate } from "@tanstack/react-router"
+import { useLiveQuery, eq } from "@tanstack/react-db"
+import { projectsCollection, buildUnitsCollection } from "%/infrastructure/database/tanstack-db-electric/admincollections"
+import { usePendingBuildUnits } from "./use-pending-build-units"
+
+export function useProjectBuildUnits(projectId: string) {
+  const navigate = useNavigate()
+  const { pendingItems, pendingIds, addPending, removePending } = usePendingBuildUnits()
+
+  const pendingIdsRef = useRef(pendingIds)
+  pendingIdsRef.current = pendingIds
+  const trpcDoneRef = useRef<Set<string>>(new Set())
+
+  const onTrpcComplete = useCallback((id: string) => {
+    trpcDoneRef.current.add(id)
+  }, [])
+
+  const { data: dbProjects } = useLiveQuery(
+    (q) => q.from({ projectsCollection }).where(({ projectsCollection: p }) => eq(p.id, projectId)),
+    [projectId]
+  )
+
+  const { data: buildUnitsFromDB } = useLiveQuery(
+    (q) => q.from({ buildUnitsCollection }).where(({ buildUnitsCollection: bu }) => eq(bu.project_id, projectId)),
+    [projectId]
+  )
+
+  // Two-signal: stop spinner only when both tRPC is done AND Electric confirms the write
+  useEffect(() => {
+    if (!buildUnitsFromDB) return
+    for (const id of pendingIdsRef.current) {
+      if (trpcDoneRef.current.has(id) && buildUnitsFromDB.some((bu) => bu.id === id)) {
+        removePending(id)
+        trpcDoneRef.current.delete(id)
+      }
+    }
+  }, [buildUnitsFromDB])
+
+  const projectName = dbProjects?.[0]?.name ?? "Project"
+
+  const dbBuildUnits = (buildUnitsFromDB ?? []).map((bu) => ({
+    id: bu.id,
+    name: bu.name,
+    description: bu.descritption,
+    health: (bu.health ?? "On track") as "On track" | "At risk" | "Off track",
+    priority: (bu.priority ?? "Low") as "High" | "Mid" | "Low",
+    waitingOnTask: {
+      name: bu.task_name ?? "—",
+      assignee: bu.task_assignee ?? "—",
+      since: bu.task_since ?? "—",
+    },
+    targetDate: bu.target_date ?? "—",
+    statusPercent: parseInt(bu.status_percent ?? "0", 10),
+  }))
+
+  // Ghost rows: keep pending items visible during Electric txid reconciliation
+  const dbIds = new Set(dbBuildUnits.map((bu) => bu.id))
+  const ghostRows = [...pendingItems.values()]
+    .filter((p) => !dbIds.has(p.id))
+    .map((p) => ({
+      id: p.id,
+      name: p.name,
+      description: p.description,
+      health: "On track" as const,
+      priority: "Low" as const,
+      waitingOnTask: { name: "—", assignee: "—", since: "—" },
+      targetDate: "—",
+      statusPercent: 0,
+    }))
+
+  const buildUnits = [...dbBuildUnits, ...ghostRows]
+
+  const onBuildUnitClick = (buildUnit: { id: string; name: string; desc: string }) => {
+    navigate({
+      to: "/projects/$projectId/$buildUnitName",
+      params: { projectId, buildUnitName: buildUnit.name },
+      state: { buildUnitId: buildUnit.id, unitDescription: buildUnit.desc, projectName },
+    })
+  }
+
+  return {
+    projectName,
+    buildUnits,
+    pendingIds,
+    addPending,
+    removePending,
+    onTrpcComplete,
+    onBuildUnitClick,
+  }
+}

--- a/web-app/code/src/presentation/hooks/use-task-route.ts
+++ b/web-app/code/src/presentation/hooks/use-task-route.ts
@@ -1,0 +1,63 @@
+import { useLiveQuery, eq } from "@tanstack/react-db"
+import { useSession } from '%/infrastructure/auth/client'
+import {
+  tasksCollection,
+  propertiesCollection,
+  membershipsCollection,
+} from '%/infrastructure/database/tanstack-db-electric/admincollections'
+import { unwrapJsonb } from '%/presentation/lib/utils'
+import type { Property } from '%/infrastructure/database/schema/admin-schema'
+
+export type TaskRouteStatus =
+  | 'loading'
+  | 'not-found-task'
+  | 'ready'
+
+// channelId is pre-resolved by the $channelName layout route via ChannelContext —
+// no need to re-query projects, buildUnits, or channels here.
+export function useTaskRoute(channelId: string, taskName: string) {
+  const { data: session } = useSession()
+
+  const { data: dbTasks } = useLiveQuery(
+    (q) => q.from({ tasksCollection }).where(({ tasksCollection: t }) => eq(t.channel_id, channelId)),
+    [channelId]
+  )
+
+  const task = (dbTasks ?? []).find((t) => t.name === taskName)
+  const taskId = task?.id ?? ''
+
+  const { data: dbTaskProperties } = useLiveQuery(
+    (q) => q.from({ propertiesCollection }).where(({ propertiesCollection: p }) => eq(p.entity_id, taskId)),
+    [taskId]
+  )
+
+  const { data: channelMembershipsData } = useLiveQuery(
+    (q) => q.from({ membershipsCollection }).where(({ membershipsCollection: m }) => eq(m.channel_id, channelId)),
+    [channelId]
+  )
+
+  if (dbTasks === undefined) return { status: 'loading' as const }
+  if (!task) return { status: 'not-found-task' as const }
+
+  const channelMemberIds: string[] = (channelMembershipsData ?? []).map((m) => m.user_id)
+  const currentAssigneeId = (task.assignee_id as string | null) ?? null
+  const currentUserId = session?.user?.id ?? ''
+
+  const properties: Property[] = (dbTaskProperties ?? []).map((p) => ({
+    ...p,
+    type: unwrapJsonb(p.type) as Property['type'],
+    entity: unwrapJsonb(p.entity) as Property['entity'],
+    status_value: unwrapJsonb(p.status_value) as Property['status_value'],
+    priority_value: unwrapJsonb(p.priority_value) as Property['priority_value'],
+  }))
+
+  return {
+    status: 'ready' as const,
+    taskId,
+    taskDescription: task.description ?? '',
+    properties,
+    channelMemberIds,
+    currentAssigneeId,
+    currentUserId,
+  }
+}

--- a/web-app/code/src/presentation/pages/ChannelPage.tsx
+++ b/web-app/code/src/presentation/pages/ChannelPage.tsx
@@ -1,7 +1,6 @@
 import { useState } from "react";
 import type { FormEvent } from "react";
-import { Link, useNavigate } from "@tanstack/react-router";
-import { useLiveQuery, eq } from "@tanstack/react-db";
+import { Link } from "@tanstack/react-router";
 import {
   ChevronRight,
   ChevronDown,
@@ -28,10 +27,7 @@ import {
   AlertDialogFooter,
   AlertDialogAction,
 } from "../components/ui/alert-dialog";
-import { tasksCollection, channelsCollection, usersCollection, membershipsCollection } from "%/infrastructure/database/tanstack-db-electric/admincollections";
-import { trpc } from "%/infrastructure/trpc/lib/trpc-client";
-import { useSession } from "%/infrastructure/auth/client";
-import type { ActivityItem, Task } from "../components/buildInlime";
+import { useChannelPage } from "../hooks/use-channel-page";
 import type { Property } from "%/infrastructure/database/schema/admin-schema";
 
 interface ChannelPageProps {
@@ -61,109 +57,47 @@ export function ChannelPage({
   properties,
   buildUnitProperties,
 }: ChannelPageProps) {
+  // UI-only toggle state
   const [rightPanelOpen, setRightPanelOpen] = useState(true);
   const [propertiesOpen, setPropertiesOpen] = useState(true);
   const [channelPropsOpen, setChannelPropsOpen] = useState(true);
   const [buildUnitPropsOpen, setBuildUnitPropsOpen] = useState(true);
   const [taskFormOpen, setTaskFormOpen] = useState(false);
   const [resourcesOpen, setResourcesOpen] = useState(true);
-  const [taskName, setTaskName] = useState("");
-  const [taskDesc, setTaskDesc] = useState("");
-  const [isSubmittingTask, setIsSubmittingTask] = useState(false);
   const [addPeopleOpen, setAddPeopleOpen] = useState(false);
-  const [isAddingMember, setIsAddingMember] = useState(false);
-  const [confirmRemoveId, setConfirmRemoveId] = useState<string | null>(null);
-  const [pendingRemovals, setPendingRemovals] = useState<Set<string>>(new Set());
-  const [removalError, setRemovalError] = useState<string | null>(null);
-  const [alreadyMemberName, setAlreadyMemberName] = useState<string | null>(null);
-  const { data: session } = useSession();
-  const navigate = useNavigate();
 
-  const { data: channelData } = useLiveQuery(
-    (q) => q.from({ channelsCollection }).where(({ channelsCollection: c }) => eq(c.id, channelId)),
-    [channelId]
-  );
+  const {
+    currentUserId,
+    isOwner,
+    channelOwnerId,
+    channelMembers,
+    nonMembers,
+    isAddingMember,
+    confirmRemoveId,
+    setConfirmRemoveId,
+    removalError,
+    setRemovalError,
+    alreadyMemberName,
+    setAlreadyMemberName,
+    tasks,
+    dbTasksReady,
+    taskName,
+    setTaskName,
+    taskDesc,
+    setTaskDesc,
+    isSubmittingTask,
+    handleAddMember,
+    handleRemoveMember,
+    handleAddTask,
+    handleTaskClick,
+  } = useChannelPage(channelId, buildUnitId, projectId, buildUnitName, channelName);
 
-  const { data: allUsers } = useLiveQuery((q) => q.from({ usersCollection }), []);
+  if (!dbTasksReady) return null;
 
-  // Derive channel members from the membershipsCollection (all channel members, not just current user)
-  const { data: channelMemberships } = useLiveQuery(
-    (q) => q.from({ membershipsCollection }).where(({ membershipsCollection: m }) => eq(m.channel_id, channelId)),
-    [channelId]
-  );
-  const channelMemberIds = (channelMemberships ?? []).map(m => m.user_id);
-  const channelMembers = (allUsers ?? []).filter(u => channelMemberIds.includes(u.id) && !pendingRemovals.has(u.id));
-  const nonMembers = (allUsers ?? []).filter(u => !channelMemberIds.includes(u.id) || pendingRemovals.has(u.id));
-
-  const handleAddMember = async (userId: string) => {
-    const user = allUsers?.find(u => u.id === userId);
-    setIsAddingMember(true);
-    try {
-      await trpc.channels.addMember.mutate({ channelId, userId });
-      setAddPeopleOpen(false);
-    } catch (err: unknown) {
-      const msg = err instanceof Error ? err.message : String(err);
-      if (msg.includes("ALREADY_MEMBER")) {
-        setAlreadyMemberName(user?.name || user?.email || userId);
-        setAddPeopleOpen(false);
-      }
-    } finally {
-      setIsAddingMember(false);
-    }
+  const onAddTask = async (e: FormEvent) => {
+    await handleAddTask(e);
+    setTaskFormOpen(false);
   };
-
-  const handleRemoveMember = async (userId: string, userName: string) => {
-    setConfirmRemoveId(null);
-    setPendingRemovals(prev => new Set(prev).add(userId));
-    try {
-      await trpc.channels.removeMember.mutate({ channelId, userId });
-    } catch (err: unknown) {
-      setPendingRemovals(prev => { const s = new Set(prev); s.delete(userId); return s; });
-      const msg = err instanceof Error ? err.message : String(err);
-      setRemovalError(`Failed to remove ${userName}: ${msg}`);
-    }
-  };
-
-  const { data: dbTasks } = useLiveQuery(
-    (q) => q.from({ tasksCollection }).where(({ tasksCollection: t }) => eq(t.channel_id, channelId)),
-    [channelId]
-  );
-
-  if (dbTasks === undefined) return null
-
-  const tasks: Task[] = dbTasks.map((t) => ({
-    id: t.id,
-    name: t.name,
-    completed: t.completed,
-  }));
-
-  const handleAddTask = async (e: FormEvent) => {
-    e.preventDefault();
-    if (!session?.user || !channelId || !buildUnitId || !taskName.trim()) return;
-    setIsSubmittingTask(true);
-    try {
-      await tasksCollection.insert({
-        id: crypto.randomUUID(),
-        name: taskName.trim(),
-        description: taskDesc.trim(),
-        completed: false,
-        opened_at: new Date(),
-        closed_at: new Date(),
-        channel_id: channelId,
-        buildunit_id: buildUnitId,
-        createdby_id: session.user.id,
-        assignee_id: null,
-      });
-      setTaskName("");
-      setTaskDesc("");
-      setTaskFormOpen(false);
-    } finally {
-      setIsSubmittingTask(false);
-    }
-  };
-
-  const channelOwnerId = channelData?.[0]?.owner_id;
-  const isOwner = session?.user?.id === channelOwnerId;
 
   return (
     <>
@@ -229,7 +163,7 @@ export function ChannelPage({
                         {nonMembers.map((u) => (
                           <button
                             key={u.id}
-                            onClick={() => handleAddMember(u.id)}
+                            onClick={() => handleAddMember(u.id, () => setAddPeopleOpen(false))}
                             disabled={isAddingMember}
                             className="w-full flex items-center gap-2 px-3 py-2 text-sm text-[#1e1e1e] hover:bg-[#fdf8f2] transition-colors disabled:opacity-50"
                           >
@@ -275,8 +209,8 @@ export function ChannelPage({
                 channelId={channelId}
                 buildunitId={buildUnitId}
                 projectId={projectId}
-                currentUserId={session?.user?.id ?? ""}
-                memberIds={session?.user ? [session.user.id] : []}
+                currentUserId={currentUserId}
+                memberIds={currentUserId ? [currentUserId] : []}
               />
             </div>
           </div>
@@ -337,14 +271,7 @@ export function ChannelPage({
               {/* Tasks */}
               <TasksRightPanel
                 tasks={tasks}
-                onTaskClick={(taskId) => {
-                  const task = dbTasks.find((t) => t.id === taskId);
-                  if (!task) return;
-                  navigate({
-                    to: '/projects/$projectId/$buildUnitName/$channelName/$taskName',
-                    params: { projectId, buildUnitName, channelName, taskName: task.name },
-                  });
-                }}
+                onTaskClick={handleTaskClick}
               />
 
               {/* Members */}
@@ -410,7 +337,7 @@ export function ChannelPage({
               <X className="w-5 h-5" />
             </button>
             <h2 className="text-xl font-semibold text-gray-800 mb-6">Add Task</h2>
-            <form onSubmit={handleAddTask} className="space-y-4">
+            <form onSubmit={onAddTask} className="space-y-4">
               <div>
                 <label className="block text-sm font-medium text-gray-700 mb-1">Task Name</label>
                 <input
@@ -444,7 +371,6 @@ export function ChannelPage({
           </div>
         </div>
       )}
-
 
       {/* Remove member error dialog */}
       <AlertDialog open={!!removalError} onOpenChange={(open) => { if (!open) setRemovalError(null); }}>

--- a/web-app/code/src/presentation/pages/InboxPage.tsx
+++ b/web-app/code/src/presentation/pages/InboxPage.tsx
@@ -1,63 +1,19 @@
 import { ArrowLeft, MessageSquare, ChevronRight } from "lucide-react";
-import { useLiveQuery } from "@tanstack/react-db";
-import { useNavigate } from "@tanstack/react-router";
-import { useSession } from "%/infrastructure/auth/client";
-import {
-  messagesCollection,
-  usersCollection,
-  channelsCollection,
-  buildUnitsCollection,
-  projectsCollection,
-} from "%/infrastructure/database/tanstack-db-electric/admincollections";
 import { Sidebar } from "../components/buildInlime";
-import { unwrapJsonb, parseTextArray } from "%/presentation/lib/utils";
+import { unwrapJsonb } from "%/presentation/lib/utils";
+import { useInboxPage } from "../hooks/use-inbox-page";
 
 export function InboxPage() {
-  const { data: session } = useSession();
-  const navigate = useNavigate();
-  const currentUserId = session?.user?.id ?? "";
-
-  const { data: allMessages } = useLiveQuery((q) => q.from({ messagesCollection }), []);
-  const { data: allUsers } = useLiveQuery((q) => q.from({ usersCollection }), []);
-  const { data: allChannels } = useLiveQuery((q) => q.from({ channelsCollection }), []);
-  const { data: allBuildUnits } = useLiveQuery((q) => q.from({ buildUnitsCollection }), []);
-  const { data: allProjects } = useLiveQuery((q) => q.from({ projectsCollection }), []);
-
-  const mentionedMessages = (allMessages ?? [])
-    .filter((m) => parseTextArray(m.mention_ids).includes(currentUserId))
-    .sort((a, b) => {
-      const aTime = a.created_at instanceof Date ? a.created_at.getTime() : new Date(a.created_at as string).getTime();
-      const bTime = b.created_at instanceof Date ? b.created_at.getTime() : new Date(b.created_at as string).getTime();
-      return bTime - aTime;
-    });
-
-  const getUserName = (userId: string) => {
-    const user = (allUsers ?? []).find((u) => u.id === userId);
-    return user?.name || user?.email || "Unknown";
-  };
-
-  const getChannel = (channelId: string) => (allChannels ?? []).find((c) => c.id === channelId);
-  const getBuildUnit = (buildunitId: string) => (allBuildUnits ?? []).find((b) => b.id === buildunitId);
-  const getProject = (projectId: string) => (allProjects ?? []).find((p) => p.id === projectId);
-
-  const handleMessageClick = (msg: NonNullable<typeof allMessages>[number]) => {
-    const buildUnit = getBuildUnit(msg.buildunit_id);
-    const channel = getChannel(msg.channel_id);
-    if (!buildUnit || !channel) return;
-    navigate({
-      to: "/projects/$projectId/$buildUnitName/$channelName/",
-      params: {
-        projectId: msg.project_id,
-        buildUnitName: buildUnit.name,
-        channelName: unwrapJsonb(channel.name),
-      },
-    });
-  };
-
-  const formatTime = (val: unknown) => {
-    const date = val instanceof Date ? val : new Date(val as string);
-    return date.toLocaleDateString("en-US", { month: "short", day: "numeric", hour: "2-digit", minute: "2-digit" });
-  };
+  const {
+    currentUserId,
+    mentionedMessages,
+    getUserName,
+    getChannel,
+    getBuildUnit,
+    getProject,
+    formatTime,
+    handleMessageClick,
+  } = useInboxPage();
 
   return (
     <div className="flex h-screen bg-white font-['Instrument_Sans',sans-serif]">
@@ -110,7 +66,6 @@ export function InboxPage() {
                         <span className="text-xs text-[#717182] whitespace-nowrap">{formatTime(msg.created_at)}</span>
                       </div>
                       <p className="text-sm text-[#1e1e1e] break-words">{msg.text}</p>
-                      {/* Breadcrumb: Project > Build Unit > Channel */}
                       <div className="flex items-center gap-1 mt-1.5 flex-wrap">
                         {project && (
                           <>

--- a/web-app/code/src/presentation/pages/MyTasksPage.tsx
+++ b/web-app/code/src/presentation/pages/MyTasksPage.tsx
@@ -1,57 +1,19 @@
 import { ArrowLeft, CheckSquare, Square, ChevronRight } from "lucide-react";
-import { useLiveQuery, eq } from "@tanstack/react-db";
-import { useNavigate } from "@tanstack/react-router";
-import { useSession } from "%/infrastructure/auth/client";
-import {
-  tasksCollection,
-  channelsCollection,
-  buildUnitsCollection,
-  projectsCollection,
-} from "%/infrastructure/database/tanstack-db-electric/admincollections";
 import { Sidebar } from "../components/buildInlime";
 import { unwrapJsonb } from "%/presentation/lib/utils";
+import { useMyTasksPage } from "../hooks/use-my-tasks-page";
 
 export function MyTasksPage() {
-  const { data: session } = useSession();
-  const navigate = useNavigate();
-  const currentUserId = session?.user?.id ?? "";
-
-  const { data: myTasks } = useLiveQuery(
-    (q) => q.from({ tasksCollection }).where(({ tasksCollection: t }) => eq(t.assignee_id, currentUserId)),
-    [currentUserId]
-  );
-
-  const { data: allChannels } = useLiveQuery((q) => q.from({ channelsCollection }), []);
-  const { data: allBuildUnits } = useLiveQuery((q) => q.from({ buildUnitsCollection }), []);
-  const { data: allProjects } = useLiveQuery((q) => q.from({ projectsCollection }), []);
-
-  const getChannel = (channelId: string) => (allChannels ?? []).find((c) => c.id === channelId);
-  const getBuildUnit = (buildunitId: string) => (allBuildUnits ?? []).find((b) => b.id === buildunitId);
-  const getProject = (projectId: string) => (allProjects ?? []).find((p) => p.id === projectId);
-
-  const handleTaskClick = (task: NonNullable<typeof myTasks>[number]) => {
-    const channel = getChannel(task.channel_id);
-    const buildUnit = getBuildUnit(task.buildunit_id);
-    if (!channel || !buildUnit) return;
-    const channelName = unwrapJsonb(channel.name);
-    navigate({
-      to: "/projects/$projectId/$buildUnitName/$channelName/$taskName",
-      params: {
-        projectId: buildUnit.project_id,
-        buildUnitName: buildUnit.name,
-        channelName,
-        taskName: task.name,
-      },
-    });
-  };
-
-  const sorted = (myTasks ?? []).slice().sort((a, b) => {
-    if (a.completed !== b.completed) return a.completed ? 1 : -1;
-    return 0;
-  });
-
-  const openCount = sorted.filter((t) => !t.completed).length;
-  const doneCount = sorted.filter((t) => t.completed).length;
+  const {
+    currentUserId,
+    sorted,
+    openCount,
+    doneCount,
+    getChannel,
+    getBuildUnit,
+    getProject,
+    handleTaskClick,
+  } = useMyTasksPage();
 
   return (
     <div className="flex h-screen bg-white font-['Instrument_Sans',sans-serif]">
@@ -116,7 +78,6 @@ export function MyTasksPage() {
                       {task.description && (
                         <p className="text-xs text-[#717182] mt-0.5 truncate">{task.description}</p>
                       )}
-                      {/* Breadcrumb: Project > Build Unit > Channel */}
                       <div className="flex items-center gap-1 mt-1.5 flex-wrap">
                         {project && (
                           <>

--- a/web-app/code/src/presentation/routes/_authenticated/projects/$projectId/$buildUnitName.tsx
+++ b/web-app/code/src/presentation/routes/_authenticated/projects/$projectId/$buildUnitName.tsx
@@ -1,5 +1,57 @@
 import { createFileRoute, Outlet } from '@tanstack/react-router'
+import { useState, useEffect } from 'react'
+import { useLiveQuery, eq } from '@tanstack/react-db'
+import { buildUnitsCollection, projectsCollection } from '%/infrastructure/database/tanstack-db-electric/admincollections'
+import { BuildUnitContextProvider } from '../../../../contexts/route-contexts'
 
 export const Route = createFileRoute('/_authenticated/projects/$projectId/$buildUnitName')({
-  component: () => <Outlet />,
+  component: BuildUnitLayout,
 })
+
+function BuildUnitLayout() {
+  const { projectId, buildUnitName } = Route.useParams()
+  const [syncTimedOut, setSyncTimedOut] = useState(false)
+
+  useEffect(() => {
+    setSyncTimedOut(false)
+    const t = setTimeout(() => setSyncTimedOut(true), 5000)
+    return () => clearTimeout(t)
+  }, [projectId, buildUnitName])
+
+  const { data: dbProject } = useLiveQuery(
+    (q) => q.from({ projectsCollection }).where(({ projectsCollection: p }) => eq(p.id, projectId)),
+    [projectId]
+  )
+
+  const { data: dbBuildUnits } = useLiveQuery(
+    (q) => q.from({ buildUnitsCollection }).where(({ buildUnitsCollection: bu }) => eq(bu.project_id, projectId)),
+    [projectId]
+  )
+
+  if (dbBuildUnits === undefined) {
+    return <div className="flex h-screen items-center justify-center text-[#717182]">Loading…</div>
+  }
+
+  const buildUnit = dbBuildUnits.find((bu) => bu.name === buildUnitName)
+
+  if (!buildUnit) {
+    if (!syncTimedOut) {
+      return <div className="flex h-screen items-center justify-center text-[#717182]">Loading…</div>
+    }
+    return (
+      <div className="flex h-screen items-center justify-center text-[#717182]">
+        Build unit "{buildUnitName}" not found.
+      </div>
+    )
+  }
+
+  return (
+    <BuildUnitContextProvider value={{
+      buildUnitId: buildUnit.id,
+      buildUnitDesc: buildUnit.description ?? '',
+      projectName: dbProject?.[0]?.name ?? 'Project',
+    }}>
+      <Outlet />
+    </BuildUnitContextProvider>
+  )
+}

--- a/web-app/code/src/presentation/routes/_authenticated/projects/$projectId/$buildUnitName/$channelName.tsx
+++ b/web-app/code/src/presentation/routes/_authenticated/projects/$projectId/$buildUnitName/$channelName.tsx
@@ -1,5 +1,63 @@
 import { createFileRoute, Outlet } from '@tanstack/react-router'
+import { useState, useEffect } from 'react'
+import { useLiveQuery, eq } from '@tanstack/react-db'
+import { ClipboardCheck } from 'lucide-react'
+import { channelsCollection } from '%/infrastructure/database/tanstack-db-electric/admincollections'
+import { CHANNEL_NAMES } from '%/infrastructure/database/schema/admin-schema'
+import { CHANNEL_ICONS } from '%/presentation/lib/channelIcons'
+import { unwrapJsonb } from '%/presentation/lib/utils'
+import { useBuildUnitContext, ChannelContextProvider } from '../../../../../contexts/route-contexts'
 
 export const Route = createFileRoute('/_authenticated/projects/$projectId/$buildUnitName/$channelName')({
-  component: () => <Outlet />,
+  component: ChannelLayout,
+  loader: async () => {
+    await channelsCollection.preload()
+  },
 })
+
+function ChannelLayout() {
+  const { channelName } = Route.useParams()
+  const { buildUnitId } = useBuildUnitContext()
+  const [syncTimedOut, setSyncTimedOut] = useState(false)
+
+  useEffect(() => {
+    setSyncTimedOut(false)
+    const t = setTimeout(() => setSyncTimedOut(true), 5000)
+    return () => clearTimeout(t)
+  }, [buildUnitId, channelName])
+
+  const { data: dbChannels } = useLiveQuery(
+    (q) => q.from({ channelsCollection }).where(({ channelsCollection: c }) => eq(c.buildunit_id, buildUnitId)),
+    [buildUnitId]
+  )
+
+  if (dbChannels === undefined) {
+    return <div className="flex h-screen items-center justify-center text-[#717182]">Loading…</div>
+  }
+
+  const channel = dbChannels.find((c) => {
+    const name = unwrapJsonb(c.name as unknown as string)
+    return name === channelName
+  })
+
+  if (!channel) {
+    if (!syncTimedOut) {
+      return <div className="flex h-screen items-center justify-center text-[#717182]">Loading…</div>
+    }
+    return (
+      <div className="flex h-screen items-center justify-center text-[#717182]">
+        Channel "{channelName}" not found.
+      </div>
+    )
+  }
+
+  return (
+    <ChannelContextProvider value={{
+      channelId: channel.id,
+      channelDescription: channel.description ?? '',
+      channelIcon: CHANNEL_ICONS[channelName as typeof CHANNEL_NAMES[number]] ?? ClipboardCheck,
+    }}>
+      <Outlet />
+    </ChannelContextProvider>
+  )
+}

--- a/web-app/code/src/presentation/routes/_authenticated/projects/$projectId/$buildUnitName/$channelName/$taskName.tsx
+++ b/web-app/code/src/presentation/routes/_authenticated/projects/$projectId/$buildUnitName/$channelName/$taskName.tsx
@@ -1,25 +1,18 @@
 import { createFileRoute } from '@tanstack/react-router'
-import { useLiveQuery, eq } from "@tanstack/react-db"
-import { useSession } from '%/infrastructure/auth/client'
 import { TaskPage } from '../../../../../../pages/TaskPage'
 import {
-  projectsCollection,
-  buildUnitsCollection,
-  channelsCollection,
   tasksCollection,
   propertiesCollection,
   resourcesCollection,
-  membershipsCollection,
 } from '%/infrastructure/database/tanstack-db-electric/admincollections'
 import { RoutePendingComponent } from '../../../../../../components/buildInlime/RoutePendingComponent'
-import { unwrapJsonb } from '%/presentation/lib/utils'
-import type { Property } from '%/infrastructure/database/schema/admin-schema'
+import { useTaskRoute } from '../../../../../../hooks/use-task-route'
+import { useBuildUnitContext, useChannelContext } from '../../../../../../contexts/route-contexts'
 
 export const Route = createFileRoute('/_authenticated/projects/$projectId/$buildUnitName/$channelName/$taskName')({
   component: TaskRoute,
   loader: async () => {
     await Promise.all([
-      channelsCollection.preload(),
       tasksCollection.preload(),
       propertiesCollection.preload(),
       resourcesCollection.preload(),
@@ -30,82 +23,15 @@ export const Route = createFileRoute('/_authenticated/projects/$projectId/$build
 
 function TaskRoute() {
   const { projectId, buildUnitName, channelName, taskName } = Route.useParams()
-  const { data: session } = useSession()
+  const { buildUnitId, projectName } = useBuildUnitContext()
+  const { channelId } = useChannelContext()
+  const result = useTaskRoute(channelId, taskName)
 
-  const { data: dbProjects } = useLiveQuery(
-    (q) => q.from({ projectsCollection }).where(({ projectsCollection: p }) => eq(p.id, projectId)),
-    [projectId]
-  )
-
-  const { data: dbBuildUnits } = useLiveQuery(
-    (q) => q.from({ buildUnitsCollection }).where(({ buildUnitsCollection: bu }) => eq(bu.project_id, projectId)),
-    [projectId]
-  )
-
-  const buildUnit = (dbBuildUnits ?? []).find((bu) => bu.name === buildUnitName)
-  const buildUnitId = buildUnit?.id ?? ''
-
-  const { data: dbChannels } = useLiveQuery(
-    (q) => q.from({ channelsCollection }).where(({ channelsCollection: c }) => eq(c.buildunit_id, buildUnitId)),
-    [buildUnitId]
-  )
-
-  const channel = (dbChannels ?? []).find((c) => {
-    const raw = c.name as unknown as string
-    const name = raw.startsWith('"') ? JSON.parse(raw) : raw
-    return name === channelName
-  })
-  const channelId = channel?.id ?? ''
-
-  const { data: dbTasks } = useLiveQuery(
-    (q) => q.from({ tasksCollection }).where(({ tasksCollection: t }) => eq(t.channel_id, channelId)),
-    [channelId]
-  )
-
-  const task = (dbTasks ?? []).find((t) => t.name === taskName)
-  const taskId = task?.id ?? ''
-
-  const { data: dbTaskProperties } = useLiveQuery(
-    (q) => q.from({ propertiesCollection }).where(({ propertiesCollection: p }) => eq(p.entity_id, taskId)),
-    [taskId]
-  )
-
-  const { data: channelMembershipsData } = useLiveQuery(
-    (q) => q.from({ membershipsCollection }).where(({ membershipsCollection: m }) => eq(m.channel_id, channelId)),
-    [channelId]
-  )
-
-  // --- Existence guards (after all hooks) ---
-
-  if (dbBuildUnits === undefined) {
+  if (result.status === 'loading') {
     return <div className="flex h-screen items-center justify-center text-[#717182]">Loading…</div>
   }
 
-  if (!buildUnit) {
-    return (
-      <div className="flex h-screen items-center justify-center text-[#717182]">
-        Build unit "{buildUnitName}" not found.
-      </div>
-    )
-  }
-
-  if (dbChannels === undefined) {
-    return <div className="flex h-screen items-center justify-center text-[#717182]">Loading…</div>
-  }
-
-  if (!channel) {
-    return (
-      <div className="flex h-screen items-center justify-center text-[#717182]">
-        Channel "{channelName}" not found.
-      </div>
-    )
-  }
-
-  if (dbTasks === undefined) {
-    return <div className="flex h-screen items-center justify-center text-[#717182]">Loading…</div>
-  }
-
-  if (!task) {
+  if (result.status === 'not-found-task') {
     return (
       <div className="flex h-screen items-center justify-center text-[#717182]">
         Task "{taskName}" not found.
@@ -113,20 +39,7 @@ function TaskRoute() {
     )
   }
 
-  // --- Render ---
-
-  const projectName = dbProjects?.[0]?.name ?? 'Project'
-  const taskDescription = task.description ?? ''
-  const channelMemberIds: string[] = (channelMembershipsData ?? []).map(m => m.user_id)
-  const currentAssigneeId = (task.assignee_id as string | null) ?? null
-
-  const properties: Property[] = (dbTaskProperties ?? []).map((p) => ({
-    ...p,
-    type: unwrapJsonb(p.type) as Property['type'],
-    entity: unwrapJsonb(p.entity) as Property['entity'],
-    status_value: unwrapJsonb(p.status_value) as Property['status_value'],
-    priority_value: unwrapJsonb(p.priority_value) as Property['priority_value'],
-  }))
+  const { taskId, taskDescription, properties, channelMemberIds, currentAssigneeId, currentUserId } = result
 
   return (
     <TaskPage
@@ -142,7 +55,7 @@ function TaskRoute() {
       properties={properties}
       channelMemberIds={channelMemberIds}
       currentAssigneeId={currentAssigneeId}
-      currentUserId={session?.user?.id ?? ""}
+      currentUserId={currentUserId}
     />
   )
 }

--- a/web-app/code/src/presentation/routes/_authenticated/projects/$projectId/$buildUnitName/$channelName/index.tsx
+++ b/web-app/code/src/presentation/routes/_authenticated/projects/$projectId/$buildUnitName/$channelName/index.tsx
@@ -1,136 +1,23 @@
 import { createFileRoute } from '@tanstack/react-router'
-import { useLiveQuery, eq } from "@tanstack/react-db"
-import { useState, useEffect } from 'react'
-import { ClipboardCheck } from 'lucide-react'
 import { ChannelPage } from '../../../../../../pages/ChannelPage'
-import { projectsCollection, buildUnitsCollection, channelsCollection, propertiesCollection, tasksCollection, resourcesCollection, messagesCollection } from '%/infrastructure/database/tanstack-db-electric/admincollections'
-import { CHANNEL_NAMES } from '%/infrastructure/database/schema/admin-schema'
-import { CHANNEL_ICONS } from '%/presentation/lib/channelIcons'
-import { unwrapJsonb } from '%/presentation/lib/utils'
+import { propertiesCollection, tasksCollection, resourcesCollection, messagesCollection } from '%/infrastructure/database/tanstack-db-electric/admincollections'
 import { RoutePendingComponent } from '../../../../../../components/buildInlime/RoutePendingComponent'
-import type { Property } from '%/infrastructure/database/schema/admin-schema'
+import { useChannelRoute } from '../../../../../../hooks/use-channel-route'
+import { useBuildUnitContext, useChannelContext } from '../../../../../../contexts/route-contexts'
 
 export const Route = createFileRoute('/_authenticated/projects/$projectId/$buildUnitName/$channelName/')({
   component: ChannelRoute,
   loader: async () => {
-    await Promise.all([channelsCollection.preload(), propertiesCollection.preload(), tasksCollection.preload(), resourcesCollection.preload(), messagesCollection.preload()])
+    await Promise.all([propertiesCollection.preload(), tasksCollection.preload(), resourcesCollection.preload(), messagesCollection.preload()])
   },
   pendingComponent: RoutePendingComponent,
 })
 
 function ChannelRoute() {
   const { projectId, buildUnitName, channelName } = Route.useParams()
-  const [syncTimedOut, setSyncTimedOut] = useState(false)
-  useEffect(() => {
-    const t = setTimeout(() => setSyncTimedOut(true), 5000)
-    return () => clearTimeout(t)
-  }, [])
-
-  // Look up the project name by projectId
-  const { data: dbProjects } = useLiveQuery(
-    (q) =>
-      q
-        .from({ projectsCollection })
-        .where(({ projectsCollection: p }) => eq(p.id, projectId)),
-    [projectId]
-  )
-
-  // Look up the build unit by projectId + buildUnitName to get its id
-  const { data: dbBuildUnits } = useLiveQuery(
-    (q) =>
-      q
-        .from({ buildUnitsCollection })
-        .where(({ buildUnitsCollection: bu }) => eq(bu.project_id, projectId)),
-    [projectId]
-  )
-
-  const buildUnit = (dbBuildUnits ?? []).find((bu) => bu.name === buildUnitName)
-  const buildUnitId = buildUnit?.id ?? ''
-
-  // Find the channel matching channelName within this build unit
-  const { data: dbChannels } = useLiveQuery(
-    (q) =>
-      q
-        .from({ channelsCollection })
-        .where(({ channelsCollection: c }) => eq(c.buildunit_id, buildUnitId)),
-    [buildUnitId]
-  )
-
-  const channel = (dbChannels ?? []).find((c) => {
-    const raw = c.name as unknown as string
-    const name = raw.startsWith('"') ? JSON.parse(raw) : raw
-    return name === channelName
-  })
-
-  const channelId = channel?.id ?? ''
-
-  // Fetch properties scoped to this channel
-  const { data: dbChannelProperties } = useLiveQuery(
-    (q) =>
-      q
-        .from({ propertiesCollection })
-        .where(({ propertiesCollection: p }) => eq(p.entity_id, channelId)),
-    [channelId]
-  )
-
-  // Fetch properties scoped to the build unit
-  const { data: dbBuildUnitProperties } = useLiveQuery(
-    (q) =>
-      q
-        .from({ propertiesCollection })
-        .where(({ propertiesCollection: p }) => eq(p.entity_id, buildUnitId)),
-    [buildUnitId]
-  )
-
-  // --- Existence guards (after all hooks) ---
-
-  if (dbBuildUnits === undefined) {
-    return <div className="flex h-screen items-center justify-center text-[#717182]">Loading…</div>
-  }
-
-  if (!buildUnit) {
-    if (!syncTimedOut) {
-      return <div className="flex h-screen items-center justify-center text-[#717182]">Loading…</div>
-    }
-    return (
-      <div className="flex h-screen items-center justify-center text-[#717182]">
-        Build unit "{buildUnitName}" not found.
-      </div>
-    )
-  }
-
-  if (dbChannels === undefined) {
-    return <div className="flex h-screen items-center justify-center text-[#717182]">Loading…</div>
-  }
-
-  if (!channel) {
-    if (!syncTimedOut) {
-      return <div className="flex h-screen items-center justify-center text-[#717182]">Loading…</div>
-    }
-    return (
-      <div className="flex h-screen items-center justify-center text-[#717182]">
-        Channel "{channelName}" not found.
-      </div>
-    )
-  }
-
-  // --- Render ---
-
-  const projectName = dbProjects?.[0]?.name ?? "Project"
-  const channelDescription = channel.description ?? ''
-  const channelIcon = CHANNEL_ICONS[channelName as typeof CHANNEL_NAMES[number]] ?? ClipboardCheck
-
-  const mapProperties = (raw_list: typeof dbChannelProperties): Property[] =>
-    (raw_list ?? []).map((p) => ({
-      ...p,
-      type: unwrapJsonb(p.type) as Property['type'],
-      entity: unwrapJsonb(p.entity) as Property['entity'],
-      status_value: unwrapJsonb(p.status_value) as Property['status_value'],
-      priority_value: unwrapJsonb(p.priority_value) as Property['priority_value'],
-    }))
-
-  const properties = mapProperties(dbChannelProperties)
-  const buildUnitProperties = mapProperties(dbBuildUnitProperties)
+  const { buildUnitId, projectName } = useBuildUnitContext()
+  const { channelId, channelDescription, channelIcon } = useChannelContext()
+  const { properties, buildUnitProperties } = useChannelRoute(buildUnitId, channelId)
 
   return (
     <ChannelPage

--- a/web-app/code/src/presentation/routes/_authenticated/projects/$projectId/$buildUnitName/index.tsx
+++ b/web-app/code/src/presentation/routes/_authenticated/projects/$projectId/$buildUnitName/index.tsx
@@ -1,16 +1,9 @@
 import { createFileRoute } from '@tanstack/react-router'
-import { useLiveQuery, eq } from "@tanstack/react-db"
-import { useState, useEffect, useCallback, useRef } from 'react'
-import { ClipboardCheck } from 'lucide-react'
 import { BuildUnitPage } from '../../../../../pages/BuildUnitPage'
-import { buildUnitsCollection, channelsCollection, propertiesCollection, projectsCollection } from '%/infrastructure/database/tanstack-db-electric/admincollections'
-import { CHANNEL_NAMES } from '%/infrastructure/database/schema/admin-schema'
-import { CHANNEL_ICONS } from '%/presentation/lib/channelIcons'
-import { unwrapJsonb } from '%/presentation/lib/utils'
+import { channelsCollection, propertiesCollection } from '%/infrastructure/database/tanstack-db-electric/admincollections'
 import { RoutePendingComponent } from '../../../../../components/buildInlime/RoutePendingComponent'
-import { usePendingItems } from '../../../../../hooks/use-pending-items'
-import type { Channel } from '../../../../../components/buildInlime'
-import type { Property } from '%/infrastructure/database/schema/admin-schema'
+import { useBuildUnitChannels } from '../../../../../hooks/use-build-unit-channels'
+import { useBuildUnitContext } from '../../../../../contexts/route-contexts'
 
 export const Route = createFileRoute('/_authenticated/projects/$projectId/$buildUnitName/')({
   component: BuildUnitIndexRoute,
@@ -22,127 +15,14 @@ export const Route = createFileRoute('/_authenticated/projects/$projectId/$build
 
 function BuildUnitIndexRoute() {
   const { projectId, buildUnitName } = Route.useParams()
-  const [syncTimedOut, setSyncTimedOut] = useState(false)
-  useEffect(() => {
-    const t = setTimeout(() => setSyncTimedOut(true), 5000)
-    return () => clearTimeout(t)
-  }, [])
+  const { buildUnitId, buildUnitDesc, projectName } = useBuildUnitContext()
+  const result = useBuildUnitChannels(buildUnitId, projectId, buildUnitName)
 
-  // Pending channels state + two-signal logic (same pattern as build units)
-  const { pendingItems: pendingChannels, pendingIds: pendingChannelIds, addPending, removePending } = usePendingItems()
-  const pendingChannelIdsRef = useRef(pendingChannelIds)
-  pendingChannelIdsRef.current = pendingChannelIds
-  const channelTrpcDoneRef = useRef<Set<string>>(new Set())
-
-  const onChannelTrpcComplete = useCallback((id: string) => {
-    channelTrpcDoneRef.current.add(id)
-  }, [])
-
-  // Look up project name
-  const { data: dbProjects } = useLiveQuery(
-    (q) =>
-      q
-        .from({ projectsCollection })
-        .where(({ projectsCollection: p }) => eq(p.id, projectId)),
-    [projectId]
-  )
-
-  // Look up the build unit by projectId + buildUnitName to get its id
-  const { data: dbBuildUnits } = useLiveQuery(
-    (q) =>
-      q
-        .from({ buildUnitsCollection })
-        .where(({ buildUnitsCollection: bu }) => eq(bu.project_id, projectId)),
-    [projectId]
-  )
-
-  const buildUnit = (dbBuildUnits ?? []).find((bu) => bu.name === buildUnitName)
-  const buildUnitId = buildUnit?.id ?? ''
-
-  // Fetch channels for this specific build unit
-  const { data: dbChannels } = useLiveQuery(
-    (q) =>
-      q
-        .from({ channelsCollection })
-        .where(({ channelsCollection: bu }) => eq(bu.buildunit_id, buildUnitId)),
-    [buildUnitId]
-  )
-
-  // Second signal: Electric updated dbChannels + tRPC done → stop spinner
-  useEffect(() => {
-    if (!dbChannels) return
-    for (const id of pendingChannelIdsRef.current) {
-      if (channelTrpcDoneRef.current.has(id) && dbChannels.some((c) => c.id === id)) {
-        removePending(id)
-        channelTrpcDoneRef.current.delete(id)
-      }
-    }
-  }, [dbChannels])
-
-  // Fetch properties for this specific build unit.
-  const { data: dbProperties } = useLiveQuery(
-    (q) =>
-      q
-        .from({ propertiesCollection })
-        .where(({ propertiesCollection: p }) => eq(p.entity_id, buildUnitId)),
-    [buildUnitId]
-  )
-
-  // --- Existence guards (after all hooks) ---
-
-  if (dbBuildUnits === undefined) {
+  if (result.status === 'loading') {
     return <div className="flex h-screen items-center justify-center text-[#717182]">Loading…</div>
   }
 
-  if (!buildUnit) {
-    if (!syncTimedOut) {
-      return <div className="flex h-screen items-center justify-center text-[#717182]">Loading…</div>
-    }
-    return (
-      <div className="flex h-screen items-center justify-center text-[#717182]">
-        Build unit "{buildUnitName}" not found.
-      </div>
-    )
-  }
-
-  // --- Render ---
-
-  const projectName = dbProjects?.[0]?.name ?? 'Project'
-  const buildUnitDesc = buildUnit.description ?? ''
-
-  const dbChannelList: Channel[] = (dbChannels ?? []).map((channel) => {
-    const raw = channel.name as unknown as string
-    const name: typeof CHANNEL_NAMES[number] = raw.startsWith('"') ? JSON.parse(raw) : raw as typeof CHANNEL_NAMES[number]
-    return {
-      id: channel.id,
-      title: name,
-      description: channel.description ?? '',
-      icon: CHANNEL_ICONS[name] ?? ClipboardCheck,
-      to: `/projects/${projectId}/${buildUnitName}/${name}`,
-    }
-  })
-
-  // Ghost rows: keep pending channels visible during Electric txid reconciliation
-  const dbChannelIds = new Set(dbChannelList.map((c) => c.id))
-  const ghostChannels: Channel[] = [...pendingChannels.values()]
-    .filter((p) => !dbChannelIds.has(p.id))
-    .map((p) => ({
-      id: p.id,
-      title: p.name as typeof CHANNEL_NAMES[number],
-      description: p.description ?? '',
-      icon: CHANNEL_ICONS[p.name as typeof CHANNEL_NAMES[number]] ?? ClipboardCheck,
-      to: undefined,
-    }))
-
-  const channels = [...dbChannelList, ...ghostChannels]
-
-  const properties: Property[] = (dbProperties ?? []).map((p) => ({
-    ...p,
-    type: unwrapJsonb(p.type) as Property['type'],
-    entity: unwrapJsonb(p.entity) as Property['entity'],
-    status_value: unwrapJsonb(p.status_value) as Property['status_value'],
-    priority_value: unwrapJsonb(p.priority_value) as Property['priority_value'],
-  }))
+  const { channels, properties, pendingChannelIds, addPending, removePending, onChannelTrpcComplete } = result
 
   return (
     <BuildUnitPage

--- a/web-app/code/src/presentation/routes/_authenticated/projects/$projectId/index.tsx
+++ b/web-app/code/src/presentation/routes/_authenticated/projects/$projectId/index.tsx
@@ -1,17 +1,12 @@
-import { createFileRoute, Link, useNavigate } from '@tanstack/react-router'
+import { createFileRoute, Link } from '@tanstack/react-router'
 import { Plus, ChevronRight } from "lucide-react";
-import { useCallback, useEffect, useRef } from "react";
 import { Sidebar } from "../../../../components/buildInlime/Sidebar";
 import { NewBuildUnitButton } from "../../../../components/buildInlime/NewBuildUnitButton";
 import { DisplayButton } from "../../../../components/buildInlime/DisplayButton";
 import { FilterButton } from "../../../../components/buildInlime/FilterButton";
-
 import { BuildUnitsTable } from "../../../../components/buildInlime/BuildUnitsTable";
-import { projectsCollection, buildUnitsCollection } from '%/infrastructure/database/tanstack-db-electric/admincollections'
 import { RoutePendingComponent } from "../../../../components/buildInlime/RoutePendingComponent";
-import { usePendingBuildUnits } from "../../../../hooks/use-pending-build-units";
-
-import { useLiveQuery, eq } from "@tanstack/react-db"
+import { useProjectBuildUnits } from "../../../../hooks/use-project-build-units";
 
 export const Route = createFileRoute('/_authenticated/projects/$projectId/')({
   component: ProjectRoute,
@@ -20,93 +15,10 @@ export const Route = createFileRoute('/_authenticated/projects/$projectId/')({
 
 function ProjectRoute() {
   const { projectId } = Route.useParams()
-  const navigate = useNavigate()
-  const { pendingItems, pendingIds, addPending, removePending } = usePendingBuildUnits()
-  // Two-signal approach: spinner stops only when BOTH tRPC is done AND Electric
-  // has next updated buildUnitsFromDB (confirming the write from the server).
-  const pendingIdsRef = useRef(pendingIds)
-  pendingIdsRef.current = pendingIds
-  const trpcDoneRef = useRef<Set<string>>(new Set())
+  const { projectName, buildUnits, pendingIds, addPending, removePending, onTrpcComplete, onBuildUnitClick } =
+    useProjectBuildUnits(projectId)
 
-  // Called by NewBuildUnitButton (via registry resolve) when tRPC write completes.
-  // Only sets the flag — the useEffect below stops the spinner on the next Electric sync.
-  const onTrpcComplete = useCallback((id: string) => {
-    trpcDoneRef.current.add(id)
-  }, [])
-
-  const { data: dbProjects } = useLiveQuery(
-    (q) =>
-      q
-        .from({ projectsCollection })
-        .where(({ projectsCollection: p }) => eq(p.id, projectId)),
-    [projectId]
-  )
-
-  const projectName = dbProjects?.[0]?.name ?? "Project"
-
-  const { data: buildUnitsFromDB } = useLiveQuery(
-    (q) =>
-      q
-        .from({ buildUnitsCollection })
-        .where(({ buildUnitsCollection: bu }) => eq(bu.project_id, projectId)),
-    [projectId]
-  )
-
-  // Second signal: whenever Electric updates buildUnitsFromDB, check if any
-  // pending item has already had its tRPC write confirmed. If so, stop spinner.
-  useEffect(() => {
-    if (!buildUnitsFromDB) return
-    for (const id of pendingIdsRef.current) {
-      if (trpcDoneRef.current.has(id) && buildUnitsFromDB.some((bu) => bu.id === id)) {
-        removePending(id)
-        trpcDoneRef.current.delete(id)
-      }
-    }
-  }, [buildUnitsFromDB])
-
-  const dbBuildUnits = (buildUnitsFromDB ?? []).map((bu) => ({
-    id: bu.id,
-    name: bu.name,
-    description: bu.descritption,
-    health: (bu.health ?? "On track") as "On track" | "At risk" | "Off track",
-    priority: (bu.priority ?? "Low") as "High" | "Mid" | "Low",
-    waitingOnTask: {
-      name: bu.task_name ?? "—",
-      assignee: bu.task_assignee ?? "—",
-      since: bu.task_since ?? "—",
-    },
-    targetDate: bu.target_date ?? "—",
-    statusPercent: parseInt(bu.status_percent ?? "0", 10),
-  }));
-
-  // During Electric txid reconciliation the optimistic entry is briefly removed
-  // before the confirmed entry arrives. Fill that gap using pendingItems so the
-  // row stays visible and doesn't flicker out of the table.
-  const dbIds = new Set(dbBuildUnits.map((bu) => bu.id))
-  const ghostRows = [...pendingItems.values()]
-    .filter((p) => !dbIds.has(p.id))
-    .map((p) => ({
-      id: p.id,
-      name: p.name,
-      description: p.description,
-      health: "On track" as const,
-      priority: "Low" as const,
-      waitingOnTask: { name: "—", assignee: "—", since: "—" },
-      targetDate: "—",
-      statusPercent: 0,
-    }))
-
-  const buildunits = [...dbBuildUnits, ...ghostRows];
-
-  const onBuildUnitClick = (buildUnit: { id: string; name: string, desc: string }) => {
-    navigate({
-      to: '/projects/$projectId/$buildUnitName',
-      params: { projectId, buildUnitName: buildUnit.name },
-      state: { buildUnitId: buildUnit.id, unitDescription: buildUnit.desc, projectName },
-    })
-  }
-
-return (
+  return (
     <div className="flex h-screen bg-white font-['Instrument_Sans',sans-serif]">
       {/* Sidebar */}
       <Sidebar projectId={projectId} />
@@ -158,7 +70,7 @@ return (
         </div>
 
         {/* Table */}
-        <BuildUnitsTable buildUnits={buildunits} onBuildUnitClick={onBuildUnitClick} pendingIds={pendingIds} />
+        <BuildUnitsTable buildUnits={buildUnits} onBuildUnitClick={onBuildUnitClick} pendingIds={pendingIds} />
       </div>
     </div>
   );


### PR DESCRIPTION
## Summary

- **Hook extraction**: Moved all data-fetching and state management out of page components and route components into dedicated hooks (`use-channel-page`, `use-inbox-page`, `use-my-tasks-page`, `use-project-build-units`, `use-build-unit-channels`, `use-channel-route`, `use-task-route`), leaving pages and route components as pure rendering/composition layers
- **Route context system**: Introduced `BuildUnitContext` and `ChannelContext` (`contexts/route-contexts.tsx`) so the `$buildUnitName` and `$channelName` layout routes resolve entity IDs once and share them with all descendants via React context
- **Waterfall elimination**: Child hooks (`use-channel-route`, `use-task-route`) no longer re-query `projectsCollection`, `buildUnitsCollection`, or `channelsCollection` — reducing `useChannelRoute` from 5 queries to 2 and `useTaskRoute` from 6 queries to 3, and removing duplicate reactive subscriptions across the route hierarchy

## Files changed

| Area | Change |
|---|---|
| `contexts/route-contexts.tsx` | New — `BuildUnitContextProvider`, `ChannelContextProvider`, typed hooks |
| `hooks/use-build-unit-channels.ts` | New — extracted from `BuildUnitPage`, drops project/buildUnit queries |
| `hooks/use-channel-route.ts` | New — simplified to 2 property queries only |
| `hooks/use-task-route.ts` | New — drops 3 redundant queries, keeps task/properties/memberships |
| `hooks/use-channel-page.ts` | New — extracted from `ChannelPage` |
| `hooks/use-inbox-page.ts` | New — extracted from `InboxPage` |
| `hooks/use-my-tasks-page.ts` | New — extracted from `MyTasksPage` |
| `hooks/use-project-build-units.ts` | New — extracted from project index route |
| `routes/$buildUnitName.tsx` | Converted to layout that resolves buildUnit + provides context |
| `routes/$channelName.tsx` | Converted to layout that resolves channel + provides context |
| `routes/$buildUnitName/index.tsx` | Consumes context, calls simplified hook |
| `routes/$channelName/index.tsx` | Consumes context, no more status checks |
| `routes/$taskName.tsx` | Consumes context, only handles not-found-task |
| `pages/ChannelPage.tsx`, `InboxPage.tsx`, `MyTasksPage.tsx` | UI-only after hook extraction |

## Test plan

- [ ] Navigate to a project → build unit page loads with channels and properties
- [ ] Navigate to a channel → channel page loads without extra loading flicker
- [ ] Navigate to a task → task detail loads correctly
- [ ] Create a new channel via NewChannelButton — two-signal spinner works correctly
- [ ] Direct URL navigation to deep routes (task page) works without not-found errors
- [ ] Inbox and My Tasks pages display correctly with mentions/assigned tasks

🤖 Generated with [Claude Code](https://claude.com/claude-code)