### PR TITLE
fix: minor business UI issues

### DIFF
--- a/web-app/code/src/application/collections/admin.ts
+++ b/web-app/code/src/application/collections/admin.ts
@@ -67,6 +67,18 @@ export const teamsCollection = createCollection(
       })
       return { txid: result.txid }
     },
+    onUpdate: async ({ transaction }) => {
+      const { modified: updatedTeam } = transaction.mutations[0]
+      const result = await trpc.teams.update.mutate({
+        id: updatedTeam.id,
+        data: {
+          name: updatedTeam.name,
+          description: updatedTeam.description,
+          member_ids: updatedTeam.member_ids,
+        },
+      })
+      return { txid: result.txid }
+    },
     onDelete: async ({ transaction }) => {
       const { original: deletedTeam } = transaction.mutations[0]
       const result = await trpc.teams.delete.mutate({ id: deletedTeam.id })

--- a/web-app/code/src/presentation/components/buildInlime/admin/PageTopBar.tsx
+++ b/web-app/code/src/presentation/components/buildInlime/admin/PageTopBar.tsx
@@ -1,5 +1,5 @@
-import type { ReactNode } from "react";
-import { Link as LinkIcon, Bell, PanelRight } from "lucide-react";
+import { useState, type ReactNode } from "react";
+import { Link as LinkIcon, Check, Bell, PanelRight } from "lucide-react";
 
 interface PageTopBarProps {
   breadcrumbs: ReactNode;
@@ -7,6 +7,14 @@ interface PageTopBarProps {
 }
 
 export function PageTopBar({ breadcrumbs, onToggleRightPanel }: PageTopBarProps) {
+  const [copied, setCopied] = useState(false);
+
+  const handleCopyLink = () => {
+    navigator.clipboard.writeText(window.location.href);
+    setCopied(true);
+    setTimeout(() => setCopied(false), 1500);
+  };
+
   return (
     <header className="border-b border-gray-200 bg-white px-6 py-2">
       <div className="flex items-center justify-between">
@@ -14,8 +22,12 @@ export function PageTopBar({ breadcrumbs, onToggleRightPanel }: PageTopBarProps)
           {breadcrumbs}
         </div>
         <div className="flex items-center gap-2">
-          <button className="p-1.5 text-[#717182] hover:bg-gray-100 rounded transition-colors">
-            <LinkIcon className="w-4 h-4" />
+          <button
+            onClick={handleCopyLink}
+            title="Copy link"
+            className={`p-1.5 rounded transition-colors ${copied ? "text-green-600 bg-green-50" : "text-[#717182] hover:bg-gray-100"}`}
+          >
+            {copied ? <Check className="w-4 h-4" /> : <LinkIcon className="w-4 h-4" />}
           </button>
           <button className="p-1.5 text-[#717182] hover:bg-gray-100 rounded transition-colors">
             <Bell className="w-4 h-4" />

--- a/web-app/code/src/presentation/components/buildInlime/admin/Sidebar.tsx
+++ b/web-app/code/src/presentation/components/buildInlime/admin/Sidebar.tsx
@@ -83,6 +83,14 @@ export function Sidebar({ projectId }: SidebarProps) {
     setCreateOpen(true);
   };
 
+  const handleAddMember = async (teamId: string, newMemberIds: string[]) => {
+    const team = teamsCollection.get(teamId);
+    if (!team) return;
+    await teamsCollection.update(teamId, (t) => {
+      t.member_ids = [...t.member_ids, ...newMemberIds];
+    });
+  };
+
   const handleCreate = async (e: React.FormEvent) => {
     e.preventDefault();
     if (!teamName.trim() || !currentUserId || !projectId) return;
@@ -304,9 +312,13 @@ export function Sidebar({ projectId }: SidebarProps) {
                     return (
                       <TeamSection
                         key={team.id}
+                        teamId={team.id}
                         name={team.name}
                         description={team.description}
                         members={members}
+                        currentMemberIds={team.member_ids}
+                        allUsers={allUsers ?? []}
+                        onAddMember={handleAddMember}
                       />
                     );
                   })

--- a/web-app/code/src/presentation/components/buildInlime/admin/TeamSection.tsx
+++ b/web-app/code/src/presentation/components/buildInlime/admin/TeamSection.tsx
@@ -1,5 +1,5 @@
 import { useState } from "react";
-import { ChevronDown, ChevronRight } from "lucide-react";
+import { ChevronDown, ChevronRight, Plus, X } from "lucide-react";
 
 interface TeamMember {
   id: string;
@@ -8,54 +8,155 @@ interface TeamMember {
 }
 
 interface TeamSectionProps {
+  teamId: string;
   name: string;
   description?: string | null;
   members: TeamMember[];
+  currentMemberIds: string[];
+  allUsers: { id: string; name: string | null; email: string }[];
+  onAddMember: (teamId: string, newMemberIds: string[]) => Promise<void>;
 }
 
-export function TeamSection({ name, description, members }: TeamSectionProps) {
+export function TeamSection({ teamId, name, description, members, currentMemberIds, allUsers, onAddMember }: TeamSectionProps) {
   const [expanded, setExpanded] = useState(false);
+  const [addOpen, setAddOpen] = useState(false);
+  const [selectedIds, setSelectedIds] = useState<string[]>([]);
+  const [isSubmitting, setIsSubmitting] = useState(false);
 
   const initial = (name[0] ?? "T").toUpperCase();
+  const nonMembers = allUsers.filter(u => !currentMemberIds.includes(u.id));
+
+  const toggleUser = (id: string) => {
+    setSelectedIds(prev => prev.includes(id) ? prev.filter(x => x !== id) : [...prev, id]);
+  };
+
+  const openAdd = (e: React.MouseEvent) => {
+    e.stopPropagation();
+    setSelectedIds([]);
+    setAddOpen(true);
+  };
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    if (!selectedIds.length) return;
+    setIsSubmitting(true);
+    try {
+      await onAddMember(teamId, selectedIds);
+      setAddOpen(false);
+    } finally {
+      setIsSubmitting(false);
+    }
+  };
 
   return (
-    <div className="mb-1">
-      <div className="group flex items-center gap-2 px-3 py-1.5 hover:bg-[#f0e5d8] rounded transition-colors">
-        <div className="w-5 h-5 rounded bg-[#976623] flex items-center justify-center flex-shrink-0">
-          <span className="text-white text-xs font-bold">{initial}</span>
+    <>
+      <div className="mb-1">
+        <div className="group flex items-center gap-2 px-3 py-1.5 hover:bg-[#f0e5d8] rounded transition-colors">
+          <div className="w-5 h-5 rounded bg-[#976623] flex items-center justify-center flex-shrink-0">
+            <span className="text-white text-xs font-bold">{initial}</span>
+          </div>
+          <span className="text-sm text-[#1e1e1e] font-medium truncate flex-1">{name}</span>
+          <div className="ml-auto flex items-center gap-1 opacity-0 group-hover:opacity-100 flex-shrink-0">
+            <button
+              onClick={openAdd}
+              className="p-0.5 hover:text-[#976623] hover:bg-[#e5d4c1] rounded transition-colors"
+              title="Add member"
+            >
+              <Plus className="w-3 h-3 text-[#717182]" />
+            </button>
+            <button onClick={() => setExpanded(!expanded)}>
+              {expanded ? (
+                <ChevronDown className="w-3 h-3 text-[#717182]" />
+              ) : (
+                <ChevronRight className="w-3 h-3 text-[#717182]" />
+              )}
+            </button>
+          </div>
         </div>
-        <span className="text-sm text-[#1e1e1e] font-medium truncate flex-1">{name}</span>
-        <button
-          onClick={() => setExpanded(!expanded)}
-          className="ml-auto opacity-0 group-hover:opacity-100 flex-shrink-0"
-        >
-          {expanded ? (
-            <ChevronDown className="w-3 h-3 text-[#717182]" />
-          ) : (
-            <ChevronRight className="w-3 h-3 text-[#717182]" />
-          )}
-        </button>
+
+        {expanded && (
+          <div className="ml-7 mt-1 space-y-1">
+            {description && (
+              <p className="px-2 py-1 text-xs text-[#717182] italic">{description}</p>
+            )}
+            {members.length === 0 ? (
+              <p className="px-2 py-1 text-xs text-[#717182]">No members</p>
+            ) : (
+              members.map((m) => (
+                <div key={m.id} className="flex items-center gap-2 px-2 py-1">
+                  <div className="w-5 h-5 rounded-full bg-[#e5d4c1] flex items-center justify-center text-[#976623] text-xs font-medium flex-shrink-0">
+                    {((m.name || m.email)[0] ?? "?").toUpperCase()}
+                  </div>
+                  <span className="text-xs text-[#1e1e1e] truncate">{m.name || m.email}</span>
+                </div>
+              ))
+            )}
+          </div>
+        )}
       </div>
 
-      {expanded && (
-        <div className="ml-7 mt-1 space-y-1">
-          {description && (
-            <p className="px-2 py-1 text-xs text-[#717182] italic">{description}</p>
-          )}
-          {members.length === 0 ? (
-            <p className="px-2 py-1 text-xs text-[#717182]">No members</p>
-          ) : (
-            members.map((m) => (
-              <div key={m.id} className="flex items-center gap-2 px-2 py-1">
-                <div className="w-5 h-5 rounded-full bg-[#e5d4c1] flex items-center justify-center text-[#976623] text-xs font-medium flex-shrink-0">
-                  {((m.name || m.email)[0] ?? "?").toUpperCase()}
-                </div>
-                <span className="text-xs text-[#1e1e1e] truncate">{m.name || m.email}</span>
+      {addOpen && (
+        <div className="fixed inset-0 z-50 flex items-center justify-center">
+          <div className="absolute inset-0 bg-black/50" onClick={() => setAddOpen(false)} />
+          <div className="relative bg-white rounded-lg shadow-xl w-full max-w-md mx-4 p-6">
+            <button
+              onClick={() => setAddOpen(false)}
+              className="absolute top-4 right-4 text-gray-400 hover:text-gray-600 transition-colors"
+            >
+              <X className="w-5 h-5" />
+            </button>
+
+            <h2 className="text-lg font-semibold text-[#1e1e1e] mb-5">Add Members to {name}</h2>
+
+            <form onSubmit={handleSubmit} className="space-y-4">
+              <div>
+                <label className="block text-sm font-medium text-[#1e1e1e] mb-2">Members</label>
+                {nonMembers.length === 0 ? (
+                  <p className="px-3 py-3 text-xs text-[#717182] border border-[#e5d4c1] rounded-md">
+                    All users are already members of this team.
+                  </p>
+                ) : (
+                  <div className="max-h-48 overflow-y-auto border border-[#e5d4c1] rounded-md divide-y divide-[#f0e5d8]">
+                    {nonMembers.map((user) => {
+                      const checked = selectedIds.includes(user.id);
+                      return (
+                        <label
+                          key={user.id}
+                          className="flex items-center gap-3 px-3 py-2 hover:bg-[#fdf8f2] transition-colors cursor-pointer"
+                        >
+                          <input
+                            type="checkbox"
+                            checked={checked}
+                            onChange={() => toggleUser(user.id)}
+                            className="accent-[#976623]"
+                          />
+                          <div className="w-6 h-6 rounded-full bg-[#e5d4c1] flex items-center justify-center text-[#976623] text-xs font-medium flex-shrink-0">
+                            {((user.name || user.email || "?")[0] ?? "?").toUpperCase()}
+                          </div>
+                          <div className="min-w-0 flex-1">
+                            <p className="text-sm text-[#1e1e1e] truncate">{user.name || user.email}</p>
+                            {user.name && (
+                              <p className="text-xs text-[#717182] truncate">{user.email}</p>
+                            )}
+                          </div>
+                        </label>
+                      );
+                    })}
+                  </div>
+                )}
               </div>
-            ))
-          )}
+
+              <button
+                type="submit"
+                disabled={isSubmitting || !selectedIds.length || nonMembers.length === 0}
+                className="w-full bg-[#976623] hover:bg-[#7d5419] disabled:opacity-50 text-white px-4 py-2 rounded-lg text-sm font-medium transition-colors"
+              >
+                {isSubmitting ? "Adding…" : "Add Members"}
+              </button>
+            </form>
+          </div>
         </div>
       )}
-    </div>
+    </>
   );
 }

--- a/web-app/code/src/presentation/components/buildInlime/communication/CommentsSection.tsx
+++ b/web-app/code/src/presentation/components/buildInlime/communication/CommentsSection.tsx
@@ -312,10 +312,11 @@ export function CommentsSection({
     [channelId]
   )
 
-  const { data: users } = useLiveQuery(
+  const { data: allUsers } = useLiveQuery(
     (q) => q.from({ usersCollection }),
     []
   )
+  const users = (allUsers ?? []).filter(u => memberIds.includes(u.id))
 
   const { messagePending, addPending, scheduleUpload, retryUpload } = usePendingResources(channelId)
 

--- a/web-app/code/src/presentation/pages/ChannelPage.tsx
+++ b/web-app/code/src/presentation/pages/ChannelPage.tsx
@@ -210,7 +210,7 @@ export function ChannelPage({
                 buildunitId={buildUnitId}
                 projectId={projectId}
                 currentUserId={currentUserId}
-                memberIds={currentUserId ? [currentUserId] : []}
+                memberIds={channelMembers.map(u => u.id)}
               />
             </div>
           </div>

--- a/web-app/code/src/presentation/pages/TaskPage.tsx
+++ b/web-app/code/src/presentation/pages/TaskPage.tsx
@@ -4,6 +4,7 @@ import {
   ChevronRight,
   ChevronDown,
   Link as LinkIcon,
+  Check,
   Bell,
   PanelRight,
   Hammer,
@@ -50,6 +51,13 @@ export function TaskPage({
   currentUserId,
 }: TaskPageProps) {
   const [rightPanelOpen, setRightPanelOpen] = useState(true);
+  const [linkCopied, setLinkCopied] = useState(false);
+
+  const handleCopyLink = () => {
+    navigator.clipboard.writeText(window.location.href);
+    setLinkCopied(true);
+    setTimeout(() => setLinkCopied(false), 1500);
+  };
   const [propertiesOpen, setPropertiesOpen] = useState(true);
   const [taskPropsOpen, setTaskPropsOpen] = useState(true);
 
@@ -89,8 +97,12 @@ export function TaskPage({
               <span className="text-[#1e1e1e]">{taskName}</span>
             </div>
             <div className="flex items-center gap-2">
-              <button className="p-1.5 text-[#717182] hover:bg-gray-100 rounded transition-colors">
-                <LinkIcon className="w-4 h-4" />
+              <button
+                onClick={handleCopyLink}
+                title="Copy link"
+                className={`p-1.5 rounded transition-colors ${linkCopied ? "text-green-600 bg-green-50" : "text-[#717182] hover:bg-gray-100"}`}
+              >
+                {linkCopied ? <Check className="w-4 h-4" /> : <LinkIcon className="w-4 h-4" />}
               </button>
               <button className="p-1.5 text-[#717182] hover:bg-gray-100 rounded transition-colors">
                 <Bell className="w-4 h-4" />


### PR DESCRIPTION
## Summary

- **Auth — stale data on user switch**: Hard redirect on logout clears all in-memory Electric collection singletons, preventing previous user's data leaking to the next user
- **Auth — duplicate insert error**: Fixed `CollectionOperationError` when navigating to a protected route while unauthenticated; `authStateCollection` now upserts instead of always inserting
- **Auth — user switch detection**: Moved user-switch detection from a component ref (destroyed on unmount) to `beforeLoad` for reliability
- **Migrations**: Squashed all previous incremental migrations (which had a duplicate `CREATE TABLE properties`) into a single clean baseline
- **Mention suggestions**: Restricted `@mention` dropdown in comments to channel members only (was showing all users in the system)
- **Add team member**: Added `+` button on each team row in the sidebar to add new members after team creation; only shows users not already in the team
- **Teams `onUpdate`**: Added missing `onUpdate` handler to `teamsCollection` that was causing `MissingHandlerError` on team member updates
- **Copy link**: Wired up the link icon button on BuildUnit, Channel, and Task pages to copy the current URL to clipboard with a brief checkmark confirmation

## Test plan

- [ ] Log in as User A → log out → log in as User B — verify no stale data from User A
- [ ] Navigate to `/projects` without logging in — verify redirect with no collection errors
- [ ] In a channel comment, type `@` — verify only channel members appear in the dropdown
- [ ] On a team in the sidebar, hover and click `+` — verify only non-members are listed; submit adds them
- [ ] Click the link icon on a BuildUnit, Channel, or Task page — verify URL is copied and icon briefly turns green

🤖 Generated with [Claude Code](https://claude.com/claude-code)