### PR TITLE
feat(mobile): barebone integration with web app

### DIFF
--- a/mobile-app/app/(tabs)/inbox.tsx
+++ b/mobile-app/app/(tabs)/inbox.tsx
@@ -1,14 +1,88 @@
-import { View, Text, StyleSheet } from "react-native"
+import { View, Text, FlatList, ActivityIndicator, StyleSheet } from "react-native"
 import { ScreenHeader } from "@/src/presentation/shared/components/ScreenHeader"
+import { useCollection } from "@tanstack/react-db"
+import { useSession } from "@/src/infrastructure/auth/client"
+import { useProjectContext } from "@/src/application/context/ProjectContext"
 import { colors } from "@/src/presentation/shared/colors"
+import type { Message } from "@buildinlime/domain-types"
+
+function formatTime(date: Date | string): string {
+  const d = typeof date === "string" ? new Date(date) : date
+  return d.toLocaleTimeString([], { hour: "2-digit", minute: "2-digit" })
+}
+
+function MentionItem({ message }: { message: Message }) {
+  return (
+    <View style={styles.mentionItem}>
+      <View style={styles.mentionDot} />
+      <View style={styles.mentionContent}>
+        <View style={styles.mentionHeader}>
+          <Text style={styles.channelLabel} numberOfLines={1}>
+            Channel message
+          </Text>
+          <Text style={styles.timestamp}>{formatTime(message.created_at)}</Text>
+        </View>
+        <Text style={styles.messageText} numberOfLines={3}>
+          {message.text}
+        </Text>
+      </View>
+    </View>
+  )
+}
 
 export default function InboxScreen() {
+  const { data: session } = useSession()
+  const { projectId, collections } = useProjectContext()
+  const currentUserId = session?.user?.id
+
+  const { data: allMessages } = useCollection(
+    collections?.messagesCollection ?? ({} as any),
+    {
+      select: (items) => {
+        if (!currentUserId) return []
+        return ([...items.values()] as Message[])
+          .filter(
+            (m) =>
+              Array.isArray(m.mention_ids) &&
+              m.mention_ids.includes(currentUserId)
+          )
+          .sort(
+            (a, b) =>
+              new Date(b.created_at).getTime() - new Date(a.created_at).getTime()
+          )
+      },
+    }
+  )
+
+  const isLoading = allMessages === undefined && !!projectId
+  const mentions = allMessages ?? []
+
   return (
     <View style={styles.container}>
       <ScreenHeader title="Inbox" subtitle="Your @mentions" />
-      <View style={styles.body}>
-        <Text style={styles.hint}>Coming in Phase 8.</Text>
-      </View>
+
+      {!projectId ? (
+        <View style={styles.centered}>
+          <Text style={styles.emptyText}>Select a project first.</Text>
+        </View>
+      ) : isLoading ? (
+        <View style={styles.centered}>
+          <ActivityIndicator size="large" color={colors.primary} />
+        </View>
+      ) : mentions.length === 0 ? (
+        <View style={styles.centered}>
+          <Text style={styles.emptyText}>No mentions yet.</Text>
+        </View>
+      ) : (
+        <FlatList
+          data={mentions}
+          keyExtractor={(item) => item.id}
+          contentContainerStyle={styles.listContent}
+          renderItem={({ item }) => <MentionItem message={item} />}
+          ItemSeparatorComponent={() => <View style={styles.separator} />}
+          showsVerticalScrollIndicator={false}
+        />
+      )}
     </View>
   )
 }
@@ -18,14 +92,66 @@ const styles = StyleSheet.create({
     flex: 1,
     backgroundColor: colors.background,
   },
-  body: {
+  centered: {
     flex: 1,
     alignItems: "center",
     justifyContent: "center",
+    paddingHorizontal: 24,
   },
-  hint: {
+  emptyText: {
     fontSize: 14,
     fontFamily: "InstrumentSans_400Regular",
     color: colors.mutedForeground,
+    textAlign: "center",
+  },
+  listContent: {
+    paddingHorizontal: 20,
+    paddingVertical: 16,
+  },
+  mentionItem: {
+    flexDirection: "row",
+    alignItems: "flex-start",
+    gap: 12,
+    paddingVertical: 12,
+  },
+  mentionDot: {
+    width: 8,
+    height: 8,
+    borderRadius: 4,
+    backgroundColor: colors.primary,
+    marginTop: 6,
+    flexShrink: 0,
+  },
+  mentionContent: {
+    flex: 1,
+    gap: 4,
+  },
+  mentionHeader: {
+    flexDirection: "row",
+    alignItems: "center",
+    justifyContent: "space-between",
+    gap: 8,
+  },
+  channelLabel: {
+    flex: 1,
+    fontSize: 12,
+    fontFamily: "InstrumentSans_600SemiBold",
+    color: colors.primary,
+  },
+  timestamp: {
+    fontSize: 11,
+    fontFamily: "InstrumentSans_400Regular",
+    color: colors.mutedForeground,
+  },
+  messageText: {
+    fontSize: 14,
+    fontFamily: "InstrumentSans_400Regular",
+    color: colors.foreground,
+    lineHeight: 20,
+  },
+  separator: {
+    height: 1,
+    backgroundColor: colors.border,
+    marginLeft: 20,
   },
 })

--- a/mobile-app/app/(tabs)/my-tasks.tsx
+++ b/mobile-app/app/(tabs)/my-tasks.tsx
@@ -1,14 +1,67 @@
-import { View, Text, StyleSheet } from "react-native"
+import { View, Text, FlatList, ActivityIndicator, StyleSheet } from "react-native"
 import { ScreenHeader } from "@/src/presentation/shared/components/ScreenHeader"
+import { useTasks } from "@/src/presentation/tasks/hooks/useTasks"
+import { useSession } from "@/src/infrastructure/auth/client"
+import { useProjectContext } from "@/src/application/context/ProjectContext"
 import { colors } from "@/src/presentation/shared/colors"
+import type { Task } from "@buildinlime/domain-types"
+
+function TaskItem({ task }: { task: Task }) {
+  return (
+    <View style={styles.taskItem}>
+      <View style={[styles.statusCircle, task.completed && styles.statusCircleCompleted]}>
+        {task.completed && <Text style={styles.checkmark}>✓</Text>}
+      </View>
+      <View style={styles.taskContent}>
+        <Text
+          style={[styles.taskName, task.completed && styles.taskNameCompleted]}
+          numberOfLines={2}
+        >
+          {task.name}
+        </Text>
+        {task.description ? (
+          <Text style={styles.taskDescription} numberOfLines={2}>
+            {task.description}
+          </Text>
+        ) : null}
+      </View>
+    </View>
+  )
+}
 
 export default function MyTasksScreen() {
+  const { data: session } = useSession()
+  const { projectId } = useProjectContext()
+  const currentUserId = session?.user?.id
+
+  const { tasks, isLoading } = useTasks(currentUserId)
+
   return (
     <View style={styles.container}>
       <ScreenHeader title="My Tasks" subtitle="Your assigned tasks" />
-      <View style={styles.body}>
-        <Text style={styles.hint}>Coming in Phase 7.</Text>
-      </View>
+
+      {!projectId ? (
+        <View style={styles.centered}>
+          <Text style={styles.emptyText}>Select a project to see your tasks.</Text>
+        </View>
+      ) : isLoading ? (
+        <View style={styles.centered}>
+          <ActivityIndicator size="large" color={colors.primary} />
+        </View>
+      ) : tasks.length === 0 ? (
+        <View style={styles.centered}>
+          <Text style={styles.emptyText}>No tasks assigned to you.</Text>
+        </View>
+      ) : (
+        <FlatList
+          data={tasks}
+          keyExtractor={(item) => item.id}
+          contentContainerStyle={styles.listContent}
+          renderItem={({ item }) => <TaskItem task={item} />}
+          ItemSeparatorComponent={() => <View style={styles.separator} />}
+          showsVerticalScrollIndicator={false}
+        />
+      )}
     </View>
   )
 }
@@ -18,14 +71,72 @@ const styles = StyleSheet.create({
     flex: 1,
     backgroundColor: colors.background,
   },
-  body: {
+  centered: {
     flex: 1,
     alignItems: "center",
     justifyContent: "center",
+    paddingHorizontal: 24,
   },
-  hint: {
+  emptyText: {
     fontSize: 14,
     fontFamily: "InstrumentSans_400Regular",
     color: colors.mutedForeground,
+    textAlign: "center",
+  },
+  listContent: {
+    paddingHorizontal: 20,
+    paddingVertical: 16,
+  },
+  taskItem: {
+    flexDirection: "row",
+    alignItems: "flex-start",
+    gap: 12,
+    paddingVertical: 12,
+  },
+  statusCircle: {
+    width: 22,
+    height: 22,
+    borderRadius: 11,
+    borderWidth: 2,
+    borderColor: colors.border,
+    alignItems: "center",
+    justifyContent: "center",
+    marginTop: 1,
+    flexShrink: 0,
+  },
+  statusCircleCompleted: {
+    backgroundColor: colors.primary,
+    borderColor: colors.primary,
+  },
+  checkmark: {
+    color: colors.primaryForeground,
+    fontSize: 12,
+    fontFamily: "InstrumentSans_700Bold",
+    lineHeight: 14,
+  },
+  taskContent: {
+    flex: 1,
+    gap: 3,
+  },
+  taskName: {
+    fontSize: 14,
+    fontFamily: "InstrumentSans_500Medium",
+    color: colors.foreground,
+    lineHeight: 20,
+  },
+  taskNameCompleted: {
+    color: colors.mutedForeground,
+    textDecorationLine: "line-through",
+  },
+  taskDescription: {
+    fontSize: 12,
+    fontFamily: "InstrumentSans_400Regular",
+    color: colors.mutedForeground,
+    lineHeight: 17,
+  },
+  separator: {
+    height: 1,
+    backgroundColor: colors.border,
+    marginLeft: 34,
   },
 })

--- a/mobile-app/app/(tabs)/project/[projectId]/[buildUnitId]/[channelId].tsx
+++ b/mobile-app/app/(tabs)/project/[projectId]/[buildUnitId]/[channelId].tsx
@@ -1,0 +1,168 @@
+import {
+  View,
+  Text,
+  TouchableOpacity,
+  KeyboardAvoidingView,
+  Platform,
+  StyleSheet,
+  ActivityIndicator,
+  ScrollView,
+  StatusBar,
+} from "react-native"
+import { useLocalSearchParams, useRouter } from "expo-router"
+import { useMessages } from "@/src/presentation/messages/hooks/useMessages"
+import { useProperties } from "@/src/presentation/properties/hooks/useProperties"
+import { MessageList } from "@/src/presentation/messages/components/MessageList"
+import { MessageInput } from "@/src/presentation/messages/components/MessageInput"
+import { PropertyPill } from "@/src/presentation/properties/components/PropertyPill"
+import { useSession } from "@/src/infrastructure/auth/client"
+import { useCollection } from "@tanstack/react-db"
+import { useProjectContext } from "@/src/application/context/ProjectContext"
+import { colors } from "@/src/presentation/shared/colors"
+import type { Channel } from "@buildinlime/domain-types"
+
+export default function ChannelScreen() {
+  const { projectId, buildUnitId, channelId } = useLocalSearchParams<{
+    projectId: string
+    buildUnitId: string
+    channelId: string
+  }>()
+  const router = useRouter()
+  const { data: session } = useSession()
+  const { collections } = useProjectContext()
+
+  // Look up channel name from channelsCollection
+  const { data: channelsData } = useCollection(collections!.channelsCollection, {
+    select: (items) => [...items.values()] as Channel[],
+  })
+  const channel = (channelsData ?? []).find((c) => c.id === channelId)
+
+  const { messages, isLoading } = useMessages(channelId)
+  const { properties } = useProperties(channelId)
+
+  // Only show channel-level properties
+  const channelProperties = properties.filter((p) => p.entity === "channel")
+
+  const currentUserId = session?.user?.id ?? ""
+
+  // Build a basic users map from message senders (best-effort without a users collection)
+  const usersMap: Record<string, string> = {}
+  for (const msg of messages) {
+    if (!usersMap[msg.createdby_id]) {
+      usersMap[msg.createdby_id] =
+        msg.createdby_id === currentUserId
+          ? session?.user?.name ?? "Me"
+          : `User ${msg.createdby_id.slice(0, 6)}`
+    }
+  }
+  if (currentUserId && !usersMap[currentUserId]) {
+    usersMap[currentUserId] = session?.user?.name ?? "Me"
+  }
+
+  return (
+    <KeyboardAvoidingView
+      style={styles.container}
+      behavior={Platform.OS === "ios" ? "padding" : "height"}
+      keyboardVerticalOffset={0}
+    >
+      {/* Inline header with back button */}
+      <View style={styles.header}>
+        <TouchableOpacity
+          style={styles.backButton}
+          onPress={() => router.back()}
+          hitSlop={{ top: 10, bottom: 10, left: 10, right: 10 }}
+          activeOpacity={0.6}
+        >
+          <Text style={styles.backArrow}>‹</Text>
+        </TouchableOpacity>
+        <Text style={styles.headerTitle} numberOfLines={1}>
+          {channel?.name ?? "Channel"}
+        </Text>
+      </View>
+
+      {/* Optional property pills row */}
+      {channelProperties.length > 0 && (
+        <ScrollView
+          horizontal
+          showsHorizontalScrollIndicator={false}
+          contentContainerStyle={styles.pillsContainer}
+          style={styles.pillsScroll}
+        >
+          {channelProperties.map((prop) => (
+            <PropertyPill key={prop.id} property={prop} />
+          ))}
+        </ScrollView>
+      )}
+
+      {/* Messages */}
+      {isLoading ? (
+        <View style={styles.centered}>
+          <ActivityIndicator size="large" color={colors.primary} />
+        </View>
+      ) : (
+        <MessageList
+          messages={messages}
+          currentUserId={currentUserId}
+          usersMap={usersMap}
+        />
+      )}
+
+      {/* Sticky message input */}
+      <MessageInput
+        channelId={channelId}
+        buildUnitId={buildUnitId}
+        projectId={projectId}
+      />
+    </KeyboardAvoidingView>
+  )
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    backgroundColor: colors.background,
+  },
+  header: {
+    flexDirection: "row",
+    alignItems: "center",
+    paddingTop: (StatusBar.currentHeight ?? 44) + 8,
+    paddingBottom: 16,
+    paddingHorizontal: 16,
+    backgroundColor: colors.background,
+    borderBottomWidth: 1,
+    borderBottomColor: colors.border,
+    gap: 8,
+  },
+  backButton: {
+    padding: 4,
+    marginRight: 4,
+  },
+  backArrow: {
+    fontSize: 32,
+    color: colors.primary,
+    fontFamily: "InstrumentSans_400Regular",
+    lineHeight: 32,
+  },
+  headerTitle: {
+    flex: 1,
+    fontSize: 18,
+    fontFamily: "InstrumentSans_600SemiBold",
+    color: colors.foreground,
+    lineHeight: 22,
+  },
+  pillsScroll: {
+    borderBottomWidth: 1,
+    borderBottomColor: colors.border,
+  },
+  pillsContainer: {
+    flexDirection: "row",
+    gap: 8,
+    paddingHorizontal: 16,
+    paddingVertical: 10,
+  },
+  centered: {
+    flex: 1,
+    alignItems: "center",
+    justifyContent: "center",
+  },
+})

--- a/mobile-app/app/(tabs)/project/[projectId]/[buildUnitId]/_layout.tsx
+++ b/mobile-app/app/(tabs)/project/[projectId]/[buildUnitId]/_layout.tsx
@@ -1,0 +1,5 @@
+import { Stack } from "expo-router"
+
+export default function BuildUnitLayout() {
+  return <Stack screenOptions={{ headerShown: false }} />
+}

--- a/mobile-app/app/(tabs)/project/[projectId]/[buildUnitId]/index.tsx
+++ b/mobile-app/app/(tabs)/project/[projectId]/[buildUnitId]/index.tsx
@@ -1,0 +1,166 @@
+import {
+  View,
+  FlatList,
+  Text,
+  TouchableOpacity,
+  ActivityIndicator,
+  ScrollView,
+  StyleSheet,
+  StatusBar,
+} from "react-native"
+import { useRouter, useLocalSearchParams } from "expo-router"
+import { useChannels } from "@/src/presentation/channels/hooks/useChannels"
+import { useProperties } from "@/src/presentation/properties/hooks/useProperties"
+import { useBuildUnits } from "@/src/presentation/build-units/hooks/useBuildUnits"
+import { ChannelCard } from "@/src/presentation/channels/components/ChannelCard"
+import { PropertyPill } from "@/src/presentation/properties/components/PropertyPill"
+import { colors } from "@/src/presentation/shared/colors"
+
+export default function ChannelsScreen() {
+  const { projectId, buildUnitId } = useLocalSearchParams<{
+    projectId: string
+    buildUnitId: string
+  }>()
+  const router = useRouter()
+
+  const { buildUnits } = useBuildUnits()
+  const buildUnit = buildUnits.find((b) => b.id === buildUnitId)
+
+  const { channels, isLoading } = useChannels(buildUnitId)
+  const { properties } = useProperties(buildUnitId)
+
+  // Only show properties tagged to this build unit entity
+  const buildUnitProperties = properties.filter((p) => p.entity === "buildUnit")
+
+  return (
+    <View style={styles.container}>
+      {/* Inline header with back button */}
+      <View style={styles.header}>
+        <TouchableOpacity
+          style={styles.backButton}
+          onPress={() => router.back()}
+          hitSlop={{ top: 10, bottom: 10, left: 10, right: 10 }}
+          activeOpacity={0.6}
+        >
+          <Text style={styles.backArrow}>‹</Text>
+        </TouchableOpacity>
+        <Text style={styles.headerTitle} numberOfLines={1}>
+          {buildUnit?.name ?? "Build Unit"}
+        </Text>
+      </View>
+
+      {/* Property pills row */}
+      {buildUnitProperties.length > 0 && (
+        <ScrollView
+          horizontal
+          showsHorizontalScrollIndicator={false}
+          contentContainerStyle={styles.pillsContainer}
+          style={styles.pillsScroll}
+        >
+          {buildUnitProperties.map((prop) => (
+            <PropertyPill key={prop.id} property={prop} />
+          ))}
+        </ScrollView>
+      )}
+
+      {/* Channels grid */}
+      {isLoading ? (
+        <View style={styles.centered}>
+          <ActivityIndicator size="large" color={colors.primary} />
+        </View>
+      ) : channels.length === 0 ? (
+        <View style={styles.centered}>
+          <Text style={styles.emptyText}>No channels in this build unit.</Text>
+        </View>
+      ) : (
+        <FlatList
+          data={channels}
+          keyExtractor={(item) => item.id}
+          numColumns={2}
+          contentContainerStyle={styles.listContent}
+          columnWrapperStyle={styles.columnWrapper}
+          renderItem={({ item }) => (
+            <View style={styles.cardWrapper}>
+              <ChannelCard
+                channel={item}
+                onPress={() =>
+                  router.push(
+                    `/(tabs)/project/${projectId}/${buildUnitId}/${item.id}` as any
+                  )
+                }
+              />
+            </View>
+          )}
+          showsVerticalScrollIndicator={false}
+        />
+      )}
+    </View>
+  )
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    backgroundColor: colors.background,
+  },
+  header: {
+    flexDirection: "row",
+    alignItems: "center",
+    paddingTop: (StatusBar.currentHeight ?? 44) + 8,
+    paddingBottom: 16,
+    paddingHorizontal: 16,
+    backgroundColor: colors.background,
+    borderBottomWidth: 1,
+    borderBottomColor: colors.border,
+    gap: 8,
+  },
+  backButton: {
+    padding: 4,
+    marginRight: 4,
+  },
+  backArrow: {
+    fontSize: 32,
+    color: colors.primary,
+    fontFamily: "InstrumentSans_400Regular",
+    lineHeight: 32,
+  },
+  headerTitle: {
+    flex: 1,
+    fontSize: 18,
+    fontFamily: "InstrumentSans_600SemiBold",
+    color: colors.foreground,
+    lineHeight: 22,
+  },
+  pillsScroll: {
+    borderBottomWidth: 1,
+    borderBottomColor: colors.border,
+  },
+  pillsContainer: {
+    flexDirection: "row",
+    gap: 8,
+    paddingHorizontal: 16,
+    paddingVertical: 10,
+  },
+  centered: {
+    flex: 1,
+    alignItems: "center",
+    justifyContent: "center",
+    paddingHorizontal: 24,
+  },
+  emptyText: {
+    fontSize: 14,
+    fontFamily: "InstrumentSans_400Regular",
+    color: colors.mutedForeground,
+    textAlign: "center",
+  },
+  listContent: {
+    padding: 16,
+    gap: 12,
+  },
+  columnWrapper: {
+    gap: 12,
+  },
+  cardWrapper: {
+    flex: 1,
+  },
+})

--- a/mobile-app/app/(tabs)/project/[projectId]/index.tsx
+++ b/mobile-app/app/(tabs)/project/[projectId]/index.tsx
@@ -1,15 +1,46 @@
-import { View, Text, StyleSheet } from "react-native"
-import { useLocalSearchParams } from "expo-router"
+import { View, FlatList, ActivityIndicator, Text, StyleSheet } from "react-native"
+import { useRouter, useLocalSearchParams } from "expo-router"
+import { ScreenHeader } from "@/src/presentation/shared/components/ScreenHeader"
+import { BuildUnitCard } from "@/src/presentation/build-units/components/BuildUnitCard"
+import { useBuildUnits } from "@/src/presentation/build-units/hooks/useBuildUnits"
 import { colors } from "@/src/presentation/shared/colors"
 
 export default function BuildUnitsScreen() {
   const { projectId } = useLocalSearchParams<{ projectId: string }>()
+  const router = useRouter()
+  const { buildUnits, isLoading } = useBuildUnits()
 
   return (
     <View style={styles.container}>
-      <Text style={styles.title}>Build Units</Text>
-      <Text style={styles.subtitle}>Project: {projectId}</Text>
-      <Text style={styles.hint}>Build units grid coming in Phase 4.</Text>
+      <ScreenHeader title="Build Units" />
+      {isLoading ? (
+        <View style={styles.centered}>
+          <ActivityIndicator size="large" color={colors.primary} />
+        </View>
+      ) : buildUnits.length === 0 ? (
+        <View style={styles.centered}>
+          <Text style={styles.emptyText}>No build units in this project.</Text>
+        </View>
+      ) : (
+        <FlatList
+          data={buildUnits}
+          keyExtractor={(item) => item.id}
+          numColumns={2}
+          contentContainerStyle={styles.listContent}
+          columnWrapperStyle={styles.columnWrapper}
+          renderItem={({ item }) => (
+            <View style={styles.cardWrapper}>
+              <BuildUnitCard
+                buildUnit={item}
+                onPress={() =>
+                  router.push(`/(tabs)/project/${projectId}/${item.id}` as any)
+                }
+              />
+            </View>
+          )}
+          showsVerticalScrollIndicator={false}
+        />
+      )}
     </View>
   )
 }
@@ -18,24 +49,27 @@ const styles = StyleSheet.create({
   container: {
     flex: 1,
     backgroundColor: colors.background,
-    paddingHorizontal: 20,
-    paddingTop: 60,
   },
-  title: {
-    fontSize: 26,
-    fontFamily: "InstrumentSans_700Bold",
-    color: colors.foreground,
-    marginBottom: 4,
+  centered: {
+    flex: 1,
+    alignItems: "center",
+    justifyContent: "center",
+    paddingHorizontal: 24,
   },
-  subtitle: {
+  emptyText: {
     fontSize: 14,
-    fontFamily: "InstrumentSans_500Medium",
-    color: colors.primary,
-    marginBottom: 8,
-  },
-  hint: {
-    fontSize: 13,
     fontFamily: "InstrumentSans_400Regular",
     color: colors.mutedForeground,
+    textAlign: "center",
+  },
+  listContent: {
+    padding: 16,
+    gap: 12,
+  },
+  columnWrapper: {
+    gap: 12,
+  },
+  cardWrapper: {
+    flex: 1,
   },
 })

--- a/mobile-app/app/(tabs)/projects/index.tsx
+++ b/mobile-app/app/(tabs)/projects/index.tsx
@@ -1,14 +1,53 @@
-import { Text, View } from "react-native"
+import { FlatList, Text, View, ActivityIndicator } from "react-native"
+import { useRouter } from "expo-router"
+import { useProjects } from "@/src/presentation/projects/hooks/useProjects"
+import { ProjectCard } from "@/src/presentation/projects/components/ProjectCard"
+import { useProjectContext } from "@/src/application/context/ProjectContext"
+import { colors } from "@/src/presentation/shared/colors"
 
 export default function ProjectsScreen() {
+  const router = useRouter()
+  const { projects, isLoading } = useProjects()
+  const { selectProject } = useProjectContext()
+
+  const handleSelectProject = async (projectId: string) => {
+    await selectProject(projectId)
+    router.push(`/project/${projectId}`)
+  }
+
+  if (isLoading) {
+    return (
+      <View style={{ flex: 1, alignItems: "center", justifyContent: "center", backgroundColor: colors.background }}>
+        <ActivityIndicator color={colors.primary} />
+      </View>
+    )
+  }
+
   return (
-    <View className="flex-1 bg-background px-6 pt-16">
-      <Text className="text-2xl font-sans-semibold text-foreground mb-1">
+    <View style={{ flex: 1, backgroundColor: colors.background, paddingHorizontal: 24, paddingTop: 64 }}>
+      <Text style={{ fontSize: 24, fontFamily: "InstrumentSans_600SemiBold", color: colors.foreground, marginBottom: 4 }}>
         Projects
       </Text>
-      <Text className="text-sm text-muted-foreground">
-        Your projects will appear here.
+      <Text style={{ fontSize: 14, color: colors.mutedForeground, marginBottom: 24 }}>
+        Select a project to get started
       </Text>
+
+      {projects && projects.length === 0 ? (
+        <Text style={{ fontSize: 14, color: colors.mutedForeground }}>No projects found.</Text>
+      ) : (
+        <FlatList
+          data={projects}
+          keyExtractor={(item) => item.id}
+          numColumns={2}
+          columnWrapperStyle={{ gap: 12 }}
+          contentContainerStyle={{ gap: 12, paddingBottom: 32 }}
+          renderItem={({ item }) => (
+            <View style={{ flex: 1 }}>
+              <ProjectCard project={item} onPress={() => handleSelectProject(item.id)} />
+            </View>
+          )}
+        />
+      )}
     </View>
   )
 }

--- a/mobile-app/src/presentation/build-units/components/BuildUnitCard.tsx
+++ b/mobile-app/src/presentation/build-units/components/BuildUnitCard.tsx
@@ -1,0 +1,64 @@
+import { TouchableOpacity, View, Text, StyleSheet } from "react-native"
+import { colors } from "@/src/presentation/shared/colors"
+import { HealthPill, PriorityTagPill } from "@/src/presentation/properties/components/PropertyPill"
+import type { BuildUnit } from "@buildinlime/domain-types"
+
+interface BuildUnitCardProps {
+  buildUnit: BuildUnit
+  onPress: () => void
+}
+
+export function BuildUnitCard({ buildUnit, onPress }: BuildUnitCardProps) {
+  return (
+    <TouchableOpacity style={styles.card} onPress={onPress} activeOpacity={0.75}>
+      <Text style={styles.name} numberOfLines={2}>
+        {buildUnit.name}
+      </Text>
+      {buildUnit.description ? (
+        <Text style={styles.description} numberOfLines={1}>
+          {buildUnit.description}
+        </Text>
+      ) : null}
+      {(buildUnit.health || buildUnit.priority) ? (
+        <View style={styles.pillRow}>
+          {buildUnit.health ? <HealthPill health={buildUnit.health} /> : null}
+          {buildUnit.priority ? <PriorityTagPill priority={buildUnit.priority} /> : null}
+        </View>
+      ) : null}
+    </TouchableOpacity>
+  )
+}
+
+const styles = StyleSheet.create({
+  card: {
+    backgroundColor: colors.card,
+    borderRadius: 12,
+    borderWidth: 1,
+    borderColor: colors.border,
+    padding: 14,
+    gap: 6,
+    shadowColor: "#000",
+    shadowOffset: { width: 0, height: 1 },
+    shadowOpacity: 0.06,
+    shadowRadius: 4,
+    elevation: 2,
+  },
+  name: {
+    fontSize: 14,
+    fontFamily: "InstrumentSans_600SemiBold",
+    color: colors.foreground,
+    lineHeight: 20,
+  },
+  description: {
+    fontSize: 12,
+    fontFamily: "InstrumentSans_400Regular",
+    color: colors.mutedForeground,
+    lineHeight: 17,
+  },
+  pillRow: {
+    flexDirection: "row",
+    gap: 6,
+    flexWrap: "wrap",
+    marginTop: 2,
+  },
+})

--- a/mobile-app/src/presentation/build-units/hooks/useBuildUnits.ts
+++ b/mobile-app/src/presentation/build-units/hooks/useBuildUnits.ts
@@ -1,0 +1,11 @@
+import { useCollection } from "@tanstack/react-db"
+import { useProjectContext } from "@/src/application/context/ProjectContext"
+import type { BuildUnit } from "@buildinlime/domain-types"
+
+export function useBuildUnits() {
+  const { collections } = useProjectContext()
+  const { data, isLoading } = useCollection(collections!.buildUnitsCollection, {
+    select: (items) => [...items.values()] as BuildUnit[],
+  })
+  return { buildUnits: data ?? [], isLoading }
+}

--- a/mobile-app/src/presentation/channels/components/ChannelCard.tsx
+++ b/mobile-app/src/presentation/channels/components/ChannelCard.tsx
@@ -1,0 +1,68 @@
+import { TouchableOpacity, View, Text, StyleSheet } from "react-native"
+import { colors } from "@/src/presentation/shared/colors"
+import type { Channel } from "@buildinlime/domain-types"
+
+const CHANNEL_EMOJI: Record<string, string> = {
+  Finance: "💰",
+  Requirements: "📋",
+  Design: "📐",
+  Materials: "🚛",
+  Tools: "🔨",
+  Execution: "✅",
+  Experimentation: "🔬",
+}
+
+interface ChannelCardProps {
+  channel: Channel
+  onPress: () => void
+}
+
+export function ChannelCard({ channel, onPress }: ChannelCardProps) {
+  const emoji = CHANNEL_EMOJI[channel.name] ?? "📁"
+
+  return (
+    <TouchableOpacity style={styles.card} onPress={onPress} activeOpacity={0.75}>
+      <View style={styles.emojiContainer}>
+        <Text style={styles.emoji}>{emoji}</Text>
+      </View>
+      <Text style={styles.name} numberOfLines={2}>
+        {channel.name}
+      </Text>
+    </TouchableOpacity>
+  )
+}
+
+const styles = StyleSheet.create({
+  card: {
+    backgroundColor: colors.card,
+    borderRadius: 12,
+    borderWidth: 1,
+    borderColor: colors.border,
+    padding: 14,
+    alignItems: "center",
+    gap: 8,
+    shadowColor: "#000",
+    shadowOffset: { width: 0, height: 1 },
+    shadowOpacity: 0.06,
+    shadowRadius: 4,
+    elevation: 2,
+  },
+  emojiContainer: {
+    width: 44,
+    height: 44,
+    borderRadius: 10,
+    backgroundColor: colors.muted,
+    alignItems: "center",
+    justifyContent: "center",
+  },
+  emoji: {
+    fontSize: 22,
+  },
+  name: {
+    fontSize: 13,
+    fontFamily: "InstrumentSans_600SemiBold",
+    color: colors.foreground,
+    textAlign: "center",
+    lineHeight: 18,
+  },
+})

--- a/mobile-app/src/presentation/channels/hooks/useChannels.ts
+++ b/mobile-app/src/presentation/channels/hooks/useChannels.ts
@@ -1,0 +1,12 @@
+import { useCollection } from "@tanstack/react-db"
+import { useProjectContext } from "@/src/application/context/ProjectContext"
+import type { Channel } from "@buildinlime/domain-types"
+
+export function useChannels(buildUnitId: string) {
+  const { collections } = useProjectContext()
+  const { data, isLoading } = useCollection(collections!.channelsCollection, {
+    select: (items) =>
+      ([...items.values()] as Channel[]).filter((c) => c.buildunit_id === buildUnitId),
+  })
+  return { channels: data ?? [], isLoading }
+}

--- a/mobile-app/src/presentation/messages/components/MessageBubble.tsx
+++ b/mobile-app/src/presentation/messages/components/MessageBubble.tsx
@@ -1,0 +1,124 @@
+import { View, Text, StyleSheet } from "react-native"
+import { colors } from "@/src/presentation/shared/colors"
+import type { Message } from "@buildinlime/domain-types"
+
+interface MessageBubbleProps {
+  message: Message
+  senderName: string
+  isOwn: boolean
+}
+
+function formatTime(date: Date | string): string {
+  const d = typeof date === "string" ? new Date(date) : date
+  const hours = d.getHours().toString().padStart(2, "0")
+  const minutes = d.getMinutes().toString().padStart(2, "0")
+  return `${hours}:${minutes}`
+}
+
+export function MessageBubble({ message, senderName, isOwn }: MessageBubbleProps) {
+  const initial = senderName.charAt(0).toUpperCase()
+
+  return (
+    <View style={[styles.container, isOwn ? styles.containerOwn : styles.containerOther]}>
+      {!isOwn && (
+        <View style={styles.avatar}>
+          <Text style={styles.avatarText}>{initial}</Text>
+        </View>
+      )}
+      <View style={[styles.bubble, isOwn ? styles.bubbleOwn : styles.bubbleOther]}>
+        {!isOwn && (
+          <Text style={styles.senderName}>{senderName}</Text>
+        )}
+        <Text style={[styles.messageText, isOwn ? styles.messageTextOwn : styles.messageTextOther]}>
+          {message.text}
+        </Text>
+        <Text style={[styles.timestamp, isOwn ? styles.timestampOwn : styles.timestampOther]}>
+          {formatTime(message.created_at)}
+        </Text>
+      </View>
+      {isOwn && (
+        <View style={[styles.avatar, styles.avatarOwn]}>
+          <Text style={styles.avatarText}>{initial}</Text>
+        </View>
+      )}
+    </View>
+  )
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flexDirection: "row",
+    alignItems: "flex-end",
+    marginVertical: 4,
+    paddingHorizontal: 16,
+    gap: 8,
+  },
+  containerOwn: {
+    justifyContent: "flex-end",
+  },
+  containerOther: {
+    justifyContent: "flex-start",
+  },
+  avatar: {
+    width: 32,
+    height: 32,
+    borderRadius: 16,
+    backgroundColor: colors.primary,
+    alignItems: "center",
+    justifyContent: "center",
+    flexShrink: 0,
+  },
+  avatarOwn: {
+    backgroundColor: colors.secondary ?? colors.primary,
+  },
+  avatarText: {
+    color: colors.primaryForeground,
+    fontSize: 13,
+    fontFamily: "InstrumentSans_700Bold",
+  },
+  bubble: {
+    maxWidth: "72%",
+    borderRadius: 14,
+    paddingHorizontal: 12,
+    paddingVertical: 8,
+    gap: 2,
+  },
+  bubbleOwn: {
+    backgroundColor: colors.primary,
+    borderBottomRightRadius: 4,
+  },
+  bubbleOther: {
+    backgroundColor: colors.muted,
+    borderBottomLeftRadius: 4,
+  },
+  senderName: {
+    fontSize: 11,
+    fontFamily: "InstrumentSans_600SemiBold",
+    color: colors.primary,
+    marginBottom: 2,
+  },
+  messageText: {
+    fontSize: 14,
+    fontFamily: "InstrumentSans_400Regular",
+    lineHeight: 20,
+  },
+  messageTextOwn: {
+    color: colors.primaryForeground,
+  },
+  messageTextOther: {
+    color: colors.foreground,
+  },
+  timestamp: {
+    fontSize: 10,
+    fontFamily: "InstrumentSans_400Regular",
+    marginTop: 2,
+  },
+  timestampOwn: {
+    color: colors.primaryForeground + "99",
+    textAlign: "right",
+  },
+  timestampOther: {
+    color: colors.mutedForeground,
+    textAlign: "left",
+  },
+})

--- a/mobile-app/src/presentation/messages/components/MessageInput.tsx
+++ b/mobile-app/src/presentation/messages/components/MessageInput.tsx
@@ -1,0 +1,106 @@
+import { View, TextInput, TouchableOpacity, StyleSheet, Text } from "react-native"
+import { useState } from "react"
+import { useSession } from "@/src/infrastructure/auth/client"
+import { colors } from "@/src/presentation/shared/colors"
+import { useProjectContext } from "@/src/application/context/ProjectContext"
+
+interface MessageInputProps {
+  channelId: string
+  buildUnitId: string
+  projectId: string
+}
+
+export function MessageInput({ channelId, buildUnitId, projectId }: MessageInputProps) {
+  const [text, setText] = useState("")
+  const { data: session } = useSession()
+  const { collections } = useProjectContext()
+
+  async function handleSend() {
+    const trimmed = text.trim()
+    if (!trimmed || !session?.user?.id || !collections) return
+
+    const id = `msg_${Date.now()}_${Math.random().toString(36).slice(2, 9)}`
+
+    try {
+      await collections.messagesCollection.insert({
+        id,
+        text: trimmed,
+        channel_id: channelId,
+        buildunit_id: buildUnitId,
+        project_id: projectId,
+        createdby_id: session.user.id,
+        mention_ids: [],
+        resource_ids: [],
+        parent_id: null,
+      })
+      setText("")
+    } catch (err) {
+      console.error("Failed to send message:", err)
+    }
+  }
+
+  return (
+    <View style={styles.container}>
+      <TextInput
+        style={styles.input}
+        value={text}
+        onChangeText={setText}
+        placeholder="Type a message…"
+        placeholderTextColor={colors.mutedForeground}
+        multiline
+        returnKeyType="default"
+        blurOnSubmit={false}
+      />
+      <TouchableOpacity
+        style={[styles.sendButton, !text.trim() && styles.sendButtonDisabled]}
+        onPress={handleSend}
+        disabled={!text.trim()}
+        activeOpacity={0.7}
+      >
+        <Text style={styles.sendButtonText}>Send</Text>
+      </TouchableOpacity>
+    </View>
+  )
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flexDirection: "row",
+    alignItems: "flex-end",
+    paddingHorizontal: 12,
+    paddingVertical: 10,
+    borderTopWidth: 1,
+    borderTopColor: colors.border,
+    backgroundColor: colors.background,
+    gap: 8,
+  },
+  input: {
+    flex: 1,
+    minHeight: 40,
+    maxHeight: 120,
+    backgroundColor: colors.muted,
+    borderRadius: 20,
+    paddingHorizontal: 16,
+    paddingVertical: 10,
+    fontSize: 14,
+    fontFamily: "InstrumentSans_400Regular",
+    color: colors.foreground,
+    lineHeight: 20,
+  },
+  sendButton: {
+    height: 40,
+    paddingHorizontal: 16,
+    borderRadius: 20,
+    backgroundColor: colors.primary,
+    alignItems: "center",
+    justifyContent: "center",
+  },
+  sendButtonDisabled: {
+    opacity: 0.4,
+  },
+  sendButtonText: {
+    color: colors.primaryForeground,
+    fontSize: 14,
+    fontFamily: "InstrumentSans_600SemiBold",
+  },
+})

--- a/mobile-app/src/presentation/messages/components/MessageList.tsx
+++ b/mobile-app/src/presentation/messages/components/MessageList.tsx
@@ -1,0 +1,42 @@
+import { FlatList, View, StyleSheet } from "react-native"
+import { MessageBubble } from "./MessageBubble"
+import type { Message } from "@buildinlime/domain-types"
+
+interface MessageListProps {
+  messages: Message[]
+  currentUserId: string
+  usersMap: Record<string, string>
+}
+
+export function MessageList({ messages, currentUserId, usersMap }: MessageListProps) {
+  // Reverse for inverted FlatList (newest at bottom)
+  const reversed = [...messages].reverse()
+
+  return (
+    <FlatList
+      data={reversed}
+      keyExtractor={(item) => item.id}
+      renderItem={({ item }) => (
+        <MessageBubble
+          message={item}
+          senderName={usersMap[item.createdby_id] ?? "Unknown"}
+          isOwn={item.createdby_id === currentUserId}
+        />
+      )}
+      inverted
+      style={styles.list}
+      contentContainerStyle={styles.content}
+      showsVerticalScrollIndicator={false}
+      keyboardShouldPersistTaps="handled"
+    />
+  )
+}
+
+const styles = StyleSheet.create({
+  list: {
+    flex: 1,
+  },
+  content: {
+    paddingVertical: 12,
+  },
+})

--- a/mobile-app/src/presentation/messages/hooks/useMessages.ts
+++ b/mobile-app/src/presentation/messages/hooks/useMessages.ts
@@ -1,0 +1,14 @@
+import { useCollection } from "@tanstack/react-db"
+import { useProjectContext } from "@/src/application/context/ProjectContext"
+import type { Message } from "@buildinlime/domain-types"
+
+export function useMessages(channelId: string) {
+  const { collections } = useProjectContext()
+  const { data, isLoading } = useCollection(collections!.messagesCollection, {
+    select: (items) =>
+      ([...items.values()] as Message[])
+        .filter((m) => m.channel_id === channelId)
+        .sort((a, b) => new Date(a.created_at).getTime() - new Date(b.created_at).getTime()),
+  })
+  return { messages: data ?? [], isLoading }
+}

--- a/mobile-app/src/presentation/projects/components/ProjectCard.tsx
+++ b/mobile-app/src/presentation/projects/components/ProjectCard.tsx
@@ -1,6 +1,6 @@
 import { TouchableOpacity, View, Text, StyleSheet } from "react-native"
 import { colors } from "@/src/presentation/shared/colors"
-import type { Project } from "../hooks/useProjects"
+import type { Project } from "@buildinlime/domain-types"
 
 interface ProjectCardProps {
   project: Project

--- a/mobile-app/src/presentation/projects/hooks/useProjects.ts
+++ b/mobile-app/src/presentation/projects/hooks/useProjects.ts
@@ -1,24 +1,10 @@
-import { useLiveQuery } from "@tanstack/react-db"
+import { useCollection } from "@tanstack/react-db"
 import { projectsCollection } from "@/src/application/collections/projects"
-
-export interface Project {
-  id: string
-  name: string
-  description?: string | null
-  owner_id: string
-  created_at?: string | Date
-  updated_at?: string | Date
-}
+import type { Project } from "@buildinlime/domain-types"
 
 export function useProjects() {
-  const { data } = useLiveQuery(
-    (q) => q.from({ projectsCollection }),
-    []
-  )
-
-  // data is undefined while the Electric sync hasn't completed yet
-  return {
-    projects: data as Project[] | undefined,
-    isLoading: data === undefined,
-  }
+  const { data, isLoading } = useCollection(projectsCollection, {
+    select: (items) => [...items.values()] as Project[],
+  })
+  return { projects: data ?? [], isLoading }
 }

--- a/mobile-app/src/presentation/properties/components/PropertyPill.tsx
+++ b/mobile-app/src/presentation/properties/components/PropertyPill.tsx
@@ -1,0 +1,135 @@
+import { View, Text, StyleSheet } from "react-native"
+import { colors } from "@/src/presentation/shared/colors"
+import type { Property } from "@buildinlime/domain-types"
+
+// Status value colors
+const STATUS_COLORS: Record<string, string> = {
+  critical: "#ef4444",
+  high: "#f97316",
+  medium: "#eab308",
+  low: "#22c55e",
+}
+
+// Priority value colors
+const PRIORITY_COLORS: Record<string, string> = {
+  notStarted: colors.mutedForeground,
+  inProgress: "#3b82f6",
+  onTrack: "#22c55e",
+  atRisk: "#f97316",
+  backLog: colors.mutedForeground,
+  overBudget: "#ef4444",
+  onHold: colors.mutedForeground,
+  completed: "#22c55e",
+  cancelled: colors.mutedForeground,
+}
+
+// Health value colors
+const HEALTH_COLORS: Record<string, string> = {
+  "On track": "#22c55e",
+  "At risk": "#f97316",
+  "Off track": "#ef4444",
+}
+
+// Human-readable labels for priority values
+const PRIORITY_LABELS: Record<string, string> = {
+  notStarted: "Not Started",
+  inProgress: "In Progress",
+  onTrack: "On Track",
+  atRisk: "At Risk",
+  backLog: "Backlog",
+  overBudget: "Over Budget",
+  onHold: "On Hold",
+  completed: "Completed",
+  cancelled: "Cancelled",
+}
+
+interface PropertyPillProps {
+  property: Property
+}
+
+export function PropertyPill({ property }: PropertyPillProps) {
+  if (property.type === "status" && property.status_value) {
+    const bgColor = STATUS_COLORS[property.status_value] ?? colors.mutedForeground
+    return (
+      <View style={[styles.pill, { backgroundColor: bgColor + "22", borderColor: bgColor }]}>
+        <View style={[styles.dot, { backgroundColor: bgColor }]} />
+        <Text style={[styles.pillText, { color: bgColor }]}>
+          {property.status_value.charAt(0).toUpperCase() + property.status_value.slice(1)}
+        </Text>
+      </View>
+    )
+  }
+
+  if (property.type === "priority" && property.priority_value) {
+    const bgColor = PRIORITY_COLORS[property.priority_value] ?? colors.mutedForeground
+    return (
+      <View style={[styles.pill, { backgroundColor: bgColor + "22", borderColor: bgColor }]}>
+        <View style={[styles.dot, { backgroundColor: bgColor }]} />
+        <Text style={[styles.pillText, { color: bgColor }]}>
+          {PRIORITY_LABELS[property.priority_value] ?? property.priority_value}
+        </Text>
+      </View>
+    )
+  }
+
+  return null
+}
+
+// Simpler inline pill for build unit health/priority fields
+interface HealthPillProps {
+  health: "On track" | "At risk" | "Off track" | null | undefined
+}
+
+export function HealthPill({ health }: HealthPillProps) {
+  if (!health) return null
+  const bgColor = HEALTH_COLORS[health] ?? colors.mutedForeground
+  return (
+    <View style={[styles.pill, { backgroundColor: bgColor + "22", borderColor: bgColor }]}>
+      <View style={[styles.dot, { backgroundColor: bgColor }]} />
+      <Text style={[styles.pillText, { color: bgColor }]}>{health}</Text>
+    </View>
+  )
+}
+
+interface PriorityTagPillProps {
+  priority: "High" | "Mid" | "Low" | null | undefined
+}
+
+export function PriorityTagPill({ priority }: PriorityTagPillProps) {
+  if (!priority) return null
+  const colorMap: Record<string, string> = {
+    High: "#ef4444",
+    Mid: "#f97316",
+    Low: "#22c55e",
+  }
+  const bgColor = colorMap[priority] ?? colors.mutedForeground
+  return (
+    <View style={[styles.pill, { backgroundColor: bgColor + "22", borderColor: bgColor }]}>
+      <View style={[styles.dot, { backgroundColor: bgColor }]} />
+      <Text style={[styles.pillText, { color: bgColor }]}>{priority}</Text>
+    </View>
+  )
+}
+
+const styles = StyleSheet.create({
+  pill: {
+    flexDirection: "row",
+    alignItems: "center",
+    paddingHorizontal: 8,
+    paddingVertical: 3,
+    borderRadius: 20,
+    borderWidth: 1,
+    gap: 4,
+    alignSelf: "flex-start",
+  },
+  dot: {
+    width: 6,
+    height: 6,
+    borderRadius: 3,
+  },
+  pillText: {
+    fontSize: 11,
+    fontFamily: "InstrumentSans_500Medium",
+    lineHeight: 16,
+  },
+})

--- a/mobile-app/src/presentation/properties/hooks/useProperties.ts
+++ b/mobile-app/src/presentation/properties/hooks/useProperties.ts
@@ -1,0 +1,12 @@
+import { useCollection } from "@tanstack/react-db"
+import { useProjectContext } from "@/src/application/context/ProjectContext"
+import type { Property } from "@buildinlime/domain-types"
+
+export function useProperties(entityId: string) {
+  const { collections } = useProjectContext()
+  const { data } = useCollection(collections!.propertiesCollection, {
+    select: (items) =>
+      ([...items.values()] as Property[]).filter((p) => p.entity_id === entityId),
+  })
+  return { properties: data ?? [] }
+}

--- a/mobile-app/src/presentation/tasks/hooks/useTasks.ts
+++ b/mobile-app/src/presentation/tasks/hooks/useTasks.ts
@@ -1,0 +1,14 @@
+import { useCollection } from "@tanstack/react-db"
+import { useProjectContext } from "@/src/application/context/ProjectContext"
+import type { Task } from "@buildinlime/domain-types"
+
+export function useTasks(assigneeId?: string) {
+  const { collections } = useProjectContext()
+  const { data, isLoading } = useCollection(collections!.tasksCollection, {
+    select: (items) => {
+      const all = [...items.values()] as Task[]
+      return assigneeId ? all.filter((t) => t.assignee_id === assigneeId) : all
+    },
+  })
+  return { tasks: data ?? [], isLoading }
+}


### PR DESCRIPTION
Closes #16

## Summary
- Implement mobile app phases 4–8: build units, channels, messaging, tasks, and inbox screens
- Extract shared domain types into `@buildinlime/domain-types` workspace package for use across mobile and web

## What's included
- Full navigation flow from project → build unit → channel → messages
- Real-time sync via TanStack DB collections backed by Electric
- Auth integration with the web app (Better Auth + cookie-based sessions)
- Inbox screen showing @mentions; My Tasks screen showing assigned tasks

## Test plan
- [ ] Run the web app dev server (`pnpm dev` in `web-app/code`)
- [ ] Start the mobile app on Android emulator (`pnpm start` in `mobile-app`)
- [ ] Sign in and verify the project list loads via Electric sync
- [ ] Navigate into a build unit → channel and confirm messages appear
- [ ] Send a message and verify it appears in real time
- [ ] Check Inbox and My Tasks screens reflect correct data

🤖 Generated with [Claude Code](https://claude.com/claude-code)