### PR TITLE
refactor(web): eliminate per-poll DB scans in Electric shape proxies

### DIFF
--- a/web-app/code/src/application/collections/communication.ts
+++ b/web-app/code/src/application/collections/communication.ts
@@ -130,11 +130,13 @@ function _makePropertiesCollection(params: {
   memberProjectIds: string[]
   memberBuildunitIds: string[]
   memberChannelIds: string[]
+  memberTaskIds: string[]
 }) {
   const url = new URL(`/api/properties`, origin)
   if (params.memberProjectIds.length > 0) url.searchParams.set(`member_project_ids`, params.memberProjectIds.join(`,`))
   if (params.memberBuildunitIds.length > 0) url.searchParams.set(`member_buildunit_ids`, params.memberBuildunitIds.join(`,`))
   if (params.memberChannelIds.length > 0) url.searchParams.set(`member_channel_ids`, params.memberChannelIds.join(`,`))
+  if (params.memberTaskIds.length > 0) url.searchParams.set(`member_task_ids`, params.memberTaskIds.join(`,`))
   return createCollection(
     electricCollectionOptions({
       id: `properties`,
@@ -248,12 +250,21 @@ export let propertiesCollection: ReturnType<typeof _makePropertiesCollection> = 
 export let messagesCollection: ReturnType<typeof _makeMessagesCollection> = null!
 
 export function initializeCommunicationCollections(params: {
-  memberProjectIds: string[]
-  memberBuildunitIds: string[]
   memberChannelIds: string[]
 }) {
   tasksCollection = _makeTasksCollection(params.memberChannelIds)
   resourcesCollection = _makeResourcesCollection(params.memberChannelIds)
-  propertiesCollection = _makePropertiesCollection(params)
   messagesCollection = _makeMessagesCollection(params.memberChannelIds)
+}
+
+// Must be called AFTER tasksCollection has been preloaded so task IDs are known.
+// Task IDs are a snapshot — new tasks created after load won't have their
+// properties stream until the page is reloaded.
+export function initializePropertiesCollection(params: {
+  memberProjectIds: string[]
+  memberBuildunitIds: string[]
+  memberChannelIds: string[]
+  memberTaskIds: string[]
+}) {
+  propertiesCollection = _makePropertiesCollection(params)
 }

--- a/web-app/code/src/application/collections/communication.ts
+++ b/web-app/code/src/application/collections/communication.ts
@@ -30,183 +30,230 @@ const electricTaskSchema = selectTaskSchema.extend({
   completed: z.preprocess(coerceBool, z.boolean()),
 })
 
-export const tasksCollection = createCollection(
-  electricCollectionOptions({
-    id: `tasks`,
-    shapeOptions: {
-      url: new URL(`/api/tasks`, origin).toString(),
-      onError: retryOnError,
-      parser: {
-        timestamptz: (date: string) => {
-          return new Date(date)
+// ---------------------------------------------------------------------------
+// Factory functions — collections are created AFTER memberships load so that
+// membership-derived IDs can be baked into the shape URLs.
+// ---------------------------------------------------------------------------
+
+function _makeTasksCollection(memberChannelIds: string[]) {
+  const url = new URL(`/api/tasks`, origin)
+  if (memberChannelIds.length > 0) url.searchParams.set(`member_channel_ids`, memberChannelIds.join(`,`))
+  return createCollection(
+    electricCollectionOptions({
+      id: `tasks`,
+      shapeOptions: {
+        url: url.toString(),
+        onError: retryOnError,
+        parser: {
+          timestamptz: (date: string) => {
+            return new Date(date)
+          },
         },
       },
-    },
-    schema: electricTaskSchema,
-    getKey: (item) => item.id,
-    onInsert: async ({ transaction }) => {
-      const { modified: newTask } = transaction.mutations[0]
-      const result = await trpc.tasks.create.mutate({
-        id: newTask.id,
-        name: newTask.name,
-        description: newTask.description,
-        completed: newTask.completed,
-        channel_id: newTask.channel_id,
-        buildunit_id: newTask.buildunit_id,
-        createdby_id: newTask.createdby_id,
-        assignee_id: newTask.assignee_id ?? null,
-      })
+      schema: electricTaskSchema,
+      getKey: (item) => item.id,
+      onInsert: async ({ transaction }) => {
+        const { modified: newTask } = transaction.mutations[0]
+        const result = await trpc.tasks.create.mutate({
+          id: newTask.id,
+          name: newTask.name,
+          description: newTask.description,
+          completed: newTask.completed,
+          channel_id: newTask.channel_id,
+          buildunit_id: newTask.buildunit_id,
+          createdby_id: newTask.createdby_id,
+          assignee_id: newTask.assignee_id ?? null,
+        })
 
-      return { txid: result.txid }
-    },
-    onUpdate: async ({ transaction }) => {
-      const { modified: updatedTask } = transaction.mutations[0]
-      const result = await trpc.tasks.update.mutate({
-        id: updatedTask.id,
-        data: {
-          name: updatedTask.name,
-          description: updatedTask.description,
-          completed: coerceBool(updatedTask.completed),
-          assignee_id: updatedTask.assignee_id,
-        },
-      })
+        return { txid: result.txid }
+      },
+      onUpdate: async ({ transaction }) => {
+        const { modified: updatedTask } = transaction.mutations[0]
+        const result = await trpc.tasks.update.mutate({
+          id: updatedTask.id,
+          data: {
+            name: updatedTask.name,
+            description: updatedTask.description,
+            completed: coerceBool(updatedTask.completed),
+            assignee_id: updatedTask.assignee_id,
+          },
+        })
 
-      return { txid: result.txid }
-    },
-    onDelete: async ({ transaction }) => {
-      const { original: deletedTask } = transaction.mutations[0]
-      const result = await trpc.tasks.delete.mutate({
-        id: deletedTask.id,
-      })
+        return { txid: result.txid }
+      },
+      onDelete: async ({ transaction }) => {
+        const { original: deletedTask } = transaction.mutations[0]
+        const result = await trpc.tasks.delete.mutate({
+          id: deletedTask.id,
+        })
 
-      return { txid: result.txid }
-    },
-  })
-)
+        return { txid: result.txid }
+      },
+    })
+  )
+}
 
-export const resourcesCollection = createCollection(
-  electricCollectionOptions({
-    id: `resources`,
-    shapeOptions: {
-      url: new URL(`/api/resources`, origin).toString(),
-      onError: retryOnError,
-      parser: {
-        timestamptz: (date: string) => {
-          return new Date(date)
+function _makeResourcesCollection(memberChannelIds: string[]) {
+  const url = new URL(`/api/resources`, origin)
+  if (memberChannelIds.length > 0) url.searchParams.set(`member_channel_ids`, memberChannelIds.join(`,`))
+  return createCollection(
+    electricCollectionOptions({
+      id: `resources`,
+      shapeOptions: {
+        url: url.toString(),
+        onError: retryOnError,
+        parser: {
+          timestamptz: (date: string) => {
+            return new Date(date)
+          },
         },
       },
-    },
-    schema: selectResourceSchema.extend({
-      file_size_bytes: z.preprocess(
-        (v) => (typeof v === "string" || typeof v === "bigint" ? Number(v) : v),
-        z.number()
-      ),
-    }),
-    getKey: (item) => item.id,
-    onDelete: async ({ transaction }) => {
-      const { original: deletedResource } = transaction.mutations[0]
-      const result = await trpc.resources.delete.mutate({
-        id: deletedResource.id,
-      })
-      return { txid: result.txid }
-    },
-  })
-)
+      schema: selectResourceSchema.extend({
+        file_size_bytes: z.preprocess(
+          (v) => (typeof v === "string" || typeof v === "bigint" ? Number(v) : v),
+          z.number()
+        ),
+      }),
+      getKey: (item) => item.id,
+      onDelete: async ({ transaction }) => {
+        const { original: deletedResource } = transaction.mutations[0]
+        const result = await trpc.resources.delete.mutate({
+          id: deletedResource.id,
+        })
+        return { txid: result.txid }
+      },
+    })
+  )
+}
 
-export const propertiesCollection = createCollection(
-  electricCollectionOptions({
-    id: `properties`,
-    shapeOptions: {
-      url: new URL(`/api/properties`, origin).toString(),
-      onError: retryOnError,
-      parser: {
-        timestamptz: (date: string) => {
-          return new Date(date)
+function _makePropertiesCollection(params: {
+  memberProjectIds: string[]
+  memberBuildunitIds: string[]
+  memberChannelIds: string[]
+}) {
+  const url = new URL(`/api/properties`, origin)
+  if (params.memberProjectIds.length > 0) url.searchParams.set(`member_project_ids`, params.memberProjectIds.join(`,`))
+  if (params.memberBuildunitIds.length > 0) url.searchParams.set(`member_buildunit_ids`, params.memberBuildunitIds.join(`,`))
+  if (params.memberChannelIds.length > 0) url.searchParams.set(`member_channel_ids`, params.memberChannelIds.join(`,`))
+  return createCollection(
+    electricCollectionOptions({
+      id: `properties`,
+      shapeOptions: {
+        url: url.toString(),
+        onError: retryOnError,
+        parser: {
+          timestamptz: (date: string) => {
+            return new Date(date)
+          },
         },
       },
-    },
-    schema: electricPropertySchema,
-    getKey: (item) => item.id,
-    onInsert: async ({ transaction }) => {
-      const { modified: newProperty } = transaction.mutations[0]
-      const result = await trpc.properties.create.mutate({
-        id: newProperty.id,
-        type: newProperty.type,
-        entity: newProperty.entity,
-        entity_id: newProperty.entity_id,
-        status_value: newProperty.status_value,
-        priority_value: newProperty.priority_value,
-        target_date: newProperty.target_date,
-        start_date: newProperty.start_date,
-        pending_task: newProperty.pending_task,
-        label_value: newProperty.label_value,
-      })
+      schema: electricPropertySchema,
+      getKey: (item) => item.id,
+      onInsert: async ({ transaction }) => {
+        const { modified: newProperty } = transaction.mutations[0]
+        const result = await trpc.properties.create.mutate({
+          id: newProperty.id,
+          type: newProperty.type,
+          entity: newProperty.entity,
+          entity_id: newProperty.entity_id,
+          status_value: newProperty.status_value,
+          priority_value: newProperty.priority_value,
+          target_date: newProperty.target_date,
+          start_date: newProperty.start_date,
+          pending_task: newProperty.pending_task,
+          label_value: newProperty.label_value,
+        })
 
-      return { txid: result.txid }
-    },
-    onUpdate: async ({ transaction }) => {
-      const { modified: updatedProperty } = transaction.mutations[0]
-      const result = await trpc.properties.update.mutate({
-        id: updatedProperty.id,
-        data: {
-          status_value: updatedProperty.status_value,
-          priority_value: updatedProperty.priority_value,
-          target_date: updatedProperty.target_date,
-          start_date: updatedProperty.start_date,
-          pending_task: updatedProperty.pending_task,
-        },
-      })
+        return { txid: result.txid }
+      },
+      onUpdate: async ({ transaction }) => {
+        const { modified: updatedProperty } = transaction.mutations[0]
+        const result = await trpc.properties.update.mutate({
+          id: updatedProperty.id,
+          data: {
+            status_value: updatedProperty.status_value,
+            priority_value: updatedProperty.priority_value,
+            target_date: updatedProperty.target_date,
+            start_date: updatedProperty.start_date,
+            pending_task: updatedProperty.pending_task,
+          },
+        })
 
-      return { txid: result.txid }
-    },
-    onDelete: async ({ transaction }) => {
-      const { original: deletedProperty } = transaction.mutations[0]
-      const result = await trpc.properties.delete.mutate({
-        id: deletedProperty.id,
-      })
+        return { txid: result.txid }
+      },
+      onDelete: async ({ transaction }) => {
+        const { original: deletedProperty } = transaction.mutations[0]
+        const result = await trpc.properties.delete.mutate({
+          id: deletedProperty.id,
+        })
 
-      return { txid: result.txid }
-    },
-  })
-)
+        return { txid: result.txid }
+      },
+    })
+  )
+}
 
-export const messagesCollection = createCollection(
-  electricCollectionOptions({
-    id: `messages`,
-    shapeOptions: {
-      url: new URL(`/api/messages`, origin).toString(),
-      onError: retryOnError,
-      parser: {
-        timestamptz: (date: string) => {
-          return new Date(date)
+function _makeMessagesCollection(memberChannelIds: string[]) {
+  const url = new URL(`/api/messages`, origin)
+  if (memberChannelIds.length > 0) url.searchParams.set(`member_channel_ids`, memberChannelIds.join(`,`))
+  return createCollection(
+    electricCollectionOptions({
+      id: `messages`,
+      shapeOptions: {
+        url: url.toString(),
+        onError: retryOnError,
+        parser: {
+          timestamptz: (date: string) => {
+            return new Date(date)
+          },
         },
       },
-    },
-    schema: selectMessageSchema,
-    getKey: (item) => item.id,
-    onInsert: async ({ transaction }) => {
-      const { modified: newMessage } = transaction.mutations[0]
-      const result = await trpc.messages.create.mutate({
-        id: newMessage.id,
-        text: newMessage.text,
-        channel_id: newMessage.channel_id,
-        buildunit_id: newMessage.buildunit_id,
-        project_id: newMessage.project_id,
-        createdby_id: newMessage.createdby_id,
-        mention_ids: newMessage.mention_ids,
-        resource_ids: newMessage.resource_ids,
-        parent_id: newMessage.parent_id ?? null,
-      })
+      schema: selectMessageSchema,
+      getKey: (item) => item.id,
+      onInsert: async ({ transaction }) => {
+        const { modified: newMessage } = transaction.mutations[0]
+        const result = await trpc.messages.create.mutate({
+          id: newMessage.id,
+          text: newMessage.text,
+          channel_id: newMessage.channel_id,
+          buildunit_id: newMessage.buildunit_id,
+          project_id: newMessage.project_id,
+          createdby_id: newMessage.createdby_id,
+          mention_ids: newMessage.mention_ids,
+          resource_ids: newMessage.resource_ids,
+          parent_id: newMessage.parent_id ?? null,
+        })
 
-      return { txid: result.txid }
-    },
-    onDelete: async ({ transaction }) => {
-      const { original: deletedMessage } = transaction.mutations[0]
-      const result = await trpc.messages.delete.mutate({
-        id: deletedMessage.id,
-      })
+        return { txid: result.txid }
+      },
+      onDelete: async ({ transaction }) => {
+        const { original: deletedMessage } = transaction.mutations[0]
+        const result = await trpc.messages.delete.mutate({
+          id: deletedMessage.id,
+        })
 
-      return { txid: result.txid }
-    },
-  })
-)
+        return { txid: result.txid }
+      },
+    })
+  )
+}
+
+// ---------------------------------------------------------------------------
+// Deferred exports — initialized by initializeCommunicationCollections()
+// called from the _authenticated loader after memberships preload.
+// ---------------------------------------------------------------------------
+export let tasksCollection: ReturnType<typeof _makeTasksCollection> = null!
+export let resourcesCollection: ReturnType<typeof _makeResourcesCollection> = null!
+export let propertiesCollection: ReturnType<typeof _makePropertiesCollection> = null!
+export let messagesCollection: ReturnType<typeof _makeMessagesCollection> = null!
+
+export function initializeCommunicationCollections(params: {
+  memberProjectIds: string[]
+  memberBuildunitIds: string[]
+  memberChannelIds: string[]
+}) {
+  tasksCollection = _makeTasksCollection(params.memberChannelIds)
+  resourcesCollection = _makeResourcesCollection(params.memberChannelIds)
+  propertiesCollection = _makePropertiesCollection(params)
+  messagesCollection = _makeMessagesCollection(params.memberChannelIds)
+}

--- a/web-app/code/src/application/collections/organization.ts
+++ b/web-app/code/src/application/collections/organization.ts
@@ -16,6 +16,7 @@ const electricMembershipSchema = selectMembershipSchema.extend({
   role: z.enum(MEMBERSHIP_ROLES).default(`viewer`),
 })
 
+// Memberships is the bootstrap collection — loaded first, before others
 export const membershipsCollection = createCollection(
   electricCollectionOptions({
     id: `memberships`,
@@ -31,53 +32,63 @@ export const membershipsCollection = createCollection(
   })
 )
 
-export const projectsCollection = createCollection(
-  electricCollectionOptions({
-    id: `projects`,
-    shapeOptions: {
-      url: new URL(`/api/projects`, origin).toString(),
-      onError: retryOnError,
-      parser: {
-        timestamptz: (date: string) => {
-          return new Date(date)
+// ---------------------------------------------------------------------------
+// Factory functions — collections are created AFTER memberships load so that
+// membership-derived IDs can be baked into the shape URLs.  This eliminates
+// the per-poll membership table scan on the server side.
+// ---------------------------------------------------------------------------
+
+function _makeProjectsCollection(memberProjectIds: string[]) {
+  const url = new URL(`/api/projects`, origin)
+  if (memberProjectIds.length > 0) url.searchParams.set(`member_ids`, memberProjectIds.join(`,`))
+  return createCollection(
+    electricCollectionOptions({
+      id: `projects`,
+      shapeOptions: {
+        url: url.toString(),
+        onError: retryOnError,
+        parser: {
+          timestamptz: (date: string) => {
+            return new Date(date)
+          },
         },
       },
-    },
-    schema: selectProjectSchema,
-    getKey: (item) => item.id,
-    onInsert: async ({ transaction }) => {
-      const { modified: newProject } = transaction.mutations[0]
-      const result = await trpc.projects.create.mutate({
-        id: newProject.id,
-        name: newProject.name,
-        description: newProject.description,
-        owner_id: newProject.owner_id,
-      })
+      schema: selectProjectSchema,
+      getKey: (item) => item.id,
+      onInsert: async ({ transaction }) => {
+        const { modified: newProject } = transaction.mutations[0]
+        const result = await trpc.projects.create.mutate({
+          id: newProject.id,
+          name: newProject.name,
+          description: newProject.description,
+          owner_id: newProject.owner_id,
+        })
 
-      return { txid: result.txid }
-    },
-    onUpdate: async ({ transaction }) => {
-      const { modified: updatedProject } = transaction.mutations[0]
-      const result = await trpc.projects.update.mutate({
-        id: updatedProject.id,
-        data: {
-          name: updatedProject.name,
-          description: updatedProject.description,
-        },
-      })
+        return { txid: result.txid }
+      },
+      onUpdate: async ({ transaction }) => {
+        const { modified: updatedProject } = transaction.mutations[0]
+        const result = await trpc.projects.update.mutate({
+          id: updatedProject.id,
+          data: {
+            name: updatedProject.name,
+            description: updatedProject.description,
+          },
+        })
 
-      return { txid: result.txid }
-    },
-    onDelete: async ({ transaction }) => {
-      const { original: deletedProject } = transaction.mutations[0]
-      const result = await trpc.projects.delete.mutate({
-        id: deletedProject.id,
-      })
+        return { txid: result.txid }
+      },
+      onDelete: async ({ transaction }) => {
+        const { original: deletedProject } = transaction.mutations[0]
+        const result = await trpc.projects.delete.mutate({
+          id: deletedProject.id,
+        })
 
-      return { txid: result.txid }
-    },
-  })
-)
+        return { txid: result.txid }
+      },
+    })
+  )
+}
 
 // Registry allowing UI components to be notified when a build unit insert
 // completes (success or error) via the onInsert handler below.
@@ -92,61 +103,65 @@ export function registerBuildUnitInsertCallback(
   _buildUnitInsertCallbacks.set(id, { resolve, reject })
 }
 
-export const buildUnitsCollection = createCollection(
-  electricCollectionOptions({
-    id: `build-units`,
-    shapeOptions: {
-      url: new URL(`/api/buildunits`, origin).toString(),
-      onError: retryOnError,
-      parser: {
-        timestamptz: (date: string) => {
-          return new Date(date)
+function _makeBuildUnitsCollection(memberBuildunitIds: string[]) {
+  const url = new URL(`/api/buildunits`, origin)
+  if (memberBuildunitIds.length > 0) url.searchParams.set(`member_ids`, memberBuildunitIds.join(`,`))
+  return createCollection(
+    electricCollectionOptions({
+      id: `build-units`,
+      shapeOptions: {
+        url: url.toString(),
+        onError: retryOnError,
+        parser: {
+          timestamptz: (date: string) => {
+            return new Date(date)
+          },
         },
       },
-    },
-    schema: selectBuildUnitSchema,
-    getKey: (item) => item.id,
-    onInsert: async ({ transaction }) => {
-      const { modified: newBuildUnit } = transaction.mutations[0]
-      try {
-        const result = await trpc.buildUnits.create.mutate({
-          id: newBuildUnit.id,
-          name: newBuildUnit.name,
-          description: newBuildUnit.description,
-          project_id: newBuildUnit.project_id,
-          owner_id: newBuildUnit.owner_id,
+      schema: selectBuildUnitSchema,
+      getKey: (item) => item.id,
+      onInsert: async ({ transaction }) => {
+        const { modified: newBuildUnit } = transaction.mutations[0]
+        try {
+          const result = await trpc.buildUnits.create.mutate({
+            id: newBuildUnit.id,
+            name: newBuildUnit.name,
+            description: newBuildUnit.description,
+            project_id: newBuildUnit.project_id,
+            owner_id: newBuildUnit.owner_id,
+          })
+          _buildUnitInsertCallbacks.get(newBuildUnit.id)?.resolve()
+          _buildUnitInsertCallbacks.delete(newBuildUnit.id)
+          return { txid: result.txid }
+        } catch (err) {
+          _buildUnitInsertCallbacks.get(newBuildUnit.id)?.reject(err instanceof Error ? err : new Error(String(err)))
+          _buildUnitInsertCallbacks.delete(newBuildUnit.id)
+          throw err
+        }
+      },
+      onUpdate: async ({ transaction }) => {
+        const { modified: updatedBuildUnit } = transaction.mutations[0]
+        const result = await trpc.buildUnits.update.mutate({
+          id: updatedBuildUnit.id,
+          data: {
+            name: updatedBuildUnit.name,
+            description: updatedBuildUnit.description,
+          },
         })
-        _buildUnitInsertCallbacks.get(newBuildUnit.id)?.resolve()
-        _buildUnitInsertCallbacks.delete(newBuildUnit.id)
+
         return { txid: result.txid }
-      } catch (err) {
-        _buildUnitInsertCallbacks.get(newBuildUnit.id)?.reject(err instanceof Error ? err : new Error(String(err)))
-        _buildUnitInsertCallbacks.delete(newBuildUnit.id)
-        throw err
-      }
-    },
-    onUpdate: async ({ transaction }) => {
-      const { modified: updatedBuildUnit } = transaction.mutations[0]
-      const result = await trpc.buildUnits.update.mutate({
-        id: updatedBuildUnit.id,
-        data: {
-          name: updatedBuildUnit.name,
-          description: updatedBuildUnit.description,
-        },
-      })
+      },
+      onDelete: async ({ transaction }) => {
+        const { original: deletedBuildUnit } = transaction.mutations[0]
+        const result = await trpc.buildUnits.delete.mutate({
+          id: deletedBuildUnit.id,
+        })
 
-      return { txid: result.txid }
-    },
-    onDelete: async ({ transaction }) => {
-      const { original: deletedBuildUnit } = transaction.mutations[0]
-      const result = await trpc.buildUnits.delete.mutate({
-        id: deletedBuildUnit.id,
-      })
-
-      return { txid: result.txid }
-    },
-  })
-)
+        return { txid: result.txid }
+      },
+    })
+  )
+}
 
 // Registry allowing UI components to be notified when a channel insert
 // completes (success or error) via the onInsert handler below.
@@ -161,58 +176,81 @@ export function registerChannelInsertCallback(
   _channelInsertCallbacks.set(id, { resolve, reject })
 }
 
-export const channelsCollection = createCollection(
-  electricCollectionOptions({
-    id: `channels`,
-    shapeOptions: {
-      url: new URL(`/api/channels`, origin).toString(),
-      onError: retryOnError,
-      parser: {
-        timestamptz: (date: string) => {
-          return new Date(date)
+function _makeChannelsCollection(memberChannelIds: string[]) {
+  const url = new URL(`/api/channels`, origin)
+  if (memberChannelIds.length > 0) url.searchParams.set(`member_ids`, memberChannelIds.join(`,`))
+  return createCollection(
+    electricCollectionOptions({
+      id: `channels`,
+      shapeOptions: {
+        url: url.toString(),
+        onError: retryOnError,
+        parser: {
+          timestamptz: (date: string) => {
+            return new Date(date)
+          },
         },
       },
-    },
-    schema: selectChannelSchema,
-    getKey: (item) => item.id,
-    onInsert: async ({ transaction }) => {
-      const { modified: newChannel } = transaction.mutations[0]
-      try {
-        const result = await trpc.channels.create.mutate({
-          id: newChannel.id,
-          name: newChannel.name,
-          description: newChannel.description,
-          buildunit_id: newChannel.buildunit_id,
-          owner_id: newChannel.owner_id,
+      schema: selectChannelSchema,
+      getKey: (item) => item.id,
+      onInsert: async ({ transaction }) => {
+        const { modified: newChannel } = transaction.mutations[0]
+        try {
+          const result = await trpc.channels.create.mutate({
+            id: newChannel.id,
+            name: newChannel.name,
+            description: newChannel.description,
+            buildunit_id: newChannel.buildunit_id,
+            owner_id: newChannel.owner_id,
+          })
+          _channelInsertCallbacks.get(newChannel.id)?.resolve()
+          _channelInsertCallbacks.delete(newChannel.id)
+          return { txid: result.txid }
+        } catch (err) {
+          _channelInsertCallbacks.get(newChannel.id)?.reject(err instanceof Error ? err : new Error(String(err)))
+          _channelInsertCallbacks.delete(newChannel.id)
+          throw err
+        }
+      },
+      onUpdate: async ({ transaction }) => {
+        const { modified: updatedChannel } = transaction.mutations[0]
+        const result = await trpc.channels.update.mutate({
+          id: updatedChannel.id,
+          data: {
+            name: updatedChannel.name,
+            description: updatedChannel.description,
+          },
         })
-        _channelInsertCallbacks.get(newChannel.id)?.resolve()
-        _channelInsertCallbacks.delete(newChannel.id)
+
         return { txid: result.txid }
-      } catch (err) {
-        _channelInsertCallbacks.get(newChannel.id)?.reject(err instanceof Error ? err : new Error(String(err)))
-        _channelInsertCallbacks.delete(newChannel.id)
-        throw err
-      }
-    },
-    onUpdate: async ({ transaction }) => {
-      const { modified: updatedChannel } = transaction.mutations[0]
-      const result = await trpc.channels.update.mutate({
-        id: updatedChannel.id,
-        data: {
-          name: updatedChannel.name,
-          description: updatedChannel.description,
-        },
-      })
+      },
+      onDelete: async ({ transaction }) => {
+        const { original: deletedChannel } = transaction.mutations[0]
+        const result = await trpc.channels.delete.mutate({
+          id: deletedChannel.id,
+        })
 
-      return { txid: result.txid }
-    },
-    onDelete: async ({ transaction }) => {
-      const { original: deletedChannel } = transaction.mutations[0]
-      const result = await trpc.channels.delete.mutate({
-        id: deletedChannel.id,
-      })
+        return { txid: result.txid }
+      },
+    })
+  )
+}
 
-      return { txid: result.txid }
-    },
-  })
-)
+// ---------------------------------------------------------------------------
+// Deferred exports — initialized by initializeOrganizationCollections()
+// called from the _authenticated loader after memberships preload.
+// ES-module live bindings ensure importers always read the current value.
+// ---------------------------------------------------------------------------
+export let projectsCollection: ReturnType<typeof _makeProjectsCollection> = null!
+export let buildUnitsCollection: ReturnType<typeof _makeBuildUnitsCollection> = null!
+export let channelsCollection: ReturnType<typeof _makeChannelsCollection> = null!
+
+export function initializeOrganizationCollections(params: {
+  memberProjectIds: string[]
+  memberBuildunitIds: string[]
+  memberChannelIds: string[]
+}) {
+  projectsCollection = _makeProjectsCollection(params.memberProjectIds)
+  buildUnitsCollection = _makeBuildUnitsCollection(params.memberBuildunitIds)
+  channelsCollection = _makeChannelsCollection(params.memberChannelIds)
+}

--- a/web-app/code/src/presentation/routes/_authenticated.tsx
+++ b/web-app/code/src/presentation/routes/_authenticated.tsx
@@ -1,7 +1,8 @@
 import { createFileRoute, Outlet, useNavigate, redirect } from '@tanstack/react-router'
 import { authClient } from '../../infrastructure/auth/client'
 import { authStateCollection } from '../../infrastructure/database/tanstack-db-electric/authCollections'
-import { projectsCollection, buildUnitsCollection, usersCollection, teamsCollection, membershipsCollection } from '../../infrastructure/database/tanstack-db-electric/admincollections'
+import { projectsCollection, buildUnitsCollection, usersCollection, teamsCollection, membershipsCollection, initializeOrganizationCollections } from '../../infrastructure/database/tanstack-db-electric/admincollections'
+import { initializeCommunicationCollections } from '../../application/collections/communication'
 import { useEffect } from 'react'
 
 function AuthLoadingComponent() {
@@ -39,6 +40,18 @@ export const Route = createFileRoute('/_authenticated')({
   loader: async () => {
     // Memberships must load first — other shapes use it for access control
     await membershipsCollection.preload()
+
+    // Extract membership-derived IDs and initialize dependent collections
+    // so their shape URLs include the IDs (eliminating per-poll DB scans)
+    const memberships = membershipsCollection.toArray
+    const memberProjectIds = [...new Set(memberships.map(m => m.project_id))].sort()
+    const memberBuildunitIds = [...new Set(memberships.map(m => m.buildunit_id))].sort()
+    const memberChannelIds = [...new Set(memberships.map(m => m.channel_id))].sort()
+
+    const membershipParams = { memberProjectIds, memberBuildunitIds, memberChannelIds }
+    initializeOrganizationCollections(membershipParams)
+    initializeCommunicationCollections(membershipParams)
+
     await Promise.all([
       projectsCollection.preload(),
       buildUnitsCollection.preload(),

--- a/web-app/code/src/presentation/routes/_authenticated.tsx
+++ b/web-app/code/src/presentation/routes/_authenticated.tsx
@@ -2,7 +2,7 @@ import { createFileRoute, Outlet, useNavigate, redirect } from '@tanstack/react-
 import { authClient } from '../../infrastructure/auth/client'
 import { authStateCollection } from '../../infrastructure/database/tanstack-db-electric/authCollections'
 import { projectsCollection, buildUnitsCollection, usersCollection, teamsCollection, membershipsCollection, initializeOrganizationCollections } from '../../infrastructure/database/tanstack-db-electric/admincollections'
-import { initializeCommunicationCollections } from '../../application/collections/communication'
+import { initializeCommunicationCollections, initializePropertiesCollection, tasksCollection, propertiesCollection } from '../../application/collections/communication'
 import { useEffect } from 'react'
 
 function AuthLoadingComponent() {
@@ -17,32 +17,34 @@ export const Route = createFileRoute('/_authenticated')({
   ssr: false, // Only run on client — avoids SSR fetch through Caddy with untrusted cert
   beforeLoad: async () => {
     const cached = authStateCollection.get(`auth`)
+    let sessionData: unknown
     if (cached?.session && cached.session.expiresAt > new Date()) {
-      return cached
-    }
-    const result = await authClient.getSession()
-
-    if (authStateCollection.get(`auth`)) {
-      authStateCollection.update(`auth`, (doc) => {
-        doc.session = result.data?.session ?? null
-        doc.user = result.data?.user ?? null
-      })
+      sessionData = cached
     } else {
-      authStateCollection.insert({ id: `auth`, ...result.data })
+      const result = await authClient.getSession()
+
+      if (authStateCollection.get(`auth`)) {
+        authStateCollection.update(`auth`, (doc) => {
+          doc.session = result.data?.session ?? null
+          doc.user = result.data?.user ?? null
+        })
+      } else {
+        authStateCollection.insert({ id: `auth`, ...result.data })
+      }
+
+      if (!result.data?.session) {
+        throw redirect({ to: `/login` })
+      }
+
+      sessionData = result.data
     }
 
-    if (!result.data?.session) {
-      throw redirect({ to: `/login` })
-    }
-
-    return result.data
-  },
-  loader: async () => {
-    // Memberships must load first — other shapes use it for access control
+    // Collection init must happen here, not in loader: child route loaders run
+    // in parallel with _authenticated's loader, so if init lived in loader the
+    // children would race and hit null.preload(). beforeLoad runs sequentially
+    // parent-before-child and completes before any loader starts.
     await membershipsCollection.preload()
 
-    // Extract membership-derived IDs and initialize dependent collections
-    // so their shape URLs include the IDs (eliminating per-poll DB scans)
     const memberships = membershipsCollection.toArray
     const memberProjectIds = [...new Set(memberships.map(m => m.project_id))].sort()
     const memberBuildunitIds = [...new Set(memberships.map(m => m.buildunit_id))].sort()
@@ -50,14 +52,23 @@ export const Route = createFileRoute('/_authenticated')({
 
     const membershipParams = { memberProjectIds, memberBuildunitIds, memberChannelIds }
     initializeOrganizationCollections(membershipParams)
-    initializeCommunicationCollections(membershipParams)
+    initializeCommunicationCollections({ memberChannelIds })
 
+    // Tasks must preload before propertiesCollection is initialized — its shape
+    // URL bakes in task IDs to let the server skip per-poll tasksTable scans.
     await Promise.all([
       projectsCollection.preload(),
       buildUnitsCollection.preload(),
       usersCollection.preload(),
       teamsCollection.preload(),
+      tasksCollection.preload(),
     ])
+
+    const memberTaskIds = [...new Set(tasksCollection.toArray.map(t => t.id))].sort()
+    initializePropertiesCollection({ ...membershipParams, memberTaskIds })
+    await propertiesCollection.preload()
+
+    return sessionData
   },
   pendingComponent: AuthLoadingComponent,
   component: AuthenticatedLayout,

--- a/web-app/code/src/presentation/routes/api/buildunits.ts
+++ b/web-app/code/src/presentation/routes/api/buildunits.ts
@@ -1,9 +1,6 @@
 import { createFileRoute } from "@tanstack/react-router"
 import { auth } from "../../../infrastructure/auth/server"
 import { prepareElectricUrl, proxyElectricRequest } from "../../../infrastructure/database/electric-proxy"
-import { db } from "../../../infrastructure/database/connection"
-import { membershipTable, buildUnitsTable } from "../../../infrastructure/database/schema/admin-schema"
-import { eq, and } from "drizzle-orm"
 
 const UUID_REGEX = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i
 
@@ -16,30 +13,17 @@ const serve = async ({ request }: { request: Request }) => {
     })
   }
 
-  const [memberships, ownedBuildUnits] = await Promise.all([
-    db
-      .select({ buildunit_id: membershipTable.buildunit_id })
-      .from(membershipTable)
-      .where(and(
-        eq(membershipTable.user_id, session.user.id),
-        eq(membershipTable.member_flag, true)
-      )),
-    db
-      .select({ id: buildUnitsTable.id })
-      .from(buildUnitsTable)
-      .where(eq(buildUnitsTable.owner_id, session.user.id)),
-  ])
+  const url = new URL(request.url)
+  const memberIds = (url.searchParams.get(`member_ids`) ?? ``).split(`,`).filter(id => UUID_REGEX.test(id))
 
-  const buildunitIds = [...new Set([
-    ...memberships.map(m => m.buildunit_id),
-    ...ownedBuildUnits.map(b => b.id),
-  ])]
-  if (buildunitIds.length === 0) {
-    return new Response(`[]`, { status: 200, headers: { "content-type": "application/json" } })
+  const parts: string[] = []
+  if (memberIds.length > 0) {
+    parts.push(`id = ANY(ARRAY[${memberIds.map(id => `'${id}'`).join(`,`)}]::text[])`)
   }
+  parts.push(`owner_id = '${session.user.id}'`)
+  let whereClause = `(${parts.join(` OR `)})`
 
-  const projectId = new URL(request.url).searchParams.get(`project_id`)
-  let whereClause = `id = ANY(ARRAY[${buildunitIds.map(id => `'${id}'`).join(`,`)}]::text[])`
+  const projectId = url.searchParams.get(`project_id`)
   if (projectId && UUID_REGEX.test(projectId)) {
     whereClause += ` AND project_id = '${projectId}'`
   }

--- a/web-app/code/src/presentation/routes/api/channels.ts
+++ b/web-app/code/src/presentation/routes/api/channels.ts
@@ -2,8 +2,8 @@ import { createFileRoute } from "@tanstack/react-router"
 import { auth } from "../../../infrastructure/auth/server"
 import { prepareElectricUrl, proxyElectricRequest } from "../../../infrastructure/database/electric-proxy"
 import { db } from "../../../infrastructure/database/connection"
-import { membershipTable, channelsTable, buildUnitsTable } from "../../../infrastructure/database/schema/admin-schema"
-import { eq, and, inArray } from "drizzle-orm"
+import { buildUnitsTable } from "../../../infrastructure/database/schema/admin-schema"
+import { eq } from "drizzle-orm"
 
 const UUID_REGEX = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i
 
@@ -16,29 +16,18 @@ const serve = async ({ request }: { request: Request }) => {
     })
   }
 
-  const [memberships, ownedChannels] = await Promise.all([
-    db
-      .select({ channel_id: membershipTable.channel_id })
-      .from(membershipTable)
-      .where(and(
-        eq(membershipTable.user_id, session.user.id),
-        eq(membershipTable.member_flag, true)
-      )),
-    db
-      .select({ id: channelsTable.id })
-      .from(channelsTable)
-      .where(eq(channelsTable.owner_id, session.user.id)),
-  ])
+  const url = new URL(request.url)
+  const memberIds = (url.searchParams.get(`member_ids`) ?? ``).split(`,`).filter(id => UUID_REGEX.test(id))
 
-  let channelIds = [...new Set([
-    ...memberships.map(m => m.channel_id),
-    ...ownedChannels.map(c => c.id),
-  ])]
-  if (channelIds.length === 0) {
-    return new Response(`[]`, { status: 200, headers: { "content-type": "application/json" } })
+  const parts: string[] = []
+  if (memberIds.length > 0) {
+    parts.push(`id = ANY(ARRAY[${memberIds.map(id => `'${id}'`).join(`,`)}]::text[])`)
   }
+  parts.push(`owner_id = '${session.user.id}'`)
+  let whereClause = `(${parts.join(` OR `)})`
 
-  const projectId = new URL(request.url).searchParams.get(`project_id`)
+  // Optional project_id filter — narrow to channels belonging to that project's build units
+  const projectId = url.searchParams.get(`project_id`)
   if (projectId && UUID_REGEX.test(projectId)) {
     const projectBuildUnits = await db
       .select({ id: buildUnitsTable.id })
@@ -46,24 +35,15 @@ const serve = async ({ request }: { request: Request }) => {
       .where(eq(buildUnitsTable.project_id, projectId))
     const projectBuildUnitIds = projectBuildUnits.map(b => b.id)
     if (projectBuildUnitIds.length > 0) {
-      const projectChannels = await db
-        .select({ id: channelsTable.id })
-        .from(channelsTable)
-        .where(inArray(channelsTable.buildunit_id, projectBuildUnitIds))
-      const projectChannelIds = new Set(projectChannels.map(c => c.id))
-      channelIds = channelIds.filter(id => projectChannelIds.has(id))
+      whereClause += ` AND buildunit_id = ANY(ARRAY[${projectBuildUnitIds.map(id => `'${id}'`).join(`,`)}]::text[])`
     } else {
-      channelIds = []
+      whereClause = `1 = 0`
     }
-  }
-
-  if (channelIds.length === 0) {
-    return new Response(`[]`, { status: 200, headers: { "content-type": "application/json" } })
   }
 
   const originUrl = prepareElectricUrl(request.url)
   originUrl.searchParams.set(`table`, `channels`)
-  originUrl.searchParams.set(`where`, `id = ANY(ARRAY[${channelIds.map(id => `'${id}'`).join(`,`)}]::text[])`)
+  originUrl.searchParams.set(`where`, whereClause)
 
   return proxyElectricRequest(originUrl)
 }

--- a/web-app/code/src/presentation/routes/api/channels.ts
+++ b/web-app/code/src/presentation/routes/api/channels.ts
@@ -1,9 +1,6 @@
 import { createFileRoute } from "@tanstack/react-router"
 import { auth } from "../../../infrastructure/auth/server"
 import { prepareElectricUrl, proxyElectricRequest } from "../../../infrastructure/database/electric-proxy"
-import { db } from "../../../infrastructure/database/connection"
-import { buildUnitsTable } from "../../../infrastructure/database/schema/admin-schema"
-import { eq } from "drizzle-orm"
 
 const UUID_REGEX = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i
 
@@ -24,26 +21,10 @@ const serve = async ({ request }: { request: Request }) => {
     parts.push(`id = ANY(ARRAY[${memberIds.map(id => `'${id}'`).join(`,`)}]::text[])`)
   }
   parts.push(`owner_id = '${session.user.id}'`)
-  let whereClause = `(${parts.join(` OR `)})`
-
-  // Optional project_id filter — narrow to channels belonging to that project's build units
-  const projectId = url.searchParams.get(`project_id`)
-  if (projectId && UUID_REGEX.test(projectId)) {
-    const projectBuildUnits = await db
-      .select({ id: buildUnitsTable.id })
-      .from(buildUnitsTable)
-      .where(eq(buildUnitsTable.project_id, projectId))
-    const projectBuildUnitIds = projectBuildUnits.map(b => b.id)
-    if (projectBuildUnitIds.length > 0) {
-      whereClause += ` AND buildunit_id = ANY(ARRAY[${projectBuildUnitIds.map(id => `'${id}'`).join(`,`)}]::text[])`
-    } else {
-      whereClause = `1 = 0`
-    }
-  }
 
   const originUrl = prepareElectricUrl(request.url)
   originUrl.searchParams.set(`table`, `channels`)
-  originUrl.searchParams.set(`where`, whereClause)
+  originUrl.searchParams.set(`where`, parts.join(` OR `))
 
   return proxyElectricRequest(originUrl)
 }

--- a/web-app/code/src/presentation/routes/api/messages.ts
+++ b/web-app/code/src/presentation/routes/api/messages.ts
@@ -1,9 +1,6 @@
 import { createFileRoute } from "@tanstack/react-router"
 import { auth } from "../../../infrastructure/auth/server"
 import { prepareElectricUrl, proxyElectricRequest } from "../../../infrastructure/database/electric-proxy"
-import { db } from "../../../infrastructure/database/connection"
-import { channelsTable, buildUnitsTable } from "../../../infrastructure/database/schema/admin-schema"
-import { eq, inArray } from "drizzle-orm"
 
 const UUID_REGEX = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i
 
@@ -17,33 +14,7 @@ const serve = async ({ request }: { request: Request }) => {
   }
 
   const url = new URL(request.url)
-  const memberChannelIds = (url.searchParams.get(`member_channel_ids`) ?? ``).split(`,`).filter(id => UUID_REGEX.test(id))
-
-  const ownedChannels = await db
-    .select({ id: channelsTable.id })
-    .from(channelsTable)
-    .where(eq(channelsTable.owner_id, session.user.id))
-
-  let channelIds = [...new Set([...memberChannelIds, ...ownedChannels.map(c => c.id)])]
-
-  const projectId = url.searchParams.get(`project_id`)
-  if (projectId && UUID_REGEX.test(projectId)) {
-    const projectBuildUnits = await db
-      .select({ id: buildUnitsTable.id })
-      .from(buildUnitsTable)
-      .where(eq(buildUnitsTable.project_id, projectId))
-    const projectBuildUnitIds = projectBuildUnits.map(b => b.id)
-    if (projectBuildUnitIds.length > 0) {
-      const projectChannels = await db
-        .select({ id: channelsTable.id })
-        .from(channelsTable)
-        .where(inArray(channelsTable.buildunit_id, projectBuildUnitIds))
-      const projectChannelIds = new Set(projectChannels.map(c => c.id))
-      channelIds = channelIds.filter(id => projectChannelIds.has(id))
-    } else {
-      channelIds = []
-    }
-  }
+  const channelIds = (url.searchParams.get(`member_channel_ids`) ?? ``).split(`,`).filter(id => UUID_REGEX.test(id))
 
   const originUrl = prepareElectricUrl(request.url)
   originUrl.searchParams.set(`table`, `messages`)

--- a/web-app/code/src/presentation/routes/api/messages.ts
+++ b/web-app/code/src/presentation/routes/api/messages.ts
@@ -2,8 +2,8 @@ import { createFileRoute } from "@tanstack/react-router"
 import { auth } from "../../../infrastructure/auth/server"
 import { prepareElectricUrl, proxyElectricRequest } from "../../../infrastructure/database/electric-proxy"
 import { db } from "../../../infrastructure/database/connection"
-import { membershipTable, channelsTable, buildUnitsTable } from "../../../infrastructure/database/schema/admin-schema"
-import { eq, and, inArray } from "drizzle-orm"
+import { channelsTable, buildUnitsTable } from "../../../infrastructure/database/schema/admin-schema"
+import { eq, inArray } from "drizzle-orm"
 
 const UUID_REGEX = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i
 
@@ -16,29 +16,17 @@ const serve = async ({ request }: { request: Request }) => {
     })
   }
 
-  const [memberships, ownedChannels] = await Promise.all([
-    db
-      .select({ channel_id: membershipTable.channel_id })
-      .from(membershipTable)
-      .where(and(
-        eq(membershipTable.user_id, session.user.id),
-        eq(membershipTable.member_flag, true)
-      )),
-    db
-      .select({ id: channelsTable.id })
-      .from(channelsTable)
-      .where(eq(channelsTable.owner_id, session.user.id)),
-  ])
+  const url = new URL(request.url)
+  const memberChannelIds = (url.searchParams.get(`member_channel_ids`) ?? ``).split(`,`).filter(id => UUID_REGEX.test(id))
 
-  let channelIds = [...new Set([
-    ...memberships.map(m => m.channel_id),
-    ...ownedChannels.map(c => c.id),
-  ])]
-  if (channelIds.length === 0) {
-    return new Response(`[]`, { status: 200, headers: { "content-type": "application/json" } })
-  }
+  const ownedChannels = await db
+    .select({ id: channelsTable.id })
+    .from(channelsTable)
+    .where(eq(channelsTable.owner_id, session.user.id))
 
-  const projectId = new URL(request.url).searchParams.get(`project_id`)
+  let channelIds = [...new Set([...memberChannelIds, ...ownedChannels.map(c => c.id)])]
+
+  const projectId = url.searchParams.get(`project_id`)
   if (projectId && UUID_REGEX.test(projectId)) {
     const projectBuildUnits = await db
       .select({ id: buildUnitsTable.id })
@@ -57,13 +45,14 @@ const serve = async ({ request }: { request: Request }) => {
     }
   }
 
-  if (channelIds.length === 0) {
-    return new Response(`[]`, { status: 200, headers: { "content-type": "application/json" } })
-  }
-
   const originUrl = prepareElectricUrl(request.url)
   originUrl.searchParams.set(`table`, `messages`)
-  originUrl.searchParams.set(`where`, `channel_id = ANY(ARRAY[${channelIds.map(id => `'${id}'`).join(`,`)}]::text[])`)
+  originUrl.searchParams.set(
+    `where`,
+    channelIds.length === 0
+      ? `1 = 0`
+      : `channel_id = ANY(ARRAY[${channelIds.map(id => `'${id}'`).join(`,`)}]::text[])`
+  )
 
   return proxyElectricRequest(originUrl)
 }

--- a/web-app/code/src/presentation/routes/api/projects.ts
+++ b/web-app/code/src/presentation/routes/api/projects.ts
@@ -1,9 +1,8 @@
 import { createFileRoute } from "@tanstack/react-router"
 import { auth } from "../../../infrastructure/auth/server"
 import { prepareElectricUrl, proxyElectricRequest } from "../../../infrastructure/database/electric-proxy"
-import { db } from "../../../infrastructure/database/connection"
-import { membershipTable, projectsTable } from "../../../infrastructure/database/schema/admin-schema"
-import { eq, and } from "drizzle-orm"
+
+const UUID_REGEX = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i
 
 const serve = async ({ request }: { request: Request }) => {
   const session = await auth.api.getSession({ headers: request.headers })
@@ -14,31 +13,19 @@ const serve = async ({ request }: { request: Request }) => {
     })
   }
 
-  const [memberships, ownedProjects] = await Promise.all([
-    db
-      .select({ project_id: membershipTable.project_id })
-      .from(membershipTable)
-      .where(and(
-        eq(membershipTable.user_id, session.user.id),
-        eq(membershipTable.member_flag, true)
-      )),
-    db
-      .select({ id: projectsTable.id })
-      .from(projectsTable)
-      .where(eq(projectsTable.owner_id, session.user.id)),
-  ])
-
-  const projectIds = [...new Set([
-    ...memberships.map(m => m.project_id),
-    ...ownedProjects.map(p => p.id),
-  ])]
-  if (projectIds.length === 0) {
-    return new Response(`[]`, { status: 200, headers: { "content-type": "application/json" } })
-  }
+  // Membership-derived IDs come from the client (via Electric-synced memberships)
+  const url = new URL(request.url)
+  const memberIds = (url.searchParams.get(`member_ids`) ?? ``).split(`,`).filter(id => UUID_REGEX.test(id))
 
   const originUrl = prepareElectricUrl(request.url)
   originUrl.searchParams.set(`table`, `projects`)
-  originUrl.searchParams.set(`where`, `id = ANY(ARRAY[${projectIds.map(id => `'${id}'`).join(`,`)}]::text[])`)
+
+  const parts: string[] = []
+  if (memberIds.length > 0) {
+    parts.push(`id = ANY(ARRAY[${memberIds.map(id => `'${id}'`).join(`,`)}]::text[])`)
+  }
+  parts.push(`owner_id = '${session.user.id}'`)
+  originUrl.searchParams.set(`where`, parts.join(` OR `))
 
   return proxyElectricRequest(originUrl)
 }

--- a/web-app/code/src/presentation/routes/api/properties.ts
+++ b/web-app/code/src/presentation/routes/api/properties.ts
@@ -2,8 +2,10 @@ import { createFileRoute } from "@tanstack/react-router"
 import { auth } from "../../../infrastructure/auth/server"
 import { prepareElectricUrl, proxyElectricRequest } from "../../../infrastructure/database/electric-proxy"
 import { db } from "../../../infrastructure/database/connection"
-import { membershipTable, tasksTable, projectsTable, buildUnitsTable, channelsTable } from "../../../infrastructure/database/schema/admin-schema"
-import { eq, and, inArray } from "drizzle-orm"
+import { tasksTable, projectsTable, buildUnitsTable, channelsTable } from "../../../infrastructure/database/schema/admin-schema"
+import { eq, inArray } from "drizzle-orm"
+
+const UUID_REGEX = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i
 
 const serve = async ({ request }: { request: Request }) => {
   const session = await auth.api.getSession({ headers: request.headers })
@@ -14,30 +16,21 @@ const serve = async ({ request }: { request: Request }) => {
     })
   }
 
-  const [memberships, ownedProjects, ownedBuildUnits, ownedChannels] = await Promise.all([
-    db
-      .select({
-        channel_id: membershipTable.channel_id,
-        buildunit_id: membershipTable.buildunit_id,
-        project_id: membershipTable.project_id,
-      })
-      .from(membershipTable)
-      .where(and(
-        eq(membershipTable.user_id, session.user.id),
-        eq(membershipTable.member_flag, true)
-      )),
+  const url = new URL(request.url)
+  const memberProjectIds = (url.searchParams.get(`member_project_ids`) ?? ``).split(`,`).filter(id => UUID_REGEX.test(id))
+  const memberBuildunitIds = (url.searchParams.get(`member_buildunit_ids`) ?? ``).split(`,`).filter(id => UUID_REGEX.test(id))
+  const memberChannelIds = (url.searchParams.get(`member_channel_ids`) ?? ``).split(`,`).filter(id => UUID_REGEX.test(id))
+
+  // Include owned entities not captured by memberships
+  const [ownedProjects, ownedBuildUnits, ownedChannels] = await Promise.all([
     db.select({ id: projectsTable.id }).from(projectsTable).where(eq(projectsTable.owner_id, session.user.id)),
     db.select({ id: buildUnitsTable.id }).from(buildUnitsTable).where(eq(buildUnitsTable.owner_id, session.user.id)),
     db.select({ id: channelsTable.id }).from(channelsTable).where(eq(channelsTable.owner_id, session.user.id)),
   ])
 
-  const channelIds = [...new Set([...memberships.map(m => m.channel_id), ...ownedChannels.map(c => c.id)])]
-  const buildunitIds = [...new Set([...memberships.map(m => m.buildunit_id), ...ownedBuildUnits.map(b => b.id)])]
-  const projectIds = [...new Set([...memberships.map(m => m.project_id), ...ownedProjects.map(p => p.id)])]
-
-  if (channelIds.length === 0 && buildunitIds.length === 0 && projectIds.length === 0) {
-    return new Response(`[]`, { status: 200, headers: { "content-type": "application/json" } })
-  }
+  const channelIds = [...new Set([...memberChannelIds, ...ownedChannels.map(c => c.id)])]
+  const buildunitIds = [...new Set([...memberBuildunitIds, ...ownedBuildUnits.map(b => b.id)])]
+  const projectIds = [...new Set([...memberProjectIds, ...ownedProjects.map(p => p.id)])]
 
   // Also include task IDs for task-level properties
   const tasks = channelIds.length > 0
@@ -45,12 +38,16 @@ const serve = async ({ request }: { request: Request }) => {
     : []
 
   const taskIds = tasks.map(t => t.id)
-
-  const allIds = [...projectIds, ...buildunitIds, ...channelIds, ...taskIds]
+  const allIds = [...new Set([...projectIds, ...buildunitIds, ...channelIds, ...taskIds])]
 
   const originUrl = prepareElectricUrl(request.url)
   originUrl.searchParams.set(`table`, `properties`)
-  originUrl.searchParams.set(`where`, `entity_id = ANY(ARRAY[${allIds.map(id => `'${id}'`).join(`,`)}]::text[])`)
+  originUrl.searchParams.set(
+    `where`,
+    allIds.length === 0
+      ? `1 = 0`
+      : `entity_id = ANY(ARRAY[${allIds.map(id => `'${id}'`).join(`,`)}]::text[])`
+  )
 
   return proxyElectricRequest(originUrl)
 }

--- a/web-app/code/src/presentation/routes/api/properties.ts
+++ b/web-app/code/src/presentation/routes/api/properties.ts
@@ -1,9 +1,6 @@
 import { createFileRoute } from "@tanstack/react-router"
 import { auth } from "../../../infrastructure/auth/server"
 import { prepareElectricUrl, proxyElectricRequest } from "../../../infrastructure/database/electric-proxy"
-import { db } from "../../../infrastructure/database/connection"
-import { tasksTable, projectsTable, buildUnitsTable, channelsTable } from "../../../infrastructure/database/schema/admin-schema"
-import { eq, inArray } from "drizzle-orm"
 
 const UUID_REGEX = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i
 
@@ -17,27 +14,11 @@ const serve = async ({ request }: { request: Request }) => {
   }
 
   const url = new URL(request.url)
-  const memberProjectIds = (url.searchParams.get(`member_project_ids`) ?? ``).split(`,`).filter(id => UUID_REGEX.test(id))
-  const memberBuildunitIds = (url.searchParams.get(`member_buildunit_ids`) ?? ``).split(`,`).filter(id => UUID_REGEX.test(id))
-  const memberChannelIds = (url.searchParams.get(`member_channel_ids`) ?? ``).split(`,`).filter(id => UUID_REGEX.test(id))
+  const projectIds = (url.searchParams.get(`member_project_ids`) ?? ``).split(`,`).filter(id => UUID_REGEX.test(id))
+  const buildunitIds = (url.searchParams.get(`member_buildunit_ids`) ?? ``).split(`,`).filter(id => UUID_REGEX.test(id))
+  const channelIds = (url.searchParams.get(`member_channel_ids`) ?? ``).split(`,`).filter(id => UUID_REGEX.test(id))
+  const taskIds = (url.searchParams.get(`member_task_ids`) ?? ``).split(`,`).filter(id => UUID_REGEX.test(id))
 
-  // Include owned entities not captured by memberships
-  const [ownedProjects, ownedBuildUnits, ownedChannels] = await Promise.all([
-    db.select({ id: projectsTable.id }).from(projectsTable).where(eq(projectsTable.owner_id, session.user.id)),
-    db.select({ id: buildUnitsTable.id }).from(buildUnitsTable).where(eq(buildUnitsTable.owner_id, session.user.id)),
-    db.select({ id: channelsTable.id }).from(channelsTable).where(eq(channelsTable.owner_id, session.user.id)),
-  ])
-
-  const channelIds = [...new Set([...memberChannelIds, ...ownedChannels.map(c => c.id)])]
-  const buildunitIds = [...new Set([...memberBuildunitIds, ...ownedBuildUnits.map(b => b.id)])]
-  const projectIds = [...new Set([...memberProjectIds, ...ownedProjects.map(p => p.id)])]
-
-  // Also include task IDs for task-level properties
-  const tasks = channelIds.length > 0
-    ? await db.select({ id: tasksTable.id }).from(tasksTable).where(inArray(tasksTable.channel_id, channelIds))
-    : []
-
-  const taskIds = tasks.map(t => t.id)
   const allIds = [...new Set([...projectIds, ...buildunitIds, ...channelIds, ...taskIds])]
 
   const originUrl = prepareElectricUrl(request.url)

--- a/web-app/code/src/presentation/routes/api/resources.ts
+++ b/web-app/code/src/presentation/routes/api/resources.ts
@@ -1,9 +1,6 @@
 import { createFileRoute } from "@tanstack/react-router"
 import { auth } from "../../../infrastructure/auth/server"
 import { prepareElectricUrl, proxyElectricRequest } from "../../../infrastructure/database/electric-proxy"
-import { db } from "../../../infrastructure/database/connection"
-import { channelsTable, buildUnitsTable } from "../../../infrastructure/database/schema/admin-schema"
-import { eq, inArray } from "drizzle-orm"
 
 const UUID_REGEX = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i
 
@@ -17,33 +14,7 @@ const serve = async ({ request }: { request: Request }) => {
   }
 
   const url = new URL(request.url)
-  const memberChannelIds = (url.searchParams.get(`member_channel_ids`) ?? ``).split(`,`).filter(id => UUID_REGEX.test(id))
-
-  const ownedChannels = await db
-    .select({ id: channelsTable.id })
-    .from(channelsTable)
-    .where(eq(channelsTable.owner_id, session.user.id))
-
-  let channelIds = [...new Set([...memberChannelIds, ...ownedChannels.map(c => c.id)])]
-
-  const projectId = url.searchParams.get(`project_id`)
-  if (projectId && UUID_REGEX.test(projectId)) {
-    const projectBuildUnits = await db
-      .select({ id: buildUnitsTable.id })
-      .from(buildUnitsTable)
-      .where(eq(buildUnitsTable.project_id, projectId))
-    const projectBuildUnitIds = projectBuildUnits.map(b => b.id)
-    if (projectBuildUnitIds.length > 0) {
-      const projectChannels = await db
-        .select({ id: channelsTable.id })
-        .from(channelsTable)
-        .where(inArray(channelsTable.buildunit_id, projectBuildUnitIds))
-      const projectChannelIds = new Set(projectChannels.map(c => c.id))
-      channelIds = channelIds.filter(id => projectChannelIds.has(id))
-    } else {
-      channelIds = []
-    }
-  }
+  const channelIds = (url.searchParams.get(`member_channel_ids`) ?? ``).split(`,`).filter(id => UUID_REGEX.test(id))
 
   const originUrl = prepareElectricUrl(request.url)
   originUrl.searchParams.set(`table`, `resources`)

--- a/web-app/code/src/presentation/routes/api/resources.ts
+++ b/web-app/code/src/presentation/routes/api/resources.ts
@@ -2,8 +2,8 @@ import { createFileRoute } from "@tanstack/react-router"
 import { auth } from "../../../infrastructure/auth/server"
 import { prepareElectricUrl, proxyElectricRequest } from "../../../infrastructure/database/electric-proxy"
 import { db } from "../../../infrastructure/database/connection"
-import { membershipTable, channelsTable, buildUnitsTable } from "../../../infrastructure/database/schema/admin-schema"
-import { eq, and, inArray } from "drizzle-orm"
+import { channelsTable, buildUnitsTable } from "../../../infrastructure/database/schema/admin-schema"
+import { eq, inArray } from "drizzle-orm"
 
 const UUID_REGEX = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i
 
@@ -16,29 +16,17 @@ const serve = async ({ request }: { request: Request }) => {
     })
   }
 
-  const [memberships, ownedChannels] = await Promise.all([
-    db
-      .select({ channel_id: membershipTable.channel_id })
-      .from(membershipTable)
-      .where(and(
-        eq(membershipTable.user_id, session.user.id),
-        eq(membershipTable.member_flag, true)
-      )),
-    db
-      .select({ id: channelsTable.id })
-      .from(channelsTable)
-      .where(eq(channelsTable.owner_id, session.user.id)),
-  ])
+  const url = new URL(request.url)
+  const memberChannelIds = (url.searchParams.get(`member_channel_ids`) ?? ``).split(`,`).filter(id => UUID_REGEX.test(id))
 
-  let channelIds = [...new Set([
-    ...memberships.map(m => m.channel_id),
-    ...ownedChannels.map(c => c.id),
-  ])]
-  if (channelIds.length === 0) {
-    return new Response(`[]`, { status: 200, headers: { "content-type": "application/json" } })
-  }
+  const ownedChannels = await db
+    .select({ id: channelsTable.id })
+    .from(channelsTable)
+    .where(eq(channelsTable.owner_id, session.user.id))
 
-  const projectId = new URL(request.url).searchParams.get(`project_id`)
+  let channelIds = [...new Set([...memberChannelIds, ...ownedChannels.map(c => c.id)])]
+
+  const projectId = url.searchParams.get(`project_id`)
   if (projectId && UUID_REGEX.test(projectId)) {
     const projectBuildUnits = await db
       .select({ id: buildUnitsTable.id })
@@ -57,13 +45,14 @@ const serve = async ({ request }: { request: Request }) => {
     }
   }
 
-  if (channelIds.length === 0) {
-    return new Response(`[]`, { status: 200, headers: { "content-type": "application/json" } })
-  }
-
   const originUrl = prepareElectricUrl(request.url)
   originUrl.searchParams.set(`table`, `resources`)
-  originUrl.searchParams.set(`where`, `channel_id = ANY(ARRAY[${channelIds.map(id => `'${id}'`).join(`,`)}]::text[])`)
+  originUrl.searchParams.set(
+    `where`,
+    channelIds.length === 0
+      ? `1 = 0`
+      : `channel_id = ANY(ARRAY[${channelIds.map(id => `'${id}'`).join(`,`)}]::text[])`
+  )
 
   return proxyElectricRequest(originUrl)
 }

--- a/web-app/code/src/presentation/routes/api/tasks.ts
+++ b/web-app/code/src/presentation/routes/api/tasks.ts
@@ -2,8 +2,8 @@ import { createFileRoute } from "@tanstack/react-router"
 import { auth } from "../../../infrastructure/auth/server"
 import { prepareElectricUrl, proxyElectricRequest } from "../../../infrastructure/database/electric-proxy"
 import { db } from "../../../infrastructure/database/connection"
-import { membershipTable, channelsTable, buildUnitsTable } from "../../../infrastructure/database/schema/admin-schema"
-import { eq, and, inArray } from "drizzle-orm"
+import { channelsTable, buildUnitsTable } from "../../../infrastructure/database/schema/admin-schema"
+import { eq, inArray } from "drizzle-orm"
 
 const UUID_REGEX = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i
 
@@ -16,29 +16,19 @@ const serve = async ({ request }: { request: Request }) => {
     })
   }
 
-  const [memberships, ownedChannels] = await Promise.all([
-    db
-      .select({ channel_id: membershipTable.channel_id })
-      .from(membershipTable)
-      .where(and(
-        eq(membershipTable.user_id, session.user.id),
-        eq(membershipTable.member_flag, true)
-      )),
-    db
-      .select({ id: channelsTable.id })
-      .from(channelsTable)
-      .where(eq(channelsTable.owner_id, session.user.id)),
-  ])
+  const url = new URL(request.url)
+  const memberChannelIds = (url.searchParams.get(`member_channel_ids`) ?? ``).split(`,`).filter(id => UUID_REGEX.test(id))
 
-  let channelIds = [...new Set([
-    ...memberships.map(m => m.channel_id),
-    ...ownedChannels.map(c => c.id),
-  ])]
-  if (channelIds.length === 0) {
-    return new Response(`[]`, { status: 200, headers: { "content-type": "application/json" } })
-  }
+  // Include channels the user owns (not captured by memberships)
+  const ownedChannels = await db
+    .select({ id: channelsTable.id })
+    .from(channelsTable)
+    .where(eq(channelsTable.owner_id, session.user.id))
 
-  const projectId = new URL(request.url).searchParams.get(`project_id`)
+  let channelIds = [...new Set([...memberChannelIds, ...ownedChannels.map(c => c.id)])]
+
+  // Optional project_id filter
+  const projectId = url.searchParams.get(`project_id`)
   if (projectId && UUID_REGEX.test(projectId)) {
     const projectBuildUnits = await db
       .select({ id: buildUnitsTable.id })
@@ -57,13 +47,14 @@ const serve = async ({ request }: { request: Request }) => {
     }
   }
 
-  if (channelIds.length === 0) {
-    return new Response(`[]`, { status: 200, headers: { "content-type": "application/json" } })
-  }
-
   const originUrl = prepareElectricUrl(request.url)
   originUrl.searchParams.set(`table`, `tasks`)
-  originUrl.searchParams.set(`where`, `channel_id = ANY(ARRAY[${channelIds.map(id => `'${id}'`).join(`,`)}]::text[])`)
+  originUrl.searchParams.set(
+    `where`,
+    channelIds.length === 0
+      ? `1 = 0`
+      : `channel_id = ANY(ARRAY[${channelIds.map(id => `'${id}'`).join(`,`)}]::text[])`
+  )
 
   return proxyElectricRequest(originUrl)
 }

--- a/web-app/code/src/presentation/routes/api/tasks.ts
+++ b/web-app/code/src/presentation/routes/api/tasks.ts
@@ -1,9 +1,6 @@
 import { createFileRoute } from "@tanstack/react-router"
 import { auth } from "../../../infrastructure/auth/server"
 import { prepareElectricUrl, proxyElectricRequest } from "../../../infrastructure/database/electric-proxy"
-import { db } from "../../../infrastructure/database/connection"
-import { channelsTable, buildUnitsTable } from "../../../infrastructure/database/schema/admin-schema"
-import { eq, inArray } from "drizzle-orm"
 
 const UUID_REGEX = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i
 
@@ -17,35 +14,7 @@ const serve = async ({ request }: { request: Request }) => {
   }
 
   const url = new URL(request.url)
-  const memberChannelIds = (url.searchParams.get(`member_channel_ids`) ?? ``).split(`,`).filter(id => UUID_REGEX.test(id))
-
-  // Include channels the user owns (not captured by memberships)
-  const ownedChannels = await db
-    .select({ id: channelsTable.id })
-    .from(channelsTable)
-    .where(eq(channelsTable.owner_id, session.user.id))
-
-  let channelIds = [...new Set([...memberChannelIds, ...ownedChannels.map(c => c.id)])]
-
-  // Optional project_id filter
-  const projectId = url.searchParams.get(`project_id`)
-  if (projectId && UUID_REGEX.test(projectId)) {
-    const projectBuildUnits = await db
-      .select({ id: buildUnitsTable.id })
-      .from(buildUnitsTable)
-      .where(eq(buildUnitsTable.project_id, projectId))
-    const projectBuildUnitIds = projectBuildUnits.map(b => b.id)
-    if (projectBuildUnitIds.length > 0) {
-      const projectChannels = await db
-        .select({ id: channelsTable.id })
-        .from(channelsTable)
-        .where(inArray(channelsTable.buildunit_id, projectBuildUnitIds))
-      const projectChannelIds = new Set(projectChannels.map(c => c.id))
-      channelIds = channelIds.filter(id => projectChannelIds.has(id))
-    } else {
-      channelIds = []
-    }
-  }
+  const channelIds = (url.searchParams.get(`member_channel_ids`) ?? ``).split(`,`).filter(id => UUID_REGEX.test(id))
 
   const originUrl = prepareElectricUrl(request.url)
   originUrl.searchParams.set(`table`, `tasks`)


### PR DESCRIPTION
## Summary
- Makes all Electric shape proxy routes pure URL-to-where translators: membership-derived IDs (`member_project_ids`, `member_buildunit_ids`, `member_channel_ids`, `member_task_ids`) are supplied by the client, so handlers no longer run per-poll DB lookups for owned entities or project-scoped filtering.
- Tasks are preloaded before `propertiesCollection` is initialized, so the properties shape URL can bake in task IDs and skip the old server-side `tasksTable` scan.
- Moves collection initialization from `_authenticated.loader` into `_authenticated.beforeLoad`. Child route loaders run in parallel with the parent's loader, and deep-link URL pastes were racing them against still-null collection assignments (`null.preload()`); `beforeLoad` is sequential parent-before-child, which eliminates the race.

## Test plan
- [ ] Paste a deep channel/task URL in a fresh tab — loads without "cannot access property preload of null".
- [ ] Hard reload `/inbox`, `/my-tasks`, a project root, a channel page, and a task detail page — all render without regressions.
- [ ] Create a task and a property on it in the same session — confirm optimistic UI still resolves (note: new tasks created after load won't have their properties stream until reload; this is the accepted Option-A tradeoff).
- [ ] Verify no server-side DB queries fire per shape poll for tasks/messages/properties/resources/channels (check server logs / `db` query counter).

🤖 Generated with [Claude Code](https://claude.com/claude-code)