### PR TITLE
feat(web): wipe OPFS cache on sign-out via signOutAndDispose

### DIFF
--- a/web-app/code/src/infrastructure/auth/client.ts
+++ b/web-app/code/src/infrastructure/auth/client.ts
@@ -1,5 +1,6 @@
 import { createAuthClient } from "better-auth/react"
 import { emailOTPClient } from "better-auth/client/plugins"
+import { disposePersistence } from "../persistence/browser-persistence"
 
 /**
  * Better Auth Client Configuration
@@ -31,6 +32,14 @@ export const {
   listSessions,
   useSession,
 } = authClient
+
+// Wraps better-auth signOut to also wipe the OPFS persistence cache, so the
+// next user logging in on the same browser does not see the previous user's
+// cached rows on first paint.
+export async function signOutAndDispose(): Promise<void> {
+  await authClient.signOut()
+  await disposePersistence()
+}
 
 // Type exports for use in components
 export type Session = typeof authClient.$Infer.Session

--- a/web-app/code/src/presentation/components/buildInlime/admin/UserInfo.tsx
+++ b/web-app/code/src/presentation/components/buildInlime/admin/UserInfo.tsx
@@ -1,6 +1,6 @@
 import { useState } from "react";
 import { ChevronDown, Settings, LogOut } from "lucide-react";
-import { authClient } from "%/infrastructure/auth/client";
+import { signOutAndDispose } from "%/infrastructure/auth/client";
 
 interface UserInfoProps {
   initials: string;
@@ -11,7 +11,7 @@ export function UserInfo({ initials, name }: UserInfoProps) {
   const [userMenuOpen, setUserMenuOpen] = useState(false);
 
   const handleLogout = async () => {
-    await authClient.signOut();
+    await signOutAndDispose();
     // Hard redirect clears all in-memory Electric collection state,
     // preventing stale data from leaking to the next user.
     window.location.href = "/login";

--- a/web-app/code/src/presentation/pages/LandingPage.tsx
+++ b/web-app/code/src/presentation/pages/LandingPage.tsx
@@ -1,6 +1,6 @@
 import { Header, Hero, FeaturesCarousel, Footer } from "../components/buildInlime";
 import { HeaderLoggedIn } from "../components/buildInlime";
-import { authClient, useRequireAuth } from "../../infrastructure/auth/client";
+import { signOutAndDispose, useRequireAuth } from "../../infrastructure/auth/client";
 
 export default function LandingPage() {
   const { user } = useRequireAuth();
@@ -8,7 +8,7 @@ export default function LandingPage() {
   const notLoggedIn = !user;
 
   const handleSignOut = async () => {
-    await authClient.signOut();
+    await signOutAndDispose();
     window.location.href = "/";
   };
 


### PR DESCRIPTION
## Summary
- Add `signOutAndDispose()` to the auth client that calls better-auth `signOut` and then disposes the OPFS persistence trio, so the next user logging in on the same browser does not see the previous user's cached rows on first paint.
- Switch `UserInfo` and `LandingPage` logout handlers to the new helper.

## Test plan
- [ ] Sign in as user A, sign out via the user menu, sign in as user B on the same browser, verify the first paint shows no rows from user A.
- [ ] Same flow from the landing page logout button.
- [ ] Confirm OPFS file is removed (DevTools → Application → Storage → File System) after sign-out.

🤖 Generated with [Claude Code](https://claude.com/claude-code)