### PR TITLE
feat(web): offline-transactions for build-units, channels, and attachment retry

### DIFF
--- a/web-app/code/src/application/actions/buildunits.ts
+++ b/web-app/code/src/application/actions/buildunits.ts
@@ -1,0 +1,81 @@
+import type { Transaction } from "@tanstack/db"
+import { buildUnitsCollection } from "%/application/collections/organization"
+import { getOfflineExecutor } from "%/infrastructure/offline/executor"
+
+export type CreateBuildUnitInput = {
+  id: string
+  name: string
+  description: string
+  project_id: string
+  owner_id: string
+}
+
+export type UpdateBuildUnitInput = {
+  id: string
+  patch: {
+    name?: string
+    description?: string | null
+  }
+}
+
+export type DeleteBuildUnitInput = { id: string }
+
+let _create: ((v: CreateBuildUnitInput) => Transaction) | null = null
+let _update: ((v: UpdateBuildUnitInput) => Transaction) | null = null
+let _delete: ((v: DeleteBuildUnitInput) => Transaction) | null = null
+
+function createBuildUnitFn() {
+  if (_create) return _create
+  _create = getOfflineExecutor().createOfflineAction<CreateBuildUnitInput>({
+    mutationFnName: `createBuildUnit`,
+    onMutate: (v: CreateBuildUnitInput) => {
+      buildUnitsCollection.insert({
+        id: v.id,
+        name: v.name,
+        description: v.description,
+        project_id: v.project_id,
+        owner_id: v.owner_id,
+        created_at: new Date(),
+      })
+    },
+  })
+  return _create
+}
+
+function updateBuildUnitFn() {
+  if (_update) return _update
+  _update = getOfflineExecutor().createOfflineAction<UpdateBuildUnitInput>({
+    mutationFnName: `updateBuildUnit`,
+    onMutate: (v: UpdateBuildUnitInput) => {
+      buildUnitsCollection.update(v.id, (b: Record<string, unknown>) => {
+        if (v.patch.name !== undefined) b.name = v.patch.name
+        if (v.patch.description !== undefined) b.description = v.patch.description
+      })
+    },
+  })
+  return _update
+}
+
+function deleteBuildUnitFn() {
+  if (_delete) return _delete
+  _delete = getOfflineExecutor().createOfflineAction<DeleteBuildUnitInput>({
+    mutationFnName: `deleteBuildUnit`,
+    onMutate: (v: DeleteBuildUnitInput) => {
+      buildUnitsCollection.delete(v.id)
+    },
+  })
+  return _delete
+}
+
+export const createBuildUnitAction = (input: CreateBuildUnitInput): Transaction =>
+  createBuildUnitFn()!(input)
+export const updateBuildUnitAction = (input: UpdateBuildUnitInput): Transaction =>
+  updateBuildUnitFn()!(input)
+export const deleteBuildUnitAction = (input: DeleteBuildUnitInput): Transaction =>
+  deleteBuildUnitFn()!(input)
+
+export function resetBuildUnitActions(): void {
+  _create = null
+  _update = null
+  _delete = null
+}

--- a/web-app/code/src/application/actions/channels.ts
+++ b/web-app/code/src/application/actions/channels.ts
@@ -1,0 +1,82 @@
+import type { Transaction } from "@tanstack/db"
+import { channelsCollection } from "%/application/collections/organization"
+import { getOfflineExecutor } from "%/infrastructure/offline/executor"
+import type { ChannelName } from "%/infrastructure/database/schema/admin-schema"
+
+export type CreateChannelInput = {
+  id: string
+  name: ChannelName
+  description: string
+  buildunit_id: string
+  owner_id: string
+}
+
+export type UpdateChannelInput = {
+  id: string
+  patch: {
+    name?: ChannelName
+    description?: string | null
+  }
+}
+
+export type DeleteChannelInput = { id: string }
+
+let _create: ((v: CreateChannelInput) => Transaction) | null = null
+let _update: ((v: UpdateChannelInput) => Transaction) | null = null
+let _delete: ((v: DeleteChannelInput) => Transaction) | null = null
+
+function createChannelFn() {
+  if (_create) return _create
+  _create = getOfflineExecutor().createOfflineAction<CreateChannelInput>({
+    mutationFnName: `createChannel`,
+    onMutate: (v: CreateChannelInput) => {
+      channelsCollection.insert({
+        id: v.id,
+        name: v.name,
+        description: v.description,
+        buildunit_id: v.buildunit_id,
+        owner_id: v.owner_id,
+        created_at: new Date(),
+      })
+    },
+  })
+  return _create
+}
+
+function updateChannelFn() {
+  if (_update) return _update
+  _update = getOfflineExecutor().createOfflineAction<UpdateChannelInput>({
+    mutationFnName: `updateChannel`,
+    onMutate: (v: UpdateChannelInput) => {
+      channelsCollection.update(v.id, (c: Record<string, unknown>) => {
+        if (v.patch.name !== undefined) c.name = v.patch.name
+        if (v.patch.description !== undefined) c.description = v.patch.description
+      })
+    },
+  })
+  return _update
+}
+
+function deleteChannelFn() {
+  if (_delete) return _delete
+  _delete = getOfflineExecutor().createOfflineAction<DeleteChannelInput>({
+    mutationFnName: `deleteChannel`,
+    onMutate: (v: DeleteChannelInput) => {
+      channelsCollection.delete(v.id)
+    },
+  })
+  return _delete
+}
+
+export const createChannelAction = (input: CreateChannelInput): Transaction =>
+  createChannelFn()!(input)
+export const updateChannelAction = (input: UpdateChannelInput): Transaction =>
+  updateChannelFn()!(input)
+export const deleteChannelAction = (input: DeleteChannelInput): Transaction =>
+  deleteChannelFn()!(input)
+
+export function resetChannelActions(): void {
+  _create = null
+  _update = null
+  _delete = null
+}

--- a/web-app/code/src/application/collections/organization.ts
+++ b/web-app/code/src/application/collections/organization.ts
@@ -9,7 +9,6 @@ import {
   selectMembershipSchema,
   MEMBERSHIP_ROLES,
 } from "%/infrastructure/database/schema/admin-schema"
-import { trpc } from "%/infrastructure/trpc/lib/trpc-client"
 import { getPersistence } from "../../infrastructure/persistence/browser-persistence"
 import { retryOnError, coerceBool, origin } from "./_shared"
 
@@ -96,19 +95,6 @@ function _makeProjectsCollection(
   )
 }
 
-// Registry allowing UI components to be notified when a build unit insert
-// completes (success or error) via the onInsert handler below.
-type InsertCallback = { resolve: () => void; reject: (err: Error) => void }
-const _buildUnitInsertCallbacks = new Map<string, InsertCallback>()
-
-export function registerBuildUnitInsertCallback(
-  id: string,
-  resolve: () => void,
-  reject: (err: Error) => void,
-) {
-  _buildUnitInsertCallbacks.set(id, { resolve, reject })
-}
-
 const BUILD_UNITS_SCHEMA_VERSION = 1
 
 function _makeBuildUnitsCollection(
@@ -132,64 +118,14 @@ function _makeBuildUnitsCollection(
         },
         schema: selectBuildUnitSchema,
         getKey: (item) => item.id,
-        onInsert: async ({ transaction }) => {
-          const { modified: newBuildUnit } = transaction.mutations[0]
-          try {
-            const result = await trpc.buildUnits.create.mutate({
-              id: newBuildUnit.id,
-              name: newBuildUnit.name,
-              description: newBuildUnit.description,
-              project_id: newBuildUnit.project_id,
-              owner_id: newBuildUnit.owner_id,
-            })
-            _buildUnitInsertCallbacks.get(newBuildUnit.id)?.resolve()
-            _buildUnitInsertCallbacks.delete(newBuildUnit.id)
-            return { txid: result.txid }
-          } catch (err) {
-            _buildUnitInsertCallbacks.get(newBuildUnit.id)?.reject(err instanceof Error ? err : new Error(String(err)))
-            _buildUnitInsertCallbacks.delete(newBuildUnit.id)
-            throw err
-          }
-        },
-        onUpdate: async ({ transaction }) => {
-          const { modified: updatedBuildUnit } = transaction.mutations[0]
-          const result = await trpc.buildUnits.update.mutate({
-            id: updatedBuildUnit.id,
-            data: {
-              name: updatedBuildUnit.name,
-              description: updatedBuildUnit.description,
-            },
-          })
-
-          return { txid: result.txid }
-        },
-        onDelete: async ({ transaction }) => {
-          const { original: deletedBuildUnit } = transaction.mutations[0]
-          const result = await trpc.buildUnits.delete.mutate({
-            id: deletedBuildUnit.id,
-          })
-
-          return { txid: result.txid }
-        },
+        // Build-unit writes go through @tanstack/offline-transactions —
+        // see application/actions/buildunits.ts.
       }),
       persistence,
       schemaVersion: BUILD_UNITS_SCHEMA_VERSION,
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
     }) as any,
   )
-}
-
-// Registry allowing UI components to be notified when a channel insert
-// completes (success or error) via the onInsert handler below.
-type ChannelInsertCallback = { resolve: () => void; reject: (err: Error) => void }
-const _channelInsertCallbacks = new Map<string, ChannelInsertCallback>()
-
-export function registerChannelInsertCallback(
-  id: string,
-  resolve: () => void,
-  reject: (err: Error) => void,
-) {
-  _channelInsertCallbacks.set(id, { resolve, reject })
 }
 
 const CHANNELS_SCHEMA_VERSION = 1
@@ -215,45 +151,8 @@ function _makeChannelsCollection(
         },
         schema: selectChannelSchema,
         getKey: (item) => item.id,
-        onInsert: async ({ transaction }) => {
-          const { modified: newChannel } = transaction.mutations[0]
-          try {
-            const result = await trpc.channels.create.mutate({
-              id: newChannel.id,
-              name: newChannel.name,
-              description: newChannel.description,
-              buildunit_id: newChannel.buildunit_id,
-              owner_id: newChannel.owner_id,
-            })
-            _channelInsertCallbacks.get(newChannel.id)?.resolve()
-            _channelInsertCallbacks.delete(newChannel.id)
-            return { txid: result.txid }
-          } catch (err) {
-            _channelInsertCallbacks.get(newChannel.id)?.reject(err instanceof Error ? err : new Error(String(err)))
-            _channelInsertCallbacks.delete(newChannel.id)
-            throw err
-          }
-        },
-        onUpdate: async ({ transaction }) => {
-          const { modified: updatedChannel } = transaction.mutations[0]
-          const result = await trpc.channels.update.mutate({
-            id: updatedChannel.id,
-            data: {
-              name: updatedChannel.name,
-              description: updatedChannel.description,
-            },
-          })
-
-          return { txid: result.txid }
-        },
-        onDelete: async ({ transaction }) => {
-          const { original: deletedChannel } = transaction.mutations[0]
-          const result = await trpc.channels.delete.mutate({
-            id: deletedChannel.id,
-          })
-
-          return { txid: result.txid }
-        },
+        // Channel writes go through @tanstack/offline-transactions —
+        // see application/actions/channels.ts.
       }),
       persistence,
       schemaVersion: CHANNELS_SCHEMA_VERSION,

--- a/web-app/code/src/application/hooks/use-pending-resources.ts
+++ b/web-app/code/src/application/hooks/use-pending-resources.ts
@@ -1,7 +1,12 @@
 import { useState, useRef, useCallback, useEffect } from "react"
 import { dbGetAll, dbPut, dbDelete, type StoredResource } from "./pending-resources-db"
 
-export type UploadStatus = "awaiting_schedule" | "scheduled" | "uploading" | "error"
+export type UploadStatus =
+  | "awaiting_schedule"
+  | "scheduled"
+  | "uploading"
+  | "awaiting_network"
+  | "error"
 
 export interface PendingResource {
   id: string
@@ -37,6 +42,8 @@ export function usePendingResources(filterChannelId: string | null, filterTaskId
   const [pending, setPending] = useState<PendingResource[]>([])
   const pendingRef = useRef<PendingResource[]>([])
   const timers = useRef<Map<string, ReturnType<typeof setTimeout>>>(new Map())
+  const retryTimers = useRef<Map<string, ReturnType<typeof setTimeout>>>(new Map())
+  const retryAttempts = useRef<Map<string, number>>(new Map())
   // Stable ref so the hydration effect can call doUpload before it is defined
   const doUploadRef = useRef<(id: string) => Promise<void>>(async () => {})
 
@@ -53,7 +60,27 @@ export function usePendingResources(filterChannelId: string | null, filterTaskId
     return () => {
       pendingRef.current.forEach((r) => URL.revokeObjectURL(r.objectUrl))
       timers.current.forEach((t) => clearTimeout(t))
+      retryTimers.current.forEach((t) => clearTimeout(t))
     }
+  }, [])
+
+  // Auto-retry any errored uploads as soon as the browser reports we're back online.
+  useEffect(() => {
+    const onOnline = () => {
+      pendingRef.current.forEach((r) => {
+        if (r.status === "error" || r.status === "awaiting_network") {
+          retryAttempts.current.set(r.id, 0)
+          const t = retryTimers.current.get(r.id)
+          if (t) {
+            clearTimeout(t)
+            retryTimers.current.delete(r.id)
+          }
+          doUploadRef.current(r.id)
+        }
+      })
+    }
+    window.addEventListener("online", onOnline)
+    return () => window.removeEventListener("online", onOnline)
   }, [])
 
   // Hydrate from IndexedDB on mount
@@ -73,6 +100,15 @@ export function usePendingResources(filterChannelId: string | null, filterTaskId
         if (r.status === "awaiting_schedule" && stored[i].status === "uploading") {
           const { objectUrl: _, ...toStore } = r
           dbPut(toStore as StoredResource)
+        }
+        // Errored / waiting-for-network uploads from a previous session: retry
+        // once on mount if we think we're online; otherwise the `online`
+        // listener will pick them up when connectivity returns.
+        if (
+          (r.status === "error" || r.status === "awaiting_network") &&
+          navigator.onLine
+        ) {
+          doUploadRef.current(r.id)
         }
         // Re-schedule timers for items that were waiting for a future time
         if (r.status === "scheduled" && r.scheduledAt) {
@@ -95,6 +131,15 @@ export function usePendingResources(filterChannelId: string | null, filterTaskId
   const doUpload = useCallback(async (id: string) => {
     const resource = pendingRef.current.find((r) => r.id === id)
     if (!resource) return
+    // Skip if an upload is already in flight for this resource (online-event
+    // retries, multiple mounted hook instances, etc. can all race).
+    if (resource.status === "uploading") return
+
+    const existingRetry = retryTimers.current.get(id)
+    if (existingRetry) {
+      clearTimeout(existingRetry)
+      retryTimers.current.delete(id)
+    }
 
     setPendingSync((prev) =>
       prev.map((r) => (r.id === id ? { ...r, status: "uploading" as UploadStatus } : r))
@@ -133,14 +178,34 @@ export function usePendingResources(filterChannelId: string | null, filterTaskId
         return prev.filter((x) => x.id !== id)
       })
       dbDelete(id)
+      retryAttempts.current.delete(id)
     } catch (err) {
       const message = err instanceof Error ? err.message : "Upload failed"
+      // While offline this isn't really a failure — surface it as a calmer
+      // "waiting for network" state so the user doesn't see a red error for
+      // an upload we're going to retry as soon as connectivity returns.
+      const nextStatus: UploadStatus = navigator.onLine ? "error" : "awaiting_network"
       setPendingSync((prev) =>
         prev.map((r) =>
-          r.id === id ? { ...r, status: "error" as UploadStatus, errorMessage: message } : r
+          r.id === id ? { ...r, status: nextStatus, errorMessage: message } : r
         )
       )
-      dbPut({ ...toStore, status: "error", errorMessage: message } as StoredResource)
+      dbPut({ ...toStore, status: nextStatus, errorMessage: message } as StoredResource)
+
+      // Auto-retry: while offline wait for the `online` event to wake us up;
+      // while online use exponential backoff (covers transient FK races where
+      // the parent message/task hasn't replayed from the outbox yet).
+      const attempt = (retryAttempts.current.get(id) ?? 0) + 1
+      retryAttempts.current.set(id, attempt)
+      const MAX_AUTO_RETRIES = 5
+      if (attempt <= MAX_AUTO_RETRIES && navigator.onLine) {
+        const delay = Math.min(30000, 1000 * 2 ** (attempt - 1))
+        const timer = setTimeout(() => {
+          retryTimers.current.delete(id)
+          doUploadRef.current(id)
+        }, delay)
+        retryTimers.current.set(id, timer)
+      }
     }
   }, [setPendingSync])
 
@@ -224,6 +289,12 @@ export function usePendingResources(filterChannelId: string | null, filterTaskId
       clearTimeout(timer)
       timers.current.delete(id)
     }
+    const retryTimer = retryTimers.current.get(id)
+    if (retryTimer) {
+      clearTimeout(retryTimer)
+      retryTimers.current.delete(id)
+    }
+    retryAttempts.current.delete(id)
     setPendingSync((prev) => {
       const r = prev.find((x) => x.id === id)
       if (r) URL.revokeObjectURL(r.objectUrl)
@@ -234,6 +305,14 @@ export function usePendingResources(filterChannelId: string | null, filterTaskId
 
   const retryUpload = useCallback(
     (id: string) => {
+      // Manual retry resets the auto-backoff counter so the user gets a fresh
+      // sequence if the next attempt also fails.
+      retryAttempts.current.set(id, 0)
+      const retryTimer = retryTimers.current.get(id)
+      if (retryTimer) {
+        clearTimeout(retryTimer)
+        retryTimers.current.delete(id)
+      }
       doUpload(id)
     },
     [doUpload]

--- a/web-app/code/src/infrastructure/auth/client.ts
+++ b/web-app/code/src/infrastructure/auth/client.ts
@@ -8,6 +8,8 @@ import { resetMessageActions } from "../../application/actions/messages"
 import { resetResourceActions } from "../../application/actions/resources"
 import { resetPropertyActions } from "../../application/actions/properties"
 import { resetTeamActions } from "../../application/actions/teams"
+import { resetBuildUnitActions } from "../../application/actions/buildunits"
+import { resetChannelActions } from "../../application/actions/channels"
 
 /**
  * Better Auth Client Configuration
@@ -52,6 +54,8 @@ export async function signOutAndDispose(): Promise<void> {
   resetResourceActions()
   resetPropertyActions()
   resetTeamActions()
+  resetBuildUnitActions()
+  resetChannelActions()
   await disposePersistence()
 }
 

--- a/web-app/code/src/infrastructure/offline/executor.ts
+++ b/web-app/code/src/infrastructure/offline/executor.ts
@@ -6,7 +6,11 @@ import {
   resourcesCollection,
   propertiesCollection,
 } from "%/application/collections/communication"
-import { projectsCollection } from "%/application/collections/organization"
+import {
+  projectsCollection,
+  buildUnitsCollection,
+  channelsCollection,
+} from "%/application/collections/organization"
 import { teamsCollection } from "%/application/collections/admin"
 import { mutationFns } from "./mutation-fns"
 
@@ -22,6 +26,8 @@ export async function initOfflineExecutor(): Promise<OfflineExecutor> {
       resources: resourcesCollection,
       properties: propertiesCollection,
       teams: teamsCollection,
+      buildUnits: buildUnitsCollection,
+      channels: channelsCollection,
     },
     mutationFns,
   })

--- a/web-app/code/src/infrastructure/offline/mutation-fns.ts
+++ b/web-app/code/src/infrastructure/offline/mutation-fns.ts
@@ -20,6 +20,7 @@ const NON_RETRIABLE_TRPC_CODES = new Set([
   "UNAUTHORIZED",
   "FORBIDDEN",
   "NOT_FOUND",
+  "CONFLICT",
   "PRECONDITION_FAILED",
   "PAYLOAD_TOO_LARGE",
   "UNPROCESSABLE_CONTENT",
@@ -208,6 +209,96 @@ const updateTeam: MutationFn = async ({ transaction }) => {
   }
 }
 
+// -------------------- build units --------------------
+
+const createBuildUnit: MutationFn = async ({ transaction }) => {
+  const { modified } = transaction.mutations[0]
+  const b = modified as Record<string, unknown>
+  try {
+    await trpc.buildUnits.create.mutate({
+      id: b.id as string,
+      name: b.name as string,
+      description: (b.description as string | null) ?? null,
+      project_id: b.project_id as string,
+      owner_id: b.owner_id as string,
+    })
+  } catch (err) {
+    wrapTrpcError(err)
+  }
+}
+
+const updateBuildUnit: MutationFn = async ({ transaction }) => {
+  const { modified } = transaction.mutations[0]
+  const b = modified as Record<string, unknown>
+  try {
+    await trpc.buildUnits.update.mutate({
+      id: b.id as string,
+      data: {
+        name: b.name as string,
+        description: (b.description as string | null) ?? null,
+      },
+    })
+  } catch (err) {
+    wrapTrpcError(err)
+  }
+}
+
+const deleteBuildUnit: MutationFn = async ({ transaction }) => {
+  const { original } = transaction.mutations[0]
+  const b = original as Record<string, unknown>
+  try {
+    await trpc.buildUnits.delete.mutate({ id: b.id as string })
+  } catch (err) {
+    wrapTrpcError(err)
+  }
+}
+
+// -------------------- channels --------------------
+
+const createChannel: MutationFn = async ({ transaction }) => {
+  const { modified } = transaction.mutations[0]
+  const c = modified as Record<string, unknown>
+  try {
+    await trpc.channels.create.mutate({
+      id: c.id as string,
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      name: c.name as any,
+      description: (c.description as string | null) ?? null,
+      buildunit_id: c.buildunit_id as string,
+      owner_id: c.owner_id as string,
+    })
+  } catch (err) {
+    wrapTrpcError(err)
+  }
+}
+
+const updateChannel: MutationFn = async ({ transaction }) => {
+  const { modified } = transaction.mutations[0]
+  const c = modified as Record<string, unknown>
+  try {
+    await trpc.channels.update.mutate({
+      id: c.id as string,
+      data: {
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        name: c.name as any,
+        description: (c.description as string | null) ?? null,
+      },
+    })
+  } catch (err) {
+    wrapTrpcError(err)
+  }
+}
+
+const deleteChannel: MutationFn = async ({ transaction }) => {
+  const { original } = transaction.mutations[0]
+  const c = original as Record<string, unknown>
+  try {
+    await trpc.channels.delete.mutate({ id: c.id as string })
+  } catch (err) {
+    wrapTrpcError(err)
+  }
+}
+
 export const mutationFns = {
   // tasks
   createTask,
@@ -225,4 +316,12 @@ export const mutationFns = {
   // teams
   createTeam,
   updateTeam,
+  // build units
+  createBuildUnit,
+  updateBuildUnit,
+  deleteBuildUnit,
+  // channels
+  createChannel,
+  updateChannel,
+  deleteChannel,
 }

--- a/web-app/code/src/infrastructure/storage/fileStorage.ts
+++ b/web-app/code/src/infrastructure/storage/fileStorage.ts
@@ -7,6 +7,7 @@ import {
   resourcesRawTable,
   messagesTable,
   membershipTable,
+  tasksTable,
 } from "%/infrastructure/database/schema/admin-schema"
 import { sql, eq, and } from "drizzle-orm"
 
@@ -69,16 +70,18 @@ export async function handleFileUpload(request: Request): Promise<Response> {
     })
   }
 
-  // If a messageId was supplied, the message is created optimistically on the client
-  // (collection.insert resolves before the onInsert tRPC call completes).
-  // Poll up to 3 seconds for the message to land in the DB before inserting the resource FK.
-  if (messageId) {
-    const deadline = Date.now() + 3000
+  // Parent rows are created optimistically on the client through
+  // @tanstack/offline-transactions; the outbox replay can add several seconds
+  // of latency on top of the tRPC round-trip. Poll up to 15s for the parent.
+  const parentTable = messageId ? messagesTable : taskId ? tasksTable : null
+  const parentId = messageId ?? taskId ?? null
+  if (parentTable && parentId) {
+    const deadline = Date.now() + 15000
     while (Date.now() < deadline) {
       const rows = await db
-        .select({ id: messagesTable.id })
-        .from(messagesTable)
-        .where(eq(messagesTable.id, messageId))
+        .select({ id: parentTable.id })
+        .from(parentTable)
+        .where(eq(parentTable.id, parentId))
         .limit(1)
       if (rows.length > 0) break
       await new Promise((resolve) => setTimeout(resolve, 300))

--- a/web-app/code/src/infrastructure/trpc/routers/buildunits.ts
+++ b/web-app/code/src/infrastructure/trpc/routers/buildunits.ts
@@ -1,7 +1,7 @@
 import { router, authedProcedure, generateTxId } from "../lib/trpc"
 import { z } from "zod"
 import { TRPCError } from "@trpc/server"
-import { eq, and, ilike } from "drizzle-orm"
+import { eq, and, ne, ilike } from "drizzle-orm"
 import {
   buildUnitsTable,
   projectsTable,
@@ -25,13 +25,16 @@ export const buildUnitsRouter = router({
         throw new TRPCError({ code: `FORBIDDEN`, message: `Only project owners can create build units` })
       }
 
-      // Prevent duplicate build unit names within the same project (case-insensitive)
+      // Prevent duplicate build unit names within the same project (case-insensitive).
+      // Exclude the same id so offline-transactions retries (which re-send the
+      // same row id) are not flagged as duplicates of themselves.
       const [duplicate] = await ctx.db
         .select({ id: buildUnitsTable.id })
         .from(buildUnitsTable)
         .where(and(
           eq(buildUnitsTable.project_id, input.project_id),
           ilike(buildUnitsTable.name, input.name),
+          ne(buildUnitsTable.id, input.id),
         ))
       if (duplicate) {
         throw new TRPCError({ code: `CONFLICT`, message: `A build unit named "${input.name}" already exists in this project` })
@@ -39,11 +42,18 @@ export const buildUnitsRouter = router({
 
       const result = await ctx.db.transaction(async (tx) => {
         const txid = await generateTxId(tx)
-        const [newItem] = await tx
+        // ON CONFLICT DO NOTHING — outbox retries become idempotent.
+        const [inserted] = await tx
           .insert(buildUnitsTable)
           .values(input)
+          .onConflictDoNothing()
           .returning()
-        return { item: newItem, txid }
+        if (inserted) return { item: inserted, txid }
+        const [existing] = await tx
+          .select()
+          .from(buildUnitsTable)
+          .where(eq(buildUnitsTable.id, input.id))
+        return { item: existing, txid }
       })
 
       return result

--- a/web-app/code/src/infrastructure/trpc/routers/channels.ts
+++ b/web-app/code/src/infrastructure/trpc/routers/channels.ts
@@ -1,7 +1,7 @@
 import { router, authedProcedure, generateTxId } from "../lib/trpc"
 import { z } from "zod"
 import { TRPCError } from "@trpc/server"
-import { eq, and, sql } from "drizzle-orm"
+import { eq, and, ne, sql } from "drizzle-orm"
 import {
   channelsTable,
   buildUnitsTable,
@@ -34,13 +34,16 @@ export const channelsRouter = router({
         throw new TRPCError({ code: `FORBIDDEN`, message: `Only project owners can create channels` })
       }
 
-      // Prevent duplicate channel names within the same build unit
+      // Prevent duplicate channel names within the same build unit.
+      // Exclude the same id so offline-transactions retries (which re-send the
+      // same row id) are not flagged as duplicates of themselves.
       const [duplicate] = await ctx.db
         .select({ id: channelsTable.id })
         .from(channelsTable)
         .where(and(
           eq(channelsTable.buildunit_id, input.buildunit_id),
-          sql`CAST(${channelsTable.name} AS text) = ${JSON.stringify(input.name)}`
+          sql`CAST(${channelsTable.name} AS text) = ${JSON.stringify(input.name)}`,
+          ne(channelsTable.id, input.id),
         ))
       if (duplicate) {
         throw new TRPCError({ code: `CONFLICT`, message: `A ${input.name} channel already exists in this build unit` })
@@ -48,23 +51,33 @@ export const channelsRouter = router({
 
       const result = await ctx.db.transaction(async (tx) => {
         const txid = await generateTxId(tx)
-        const [newItem] = await tx
+        // ON CONFLICT DO NOTHING — outbox retries become idempotent.
+        const [inserted] = await tx
           .insert(channelsTable)
           .values(input)
+          .onConflictDoNothing()
           .returning()
 
-        // Auto-add the channel owner as a member with role 'owner'
-        await tx.insert(membershipTable).values({
-          id: crypto.randomUUID(),
-          user_id: ctx.session.user.id,
-          channel_id: newItem.id,
-          buildunit_id: input.buildunit_id,
-          project_id: buildUnit.project_id,
-          member_flag: true,
-          role: `owner`,
-        })
+        if (inserted) {
+          // Auto-add the channel owner as a member with role 'owner'.
+          // Only runs on fresh insert; on retry we skip to avoid duplicate memberships.
+          await tx.insert(membershipTable).values({
+            id: crypto.randomUUID(),
+            user_id: ctx.session.user.id,
+            channel_id: inserted.id,
+            buildunit_id: input.buildunit_id,
+            project_id: buildUnit.project_id,
+            member_flag: true,
+            role: `owner`,
+          })
+          return { item: inserted, txid }
+        }
 
-        return { item: newItem, txid }
+        const [existing] = await tx
+          .select()
+          .from(channelsTable)
+          .where(eq(channelsTable.id, input.id))
+        return { item: existing, txid }
       })
 
       return result

--- a/web-app/code/src/presentation/components/buildInlime/communication/CommentsSection.tsx
+++ b/web-app/code/src/presentation/components/buildInlime/communication/CommentsSection.tsx
@@ -167,12 +167,22 @@ function MessageItem({
                 >
                   {r.status === "uploading" ? (
                     <Loader className="w-3 h-3 animate-spin shrink-0" />
+                  ) : r.status === "awaiting_network" ? (
+                    <Loader className="w-3 h-3 animate-spin shrink-0 text-[#976623]" />
                   ) : r.status === "error" ? (
                     mimeIcon(r.file.type, "w-3 h-3 text-red-400")
                   ) : (
                     mimeIcon(r.file.type, "w-3 h-3 text-[#976623]")
                   )}
-                  <span className="max-w-[140px] truncate">{r.name}</span>
+                  <span
+                    className="max-w-[140px] truncate"
+                    title={r.status === "awaiting_network" ? "Will upload when back online" : undefined}
+                  >
+                    {r.name}
+                  </span>
+                  {r.status === "awaiting_network" && (
+                    <span className="text-[#976623] shrink-0">Waiting for network…</span>
+                  )}
                   {r.status === "error" && (
                     <>
                       <span className="text-red-500 shrink-0">Failed</span>

--- a/web-app/code/src/presentation/components/buildInlime/communication/ResourcesSection.tsx
+++ b/web-app/code/src/presentation/components/buildInlime/communication/ResourcesSection.tsx
@@ -119,6 +119,11 @@ export function ResourcesSection({
                 {r.status === "error" && (
                   <p className="text-[10px] text-red-500">{r.errorMessage}</p>
                 )}
+                {r.status === "awaiting_network" && (
+                  <p className="text-[10px] text-[#976623]">
+                    Waiting for network — will upload when back online
+                  </p>
+                )}
                 {r.status === "uploading" && (
                   <p className="text-[10px] text-[#717182]">Uploading…</p>
                 )}

--- a/web-app/code/src/presentation/components/buildInlime/communication/upload-schedule-popover.tsx
+++ b/web-app/code/src/presentation/components/buildInlime/communication/upload-schedule-popover.tsx
@@ -66,8 +66,10 @@ export function UploadSchedulePopover({
     onSchedule(resourceId, scheduled)
   }
 
+  const isBusy = status === "uploading" || status === "awaiting_network"
+
   const triggerIcon = () => {
-    if (status === "uploading") {
+    if (status === "uploading" || status === "awaiting_network") {
       return <Loader2 className="w-3.5 h-3.5 animate-spin text-[#976623]" />
     }
     if (status === "scheduled") {
@@ -81,6 +83,7 @@ export function UploadSchedulePopover({
 
   const triggerTitle = () => {
     if (status === "uploading") return "Uploading…"
+    if (status === "awaiting_network") return "Waiting for network — will upload when back online"
     if (status === "scheduled" && scheduledAt)
       return `Scheduled: ${format(scheduledAt, "MMM d, h:mm a")}`
     if (status === "error") return "Upload failed — click to retry"
@@ -88,11 +91,11 @@ export function UploadSchedulePopover({
   }
 
   return (
-    <Popover.Root open={open} onOpenChange={status === "uploading" ? undefined : setOpen}>
+    <Popover.Root open={open} onOpenChange={isBusy ? undefined : setOpen}>
       <Popover.Trigger asChild>
         <button
           title={triggerTitle()}
-          disabled={status === "uploading"}
+          disabled={isBusy}
           className="p-1 rounded transition-colors hover:bg-[#f0e5d8] disabled:cursor-not-allowed"
         >
           {triggerIcon()}

--- a/web-app/code/src/presentation/components/buildInlime/organization/NewBuildUnitButton.tsx
+++ b/web-app/code/src/presentation/components/buildInlime/organization/NewBuildUnitButton.tsx
@@ -4,14 +4,14 @@ import type { FormEvent } from "react";
 import { useParams } from "@tanstack/react-router";
 import { useLiveQuery, eq } from "@tanstack/react-db";
 import { useSession } from "%/infrastructure/auth/client";
-import { projectsCollection, buildUnitsCollection, registerBuildUnitInsertCallback } from "%/infrastructure/database/tanstack-db-electric/admincollections";
+import { projectsCollection } from "%/infrastructure/database/tanstack-db-electric/admincollections";
+import { createBuildUnitAction } from "%/application/actions/buildunits";
+import type { PendingBuildUnit } from "%/presentation/hooks/use-pending-build-units";
 
 interface NewBuildUnitFormData {
   name: string;
   description: string;
 }
-
-import type { PendingBuildUnit } from "%/presentation/hooks/use-pending-build-units";
 
 interface NewBuildUnitButtonProps {
   addPending: (item: PendingBuildUnit) => void;
@@ -48,7 +48,6 @@ export function NewBuildUnitButton({ addPending, removePending, onTrpcComplete }
       description: formData.description,
       project_id: projectId,
       owner_id: session.user.id,
-      created_at: new Date(),
     };
 
     // Close modal immediately for instant feedback
@@ -56,21 +55,23 @@ export function NewBuildUnitButton({ addPending, removePending, onTrpcComplete }
     setDuplicateError(false);
     setIsPopupOpen(false);
 
-    // Register callback: success is a no-op (ProjectRoute detects Electric sync and
-    // removes the spinner); on error the optimistic insert is rolled back and we
-    // reopen the form so the user can retry.
     addPending({ id: payload.id, name: payload.name, description: payload.description ?? null });
-    registerBuildUnitInsertCallback(
-      payload.id,
+
+    // Queue via @tanstack/offline-transactions. On success the spinner is removed
+    // (ProjectRoute also detects Electric sync). On NonRetriableError (e.g.
+    // duplicate name → CONFLICT) the optimistic insert is rolled back and we
+    // reopen the form so the user can retry.
+    const tx = createBuildUnitAction(payload);
+    tx.isPersisted.promise.then(
       () => onTrpcComplete(payload.id),
-      (err: Error) => {
+      (err: unknown) => {
+        const message = err instanceof Error ? err.message : String(err);
         removePending(payload.id);
         setFormData({ name: payload.name, description: payload.description });
-        setDuplicateError(err.message.includes(`already exists`));
+        setDuplicateError(message.includes(`already exists`));
         setIsPopupOpen(true);
       },
     );
-    buildUnitsCollection.insert(payload);
   };
 
   const handleInputChange = (

--- a/web-app/code/src/presentation/components/buildInlime/organization/NewChannelButton.tsx
+++ b/web-app/code/src/presentation/components/buildInlime/organization/NewChannelButton.tsx
@@ -3,7 +3,8 @@ import { useState } from "react";
 import type { FormEvent } from "react";
 import { useLiveQuery, eq } from "@tanstack/react-db";
 import { useSession } from "%/infrastructure/auth/client";
-import { buildUnitsCollection, channelsCollection, projectsCollection, registerChannelInsertCallback } from "%/infrastructure/database/tanstack-db-electric/admincollections";
+import { buildUnitsCollection, projectsCollection } from "%/infrastructure/database/tanstack-db-electric/admincollections";
+import { createChannelAction } from "%/application/actions/channels";
 import type { PendingItem } from "%/presentation/hooks/use-pending-items";
 
 interface NewChannelFormData {
@@ -62,7 +63,6 @@ export function NewChannelButton({ buildUnitId, addPending, removePending, onTrp
       description: formData.description,
       buildunit_id: buildUnitId,
       owner_id: session.user.id,
-      created_at: new Date(),
     };
 
     setFormData({ name: "Requirements", description: "" });
@@ -70,17 +70,21 @@ export function NewChannelButton({ buildUnitId, addPending, removePending, onTrp
     setIsPopupOpen(false);
 
     addPending({ id: payload.id, name: payload.name, description: payload.description });
-    registerChannelInsertCallback(
-      payload.id,
+
+    // Queue via @tanstack/offline-transactions. On NonRetriableError (e.g.
+    // duplicate channel name → CONFLICT) the optimistic insert is rolled back
+    // and we reopen the form so the user can retry.
+    const tx = createChannelAction(payload);
+    tx.isPersisted.promise.then(
       () => onTrpcComplete(payload.id),
-      (err: Error) => {
+      (err: unknown) => {
+        const message = err instanceof Error ? err.message : String(err);
         removePending(payload.id);
         setFormData({ name: payload.name, description: payload.description });
-        setDuplicateError(err.message.includes(`already exists`));
+        setDuplicateError(message.includes(`already exists`));
         setIsPopupOpen(true);
       },
     );
-    channelsCollection.insert(payload);
   };
 
   const handleInputChange = (


### PR DESCRIPTION
## Summary
- Migrates build-unit and channel mutations to `@tanstack/offline-transactions`, completing the offline rollout for the remaining web entities.
- Adds offline-aware attachment uploads: auto-retry on reconnect with exponential backoff and a new `awaiting_network` state so queued attachments render as a calm "Waiting for network…" pill instead of a red Failed/Retry UI .
- Bumps server-side polling deadline in `fileStorage.ts` from 3s → 15s and extends polling to `taskId` parents (was message-only) to fix the FK race for offline-queued messages/tasks.

## Changes
- New action files: `application/actions/buildunits.ts`, `application/actions/channels.ts`.
- `infrastructure/offline/mutation-fns.ts`: +7 mutationFns for build-units/channels.
- `infrastructure/offline/executor.ts`: registers build-units + channels collections.
- `infrastructure/auth/client.ts`: resets the new actions on sign-out.
- Removes legacy `onInsert/onUpdate/onDelete` for build-units/channels in `collections/organization.ts`.
- `NewBuildUnitButton` / `NewChannelButton` refactored to use `Transaction.isPersisted.promise` for inline duplicate-name error UX (replaces the old callback-registry approach).
- tRPC `buildunits` / `channels` insert routers: `ON CONFLICT (id) DO NOTHING` + re-select for retry idempotency.
- `usePendingResources`: hydration retry on mount, window `online` listener, exponential backoff (cap 5 attempts / 30s), guard against concurrent in-flight uploads for the same resource id.
- Consumers updated for `awaiting_network`: `CommentsSection`, `ResourcesSection`, `upload-schedule-popover`.

## Test plan
- [ ] Online: create/edit/delete build-units and channels — optimistic UI + server reconciliation work.
- [ ] Offline: create build-unit / channel, reload network, mutations replay in FIFO order.
- [ ] Duplicate-name on build-unit/channel insert surfaces inline (form re-opens with error).
- [ ] Attach a file to a comment while offline → renders "Waiting for network…" pill; reconnects and uploads automatically.
- [ ] Failed upload retries with backoff and stops after 5 attempts.
- [ ] Sign-out clears outbox state for new entities.


🤖 Generated with [Claude Code](https://claude.com/claude-code)