### PR TITLE
feat(mobile): file attachments with offline upload manager

### DIFF
--- a/mobile-app/app/(tabs)/_layout.tsx
+++ b/mobile-app/app/(tabs)/_layout.tsx
@@ -5,6 +5,7 @@ import DrawerContent from "@/src/presentation/shared/components/DrawerContent"
 import { useSession } from "@/src/infrastructure/auth/client"
 import { initBootstrapCollections, initProjectCollections } from "@/src/application/collections/init"
 import { initOfflineExecutor } from "@/src/infrastructure/offline/executor"
+import { initUploadManager } from "@/src/infrastructure/offline/upload-manager"
 import { resetAllOfflineActions } from "@/src/application/actions"
 import { useProjectContext } from "@/src/application/context/ProjectContext"
 import { colors } from "@/src/presentation/shared/colors"
@@ -60,6 +61,10 @@ export default function DrawerLayout() {
         // action references so the next call binds against the new executor.
         resetAllOfflineActions()
         await initOfflineExecutor()
+        // Upload manager: a separate service from the executor (binaries do not
+        // belong in the outbox). initUploadManager is idempotent, so re-running
+        // it on project switch is a no-op.
+        await initUploadManager()
         if (__DEV__) console.log(`[layout] Project collections + offline executor ready`)
         setProjectReady(true)
       })

--- a/mobile-app/app/(tabs)/project/[projectId]/[buildUnitId]/[channelId].tsx
+++ b/mobile-app/app/(tabs)/project/[projectId]/[buildUnitId]/[channelId].tsx
@@ -108,7 +108,11 @@ export default function ChannelScreen() {
       )}
 
       {/* Collapsible resources */}
-      <ResourcesSection channelId={channelId} />
+      <ResourcesSection
+        channelId={channelId}
+        buildUnitId={buildUnitId}
+        projectId={projectId}
+      />
 
       {/* Messages */}
       {isLoading ? (
@@ -117,6 +121,7 @@ export default function ChannelScreen() {
         </View>
       ) : (
         <MessageList
+          channelId={channelId}
           messages={messages}
           currentUserId={currentUserId}
           usersMap={usersMap}

--- a/mobile-app/src/infrastructure/auth/client.ts
+++ b/mobile-app/src/infrastructure/auth/client.ts
@@ -5,6 +5,8 @@ import { resetAllCollections } from "../../application/collections/init"
 import { disposePersistence } from "../persistence/expo-persistence"
 import { disposeOfflineExecutor } from "../offline/executor"
 import { disposeOutboxDb } from "../offline/storage"
+import { disposeUploadManager } from "../offline/upload-manager"
+import { disposeOnlineDetector } from "../offline/online-detector"
 import { resetAllOfflineActions } from "../../application/actions"
 
 const apiUrl = process.env.EXPO_PUBLIC_API_URL ?? "http://10.0.2.2:3000"
@@ -38,6 +40,12 @@ export async function signOutAndDispose(): Promise<void> {
   // the AuthGuard to navigate to login — at that point the cleanup
   // must already be complete so re-login can init from a clean slate.
   disposeOfflineExecutor()
+  // Dispose the upload manager BEFORE disposePersistence() — it deletes its
+  // pending_attachments rows from the main DB and removes copied local files.
+  await disposeUploadManager()
+  // Both connectivity consumers (executor + upload manager) are gone now, so
+  // the shared detector can be torn down for real.
+  disposeOnlineDetector()
   resetAllOfflineActions()
   resetAllCollections()
   await disposePersistence()

--- a/mobile-app/src/infrastructure/auth/cookie-fetch.ts
+++ b/mobile-app/src/infrastructure/auth/cookie-fetch.ts
@@ -37,6 +37,20 @@ export async function getAuthCookieHeader(): Promise<string> {
 }
 
 /**
+ * Auth headers (session cookie + Origin) for requests that CANNOT go through
+ * createCookieFetch — e.g. FileSystem.downloadAsync / uploadAsync, which take
+ * a plain headers map and do their own native networking. Keeping this as the
+ * single header-builder means cookieFetch and the file-transfer paths can't
+ * drift apart on what auth headers they send.
+ */
+export async function getAuthHeaders(): Promise<Record<string, string>> {
+  const headers: Record<string, string> = { Origin: ORIGIN }
+  const cookieHeader = await getAuthCookieHeader()
+  if (cookieHeader) headers.Cookie = cookieHeader
+  return headers
+}
+
+/**
  * Parses a raw Set-Cookie header string into a name=value pair.
  * Strips directives like Path, HttpOnly, SameSite, Expires, Max-Age, Domain.
  */
@@ -58,18 +72,12 @@ function parseSetCookieHeader(raw: string): { name: string; value: string } | nu
  */
 export function createCookieFetch(): typeof fetch {
   return async (input: RequestInfo | URL, init?: RequestInit): Promise<Response> => {
-    // 1. Load stored cookies and build Cookie header
-    const cookieMap = await loadCookies()
-    const cookieHeader = Object.entries(cookieMap)
-      .map(([k, v]) => `${k}=${v}`)
-      .join("; ")
-
+    // 1. Attach stored cookies + Origin (the latter so Better Auth's CSRF
+    //    check passes in React Native). Shared builder — see getAuthHeaders.
     const headers = new Headers(init?.headers)
-    if (cookieHeader) {
-      headers.set("Cookie", cookieHeader)
+    for (const [key, value] of Object.entries(await getAuthHeaders())) {
+      headers.set(key, value)
     }
-    // Inject Origin so Better Auth's CSRF check passes in React Native
-    headers.set("Origin", ORIGIN)
 
     // 2. Make the actual request
     const response = await fetch(input, { ...init, headers })

--- a/mobile-app/src/infrastructure/offline/executor.ts
+++ b/mobile-app/src/infrastructure/offline/executor.ts
@@ -14,7 +14,7 @@ import {
 import { teamsCollection } from "../../application/collections/admin"
 import { mutationFns } from "./mutation-fns"
 import { sqliteStorageAdapter } from "./storage"
-import { createOnlineDetector } from "./online-detector"
+import { getOnlineDetector } from "./online-detector"
 
 // NOTE: this module deliberately does NOT import the actions barrel, since
 // each action module imports `getOfflineExecutor` from here — pulling the
@@ -48,8 +48,9 @@ export async function initOfflineExecutor(): Promise<OfflineExecutor> {
     storage: sqliteStorageAdapter,
     // Custom detector — the built-in ReactNativeOnlineDetector notifies the
     // executor before updating its online flag, so offline-queued transactions
-    // never drain on reconnect. See online-detector.ts.
-    onlineDetector: createOnlineDetector(),
+    // never drain on reconnect. Shared singleton with the upload manager; see
+    // online-detector.ts.
+    onlineDetector: getOnlineDetector(),
   })
   await executor.waitForInit()
   _executor = executor

--- a/mobile-app/src/infrastructure/offline/mutation-fns.ts
+++ b/mobile-app/src/infrastructure/offline/mutation-fns.ts
@@ -111,6 +111,10 @@ const createMessage: MutationFn = async ({ transaction }) => {
     await trpc.messages.create.mutate({
       id: m.id as string,
       text: m.text as string,
+      // Forward the client's optimistic send time so the synced row keeps the
+      // same created_at the UI sorted on — see createMessageSchema. Serialised
+      // through the outbox as an ISO string; the server coerces it back.
+      created_at: m.created_at as string,
       channel_id: m.channel_id as string,
       buildunit_id: m.buildunit_id as string,
       project_id: m.project_id as string,

--- a/mobile-app/src/infrastructure/offline/online-detector.ts
+++ b/mobile-app/src/infrastructure/offline/online-detector.ts
@@ -13,10 +13,20 @@ import type { OnlineDetector } from "@tanstack/offline-transactions"
 //
 // This implementation updates `online` BEFORE notifying, so the executor
 // observes the correct state when it wakes.
+//
+// SHARED SINGLETON: both the offline executor and the upload manager need a
+// connectivity source. Rather than each wiring its own NetInfo listener, they
+// consume the one detector returned by getOnlineDetector() — a single source
+// of truth. See upload-manager.ts.
 const toOnline = (state: NetInfoState): boolean =>
   !!state.isConnected && state.isInternetReachable !== false
 
-export function createOnlineDetector(): OnlineDetector {
+interface InternalDetector extends OnlineDetector {
+  /** Real teardown — `dispose()` itself is a no-op (see getOnlineDetector). */
+  _teardown(): void
+}
+
+function createOnlineDetector(): InternalDetector {
   const listeners = new Set<() => void>()
   let online = true
 
@@ -58,10 +68,30 @@ export function createOnlineDetector(): OnlineDetector {
     isOnline() {
       return online
     },
-    dispose() {
+    // No-op: the detector is a shared singleton, so a consumer disposing
+    // (e.g. the executor being torn down and rebuilt on project switch) must
+    // NOT kill the connectivity source the other consumer still depends on.
+    // Real teardown happens via disposeOnlineDetector() at sign-out.
+    dispose() {},
+    _teardown() {
       netInfoUnsubscribe()
       appStateSubscription.remove()
       listeners.clear()
     },
   }
+}
+
+let _detector: InternalDetector | null = null
+
+/** Lazily-created shared connectivity detector for executor + upload manager. */
+export function getOnlineDetector(): OnlineDetector {
+  if (!_detector) _detector = createOnlineDetector()
+  return _detector
+}
+
+/** Real teardown of the shared detector. Called at sign-out. */
+export function disposeOnlineDetector(): void {
+  if (!_detector) return
+  _detector._teardown()
+  _detector = null
 }

--- a/mobile-app/src/infrastructure/offline/pending-uploads-db.ts
+++ b/mobile-app/src/infrastructure/offline/pending-uploads-db.ts
@@ -1,0 +1,159 @@
+import { openDatabaseSync, deleteDatabaseAsync } from "expo-sqlite"
+import type { SQLiteDatabase } from "expo-sqlite"
+
+// SQLite CRUD over the `pending_attachments` table — attachment METADATA only
+// (the file bytes are kept as a binary file on disk; see upload-manager.ts).
+//
+// DEDICATED DATABASE: this table lives in its OWN SQLite file, NOT the main
+// collections DB (buildinlime.sqlite). Sharing that connection let upload
+// metadata writes contend with Electric's sync-persistence multi-statement
+// transactions, producing "database is locked" / "Failed to persist wrapped
+// sync transaction" errors — the same contention that forced the offline
+// outbox into its own file (see storage.ts). A dedicated file gives this
+// table a single, uncontended writer.
+
+const UPLOADS_DB_NAME = "buildinlime-uploads.sqlite"
+
+export type UploadStatus =
+  | "awaiting_schedule"
+  | "scheduled"
+  | "uploading"
+  | "awaiting_network"
+  | "error"
+
+export interface PendingAttachmentRow {
+  resource_id: string
+  uri: string
+  name: string
+  mime_type: string
+  channel_id: string
+  buildunit_id: string
+  project_id: string
+  createdby_id: string
+  message_id: string | null
+  status: UploadStatus
+  scheduled_at: string | null
+  error_message: string | null
+}
+
+let _db: SQLiteDatabase | null = null
+
+function getDb(): SQLiteDatabase {
+  if (_db) return _db
+  const db = openDatabaseSync(UPLOADS_DB_NAME)
+  // WAL + busy_timeout for the same reasons as the other DBs — but since this
+  // file has a single writer (the upload manager), real contention is rare.
+  db.execSync(`
+    PRAGMA journal_mode=WAL;
+    PRAGMA busy_timeout=5000;
+  `)
+  db.execSync(`
+    CREATE TABLE IF NOT EXISTS pending_attachments (
+      resource_id TEXT PRIMARY KEY NOT NULL,
+      uri TEXT NOT NULL,
+      name TEXT NOT NULL,
+      mime_type TEXT NOT NULL,
+      channel_id TEXT NOT NULL,
+      buildunit_id TEXT NOT NULL,
+      project_id TEXT NOT NULL,
+      createdby_id TEXT NOT NULL,
+      message_id TEXT,
+      status TEXT NOT NULL,
+      scheduled_at TEXT,
+      error_message TEXT
+    );
+  `)
+  _db = db
+  return db
+}
+
+export async function getAll(): Promise<PendingAttachmentRow[]> {
+  return getDb().getAllAsync<PendingAttachmentRow>(
+    `SELECT * FROM pending_attachments`,
+  )
+}
+
+export async function put(row: PendingAttachmentRow): Promise<void> {
+  await getDb().runAsync(
+    `INSERT INTO pending_attachments
+       (resource_id, uri, name, mime_type, channel_id, buildunit_id,
+        project_id, createdby_id, message_id, status, scheduled_at, error_message)
+     VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+     ON CONFLICT(resource_id) DO UPDATE SET
+       uri = excluded.uri,
+       name = excluded.name,
+       mime_type = excluded.mime_type,
+       channel_id = excluded.channel_id,
+       buildunit_id = excluded.buildunit_id,
+       project_id = excluded.project_id,
+       createdby_id = excluded.createdby_id,
+       message_id = excluded.message_id,
+       status = excluded.status,
+       scheduled_at = excluded.scheduled_at,
+       error_message = excluded.error_message`,
+    [
+      row.resource_id,
+      row.uri,
+      row.name,
+      row.mime_type,
+      row.channel_id,
+      row.buildunit_id,
+      row.project_id,
+      row.createdby_id,
+      row.message_id,
+      row.status,
+      row.scheduled_at,
+      row.error_message,
+    ],
+  )
+}
+
+export async function updateStatus(
+  resourceId: string,
+  status: UploadStatus,
+  errorMessage?: string | null,
+): Promise<void> {
+  await getDb().runAsync(
+    `UPDATE pending_attachments
+       SET status = ?, error_message = ?
+     WHERE resource_id = ?`,
+    [status, errorMessage ?? null, resourceId],
+  )
+}
+
+export async function updateSchedule(
+  resourceId: string,
+  status: UploadStatus,
+  scheduledAt: string | null,
+): Promise<void> {
+  await getDb().runAsync(
+    `UPDATE pending_attachments
+       SET status = ?, scheduled_at = ?
+     WHERE resource_id = ?`,
+    [status, scheduledAt, resourceId],
+  )
+}
+
+export async function remove(resourceId: string): Promise<void> {
+  await getDb().runAsync(`DELETE FROM pending_attachments WHERE resource_id = ?`, [
+    resourceId,
+  ])
+}
+
+export async function clear(): Promise<void> {
+  await getDb().runAsync(`DELETE FROM pending_attachments`)
+}
+
+// Closes and deletes the uploads database. Called on sign-out — the table is
+// user-scoped and must not leak the previous user's pending uploads.
+export async function disposeUploadsDb(): Promise<void> {
+  if (!_db) return
+  const db = _db
+  _db = null
+  try {
+    db.closeSync()
+    await deleteDatabaseAsync(UPLOADS_DB_NAME)
+  } catch {
+    // Best-effort — never block sign-out.
+  }
+}

--- a/mobile-app/src/infrastructure/offline/upload-manager.ts
+++ b/mobile-app/src/infrastructure/offline/upload-manager.ts
@@ -1,0 +1,475 @@
+import * as FileSystem from "expo-file-system/legacy"
+import * as Crypto from "expo-crypto"
+import { createCookieFetch } from "../auth/cookie-fetch"
+import { getOnlineDetector } from "./online-detector"
+import {
+  getAll,
+  put,
+  updateStatus,
+  updateSchedule,
+  remove,
+  clear,
+  disposeUploadsDb,
+  type PendingAttachmentRow,
+  type UploadStatus,
+} from "./pending-uploads-db"
+
+// Upload manager — a SERVICE module, not a hook.
+//
+// Deliberately NOT a hook: uploads must survive screen unmounts. The manager
+// is a singleton started once (initUploadManager, in the tab layout) and
+// disposed once (disposeUploadManager, at sign-out), exactly like the offline
+// executor.
+//
+// File uploads stay OUT of @tanstack/offline-transactions: the executor's
+// outbox serialises mutations to JSON, and multi-MB binaries do not belong
+// there. The upload IS the resource "create" — mobile never inserts a
+// `resources` row through the executor. The server creates it on a successful
+// upload; Electric then syncs it into resourcesCollection. Until then, the
+// pending upload is the optimistic state.
+
+const API_URL = process.env.EXPO_PUBLIC_API_URL ?? "http://10.0.2.2:3000"
+const UPLOAD_ENDPOINT = `${API_URL}/api/resources/upload`
+
+// Picked files live in OS-managed temp/cache locations that can be reaped at
+// any time. Copy them under documentDirectory so a queued upload still has its
+// bytes after an app restart.
+const UPLOAD_DIR = `${FileSystem.documentDirectory}pending-uploads/`
+
+const MAX_AUTO_RETRIES = 5
+const MAX_BACKOFF_MS = 30_000
+
+export type { UploadStatus }
+
+export interface PendingUpload {
+  id: string
+  uri: string
+  name: string
+  mimeType: string
+  channelId: string
+  buildUnitId: string
+  projectId: string
+  createdById: string
+  messageId: string | null
+  status: UploadStatus
+  scheduledAt: Date | null
+  errorMessage?: string
+}
+
+export interface EnqueueUploadOptions {
+  name: string
+  mimeType: string
+  channelId: string
+  buildUnitId: string
+  projectId: string
+  createdById: string
+  messageId?: string | null
+}
+
+export interface EnqueueControl {
+  /**
+   * Start uploading immediately (default true). Pass false for message
+   * attachments: they must wait in `awaiting_schedule` until the message is
+   * sent — only then does startUpload() fire them, so the server's 15s
+   * parent-poll finds the message in time.
+   */
+  autoStart?: boolean
+}
+
+// ---------------------------------------------------------------------------
+// Module state
+// ---------------------------------------------------------------------------
+
+const uploads = new Map<string, PendingUpload>()
+const subscribers = new Set<(uploads: PendingUpload[]) => void>()
+const scheduleTimers = new Map<string, ReturnType<typeof setTimeout>>()
+const retryTimers = new Map<string, ReturnType<typeof setTimeout>>()
+const retryAttempts = new Map<string, number>()
+// Ids with a doUpload() POST currently in flight. Tracked separately from the
+// persisted `uploading` status so hydration can RESUME an interrupted upload
+// (its row still says `uploading`) without doUpload's re-entrancy guard
+// rejecting it.
+const inFlight = new Set<string>()
+let initialized = false
+let onlineUnsub: (() => void) | null = null
+
+// ---------------------------------------------------------------------------
+// Subscription
+// ---------------------------------------------------------------------------
+
+function snapshot(): PendingUpload[] {
+  return Array.from(uploads.values())
+}
+
+function notify(): void {
+  const snap = snapshot()
+  for (const cb of subscribers) {
+    try {
+      cb(snap)
+    } catch (err) {
+      console.warn(`[uploads] subscriber error:`, err)
+    }
+  }
+}
+
+export function subscribe(cb: (uploads: PendingUpload[]) => void): () => void {
+  subscribers.add(cb)
+  cb(snapshot())
+  return () => subscribers.delete(cb)
+}
+
+export function getUploads(): PendingUpload[] {
+  return snapshot()
+}
+
+// ---------------------------------------------------------------------------
+// Row <-> PendingUpload mapping
+// ---------------------------------------------------------------------------
+
+function rowToUpload(row: PendingAttachmentRow): PendingUpload {
+  return {
+    id: row.resource_id,
+    uri: row.uri,
+    name: row.name,
+    mimeType: row.mime_type,
+    channelId: row.channel_id,
+    buildUnitId: row.buildunit_id,
+    projectId: row.project_id,
+    createdById: row.createdby_id,
+    messageId: row.message_id,
+    status: row.status,
+    scheduledAt: row.scheduled_at ? new Date(row.scheduled_at) : null,
+    errorMessage: row.error_message ?? undefined,
+  }
+}
+
+function uploadToRow(u: PendingUpload): PendingAttachmentRow {
+  return {
+    resource_id: u.id,
+    uri: u.uri,
+    name: u.name,
+    mime_type: u.mimeType,
+    channel_id: u.channelId,
+    buildunit_id: u.buildUnitId,
+    project_id: u.projectId,
+    createdby_id: u.createdById,
+    message_id: u.messageId,
+    status: u.status,
+    scheduled_at: u.scheduledAt ? u.scheduledAt.toISOString() : null,
+    error_message: u.errorMessage ?? null,
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Lifecycle
+// ---------------------------------------------------------------------------
+
+/**
+ * Hydrate the manager from SQLite. Call once, after the persistence DB is
+ * ready (tab layout, Phase 2). Interrupted `uploading` rows are reset to
+ * `awaiting_schedule` and re-driven; `error`/`awaiting_network` rows are
+ * retried; `scheduled` rows get their timers rebuilt.
+ */
+export async function initUploadManager(): Promise<void> {
+  if (initialized) return
+  initialized = true
+
+  await FileSystem.makeDirectoryAsync(UPLOAD_DIR, { intermediates: true }).catch(
+    () => {},
+  )
+
+  let rows: PendingAttachmentRow[] = []
+  try {
+    rows = await getAll()
+  } catch (err) {
+    console.warn(`[uploads] hydrate failed:`, err)
+  }
+
+  for (const row of rows) {
+    uploads.set(row.resource_id, rowToUpload(row))
+  }
+  notify()
+
+  for (const upload of uploads.values()) {
+    // `uploading` — interrupted mid-flight by an app kill: resume it.
+    // `error` / `awaiting_network` — a previous attempt failed: retry it.
+    if (
+      upload.status === "uploading" ||
+      upload.status === "error" ||
+      upload.status === "awaiting_network"
+    ) {
+      void doUpload(upload.id)
+    } else if (upload.status === "scheduled" && upload.scheduledAt) {
+      armScheduleTimer(upload.id, upload.scheduledAt)
+    }
+    // `awaiting_schedule` — deliberately left alone: a message attachment
+    // waiting for its message to be sent, or a file awaiting a schedule.
+  }
+
+  // Auto-retry errored / awaiting-network uploads as soon as the shared
+  // detector reports we are back online.
+  const detector = getOnlineDetector()
+  onlineUnsub = detector.subscribe(() => {
+    if (!detector.isOnline()) return
+    for (const upload of uploads.values()) {
+      if (upload.status === "error" || upload.status === "awaiting_network") {
+        retryUpload(upload.id)
+      }
+    }
+  })
+
+  if (__DEV__) {
+    console.log(`[uploads] Upload manager ready, ${uploads.size} pending`)
+  }
+}
+
+/**
+ * Drop all pending uploads — rows and the copied local files. Called at
+ * sign-out: pending uploads are user-scoped, mirroring how the executor's
+ * outbox is wiped. In-flight uploads are abandoned (parity with the outbox).
+ */
+export async function disposeUploadManager(): Promise<void> {
+  if (!initialized) return
+  initialized = false
+
+  onlineUnsub?.()
+  onlineUnsub = null
+
+  for (const t of scheduleTimers.values()) clearTimeout(t)
+  for (const t of retryTimers.values()) clearTimeout(t)
+  scheduleTimers.clear()
+  retryTimers.clear()
+  retryAttempts.clear()
+  inFlight.clear()
+
+  for (const upload of uploads.values()) {
+    await FileSystem.deleteAsync(upload.uri, { idempotent: true }).catch(() => {})
+  }
+  uploads.clear()
+  notify()
+
+  await clear().catch(() => {})
+  // Close + delete the dedicated uploads DB file — user-scoped, mirroring how
+  // the executor's outbox DB is disposed.
+  await disposeUploadsDb().catch(() => {})
+}
+
+// ---------------------------------------------------------------------------
+// Enqueue
+// ---------------------------------------------------------------------------
+
+/**
+ * Copy a picked file into durable storage, persist a pending row, and start
+ * the upload. Returns the generated resource id (also the upload id).
+ */
+export async function enqueueUpload(
+  fileUri: string,
+  opts: EnqueueUploadOptions,
+  control: EnqueueControl = {},
+): Promise<string> {
+  const id = Crypto.randomUUID()
+  await FileSystem.makeDirectoryAsync(UPLOAD_DIR, { intermediates: true }).catch(
+    () => {},
+  )
+  const localUri = `${UPLOAD_DIR}${id}`
+  await FileSystem.copyAsync({ from: fileUri, to: localUri })
+
+  const upload: PendingUpload = {
+    id,
+    uri: localUri,
+    name: opts.name,
+    mimeType: opts.mimeType,
+    channelId: opts.channelId,
+    buildUnitId: opts.buildUnitId,
+    projectId: opts.projectId,
+    createdById: opts.createdById,
+    messageId: opts.messageId ?? null,
+    status: "awaiting_schedule",
+    scheduledAt: null,
+  }
+  uploads.set(id, upload)
+  await put(uploadToRow(upload))
+  notify()
+
+  if (control.autoStart ?? true) void doUpload(id)
+  return id
+}
+
+/**
+ * Start (or restart) an upload that is resting in `awaiting_schedule` — used
+ * by MessageInput once the parent message is sent.
+ */
+export function startUpload(id: string): void {
+  void doUpload(id)
+}
+
+// ---------------------------------------------------------------------------
+// Upload
+// ---------------------------------------------------------------------------
+
+function setStatus(
+  id: string,
+  status: UploadStatus,
+  errorMessage?: string,
+): PendingUpload | undefined {
+  const upload = uploads.get(id)
+  if (!upload) return undefined
+  upload.status = status
+  upload.errorMessage = errorMessage
+  notify()
+  return upload
+}
+
+async function doUpload(id: string): Promise<void> {
+  const upload = uploads.get(id)
+  if (!upload) return
+  // Already in flight — online-event retries and the scheduled/backoff timers
+  // can all race to call doUpload for the same id.
+  if (inFlight.has(id)) return
+  inFlight.add(id)
+
+  const existingRetry = retryTimers.get(id)
+  if (existingRetry) {
+    clearTimeout(existingRetry)
+    retryTimers.delete(id)
+  }
+
+  setStatus(id, "uploading")
+  await updateStatus(id, "uploading").catch(() => {})
+
+  const formData = new FormData()
+  // React Native streams the file from disk given a { uri, name, type } part —
+  // no base64-in-memory copy.
+  formData.append("file", {
+    uri: upload.uri,
+    name: upload.name,
+    type: upload.mimeType,
+  } as unknown as Blob)
+  formData.append("resourceId", upload.id)
+  formData.append("name", upload.name)
+  formData.append("channelId", upload.channelId)
+  formData.append("buildunitId", upload.buildUnitId)
+  formData.append("projectId", upload.projectId)
+  if (upload.messageId) formData.append("messageId", upload.messageId)
+
+  try {
+    const cookieFetch = createCookieFetch()
+    const res = await cookieFetch(UPLOAD_ENDPOINT, {
+      method: "POST",
+      body: formData,
+    })
+    if (!res.ok) {
+      const err = await res
+        .json()
+        .catch(() => ({ error: `Upload failed (${res.status})` }))
+      throw new Error(err.error ?? `Upload failed (${res.status})`)
+    }
+
+    // Success — drop the row and the local file. Electric syncs the new
+    // `resources` row into resourcesCollection on its own.
+    uploads.delete(id)
+    retryAttempts.delete(id)
+    notify()
+    await remove(id).catch(() => {})
+    await FileSystem.deleteAsync(upload.uri, { idempotent: true }).catch(() => {})
+  } catch (err) {
+    const message = err instanceof Error ? err.message : "Upload failed"
+    // Offline isn't really a failure — surface a calmer "awaiting network"
+    // state instead of a red error for something we will auto-retry.
+    const online = getOnlineDetector().isOnline()
+    const nextStatus: UploadStatus = online ? "error" : "awaiting_network"
+    setStatus(id, nextStatus, message)
+    await updateStatus(id, nextStatus, message).catch(() => {})
+
+    // Auto-retry: while offline the online-detector wakes us on reconnect (see
+    // initUploadManager wiring); while online use exponential backoff (covers
+    // transient FK races where the parent message hasn't replayed yet).
+    const attempt = (retryAttempts.get(id) ?? 0) + 1
+    retryAttempts.set(id, attempt)
+    if (attempt <= MAX_AUTO_RETRIES && online) {
+      const delay = Math.min(MAX_BACKOFF_MS, 1000 * 2 ** (attempt - 1))
+      const timer = setTimeout(() => {
+        retryTimers.delete(id)
+        void doUpload(id)
+      }, delay)
+      retryTimers.set(id, timer)
+    }
+  } finally {
+    inFlight.delete(id)
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Schedule / cancel / retry
+// ---------------------------------------------------------------------------
+
+function armScheduleTimer(id: string, when: Date): void {
+  const existing = scheduleTimers.get(id)
+  if (existing) clearTimeout(existing)
+  const delay = when.getTime() - Date.now()
+  if (delay <= 0) {
+    void doUpload(id)
+    return
+  }
+  const timer = setTimeout(() => {
+    scheduleTimers.delete(id)
+    void doUpload(id)
+  }, delay)
+  scheduleTimers.set(id, timer)
+}
+
+/** Defer an upload to a future time (null = upload now). */
+export async function scheduleUpload(
+  id: string,
+  when: Date | null,
+): Promise<void> {
+  const upload = uploads.get(id)
+  if (!upload) return
+  const existing = scheduleTimers.get(id)
+  if (existing) {
+    clearTimeout(existing)
+    scheduleTimers.delete(id)
+  }
+  if (!when || when.getTime() <= Date.now()) {
+    void doUpload(id)
+    return
+  }
+  upload.status = "scheduled"
+  upload.scheduledAt = when
+  notify()
+  await updateSchedule(id, "scheduled", when.toISOString()).catch(() => {})
+  armScheduleTimer(id, when)
+}
+
+/** Drop a pending upload — clears timers, the row, and the local file. */
+export async function cancelUpload(id: string): Promise<void> {
+  const upload = uploads.get(id)
+  const scheduleTimer = scheduleTimers.get(id)
+  if (scheduleTimer) {
+    clearTimeout(scheduleTimer)
+    scheduleTimers.delete(id)
+  }
+  const retryTimer = retryTimers.get(id)
+  if (retryTimer) {
+    clearTimeout(retryTimer)
+    retryTimers.delete(id)
+  }
+  retryAttempts.delete(id)
+  uploads.delete(id)
+  notify()
+  await remove(id).catch(() => {})
+  if (upload) {
+    await FileSystem.deleteAsync(upload.uri, { idempotent: true }).catch(() => {})
+  }
+}
+
+/** Manual retry — resets the auto-backoff counter for a fresh sequence. */
+export function retryUpload(id: string): void {
+  retryAttempts.set(id, 0)
+  const retryTimer = retryTimers.get(id)
+  if (retryTimer) {
+    clearTimeout(retryTimer)
+    retryTimers.delete(id)
+  }
+  void doUpload(id)
+}

--- a/mobile-app/src/infrastructure/persistence/expo-persistence.ts
+++ b/mobile-app/src/infrastructure/persistence/expo-persistence.ts
@@ -38,22 +38,10 @@ export function getPersistence(): PersistenceTrio {
     database: database as unknown as ExpoSQLiteDatabaseLike,
   })
 
-  database.execSync(`
-    CREATE TABLE IF NOT EXISTS pending_attachments (
-      resource_id TEXT PRIMARY KEY NOT NULL,
-      uri TEXT NOT NULL,
-      name TEXT NOT NULL,
-      mime_type TEXT NOT NULL,
-      channel_id TEXT NOT NULL,
-      buildunit_id TEXT NOT NULL,
-      project_id TEXT NOT NULL,
-      createdby_id TEXT NOT NULL,
-      message_id TEXT,
-      status TEXT NOT NULL,
-      scheduled_at TEXT,
-      error_message TEXT
-    );
-  `)
+  // NOTE: the upload manager's `pending_attachments` table deliberately lives
+  // in its OWN database file (see pending-uploads-db.ts), not here — sharing
+  // this connection caused "database is locked" failures against Electric's
+  // sync-persistence transactions.
 
   if (__DEV__) console.log(`[SQLite] Persistence ready in ${Date.now() - t0}ms`)
   _trio = { database, persistence }

--- a/mobile-app/src/presentation/messages/components/MessageBubble.tsx
+++ b/mobile-app/src/presentation/messages/components/MessageBubble.tsx
@@ -1,11 +1,15 @@
 import { View, Text, StyleSheet } from "react-native"
 import { colors } from "@/src/presentation/shared/colors"
-import type { Message } from "@buildinlime/domain-types"
+import { MessageAttachments } from "@/src/presentation/resources/components/MessageAttachments"
+import type { PendingUpload } from "@/src/infrastructure/offline/upload-manager"
+import type { Message, Resource } from "@buildinlime/domain-types"
 
 interface MessageBubbleProps {
   message: Message
   senderName: string
   isOwn: boolean
+  attachments: Resource[]
+  pendingAttachments: PendingUpload[]
 }
 
 function formatTime(date: Date | string | undefined): string {
@@ -15,8 +19,15 @@ function formatTime(date: Date | string | undefined): string {
   return `${d.getHours().toString().padStart(2, "0")}:${d.getMinutes().toString().padStart(2, "0")}`
 }
 
-export function MessageBubble({ message, senderName, isOwn }: MessageBubbleProps) {
+export function MessageBubble({
+  message,
+  senderName,
+  isOwn,
+  attachments,
+  pendingAttachments,
+}: MessageBubbleProps) {
   const initial = senderName.charAt(0).toUpperCase()
+  const hasText = !!message.text?.trim()
 
   return (
     <View style={[styles.container, isOwn ? styles.containerOwn : styles.containerOther]}>
@@ -29,9 +40,16 @@ export function MessageBubble({ message, senderName, isOwn }: MessageBubbleProps
         {!isOwn && (
           <Text style={styles.senderName}>{senderName}</Text>
         )}
-        <Text style={[styles.messageText, isOwn ? styles.messageTextOwn : styles.messageTextOther]}>
-          {message.text}
-        </Text>
+        {hasText && (
+          <Text style={[styles.messageText, isOwn ? styles.messageTextOwn : styles.messageTextOther]}>
+            {message.text}
+          </Text>
+        )}
+        <MessageAttachments
+          resources={attachments}
+          pendingUploads={pendingAttachments}
+          isOwn={isOwn}
+        />
         <Text style={[styles.timestamp, isOwn ? styles.timestampOwn : styles.timestampOther]}>
           {formatTime(message.created_at)}
         </Text>

--- a/mobile-app/src/presentation/messages/components/MessageInput.tsx
+++ b/mobile-app/src/presentation/messages/components/MessageInput.tsx
@@ -1,10 +1,12 @@
-import { View, TextInput, TouchableOpacity, StyleSheet, Text } from "react-native"
+import { View, TextInput, TouchableOpacity, StyleSheet, Text, Alert } from "react-native"
 import { useState } from "react"
 import { useSafeAreaInsets } from "react-native-safe-area-context"
-import NetInfo from "@react-native-community/netinfo"
+import * as DocumentPicker from "expo-document-picker"
+import * as Crypto from "expo-crypto"
 import { useSession } from "@/src/infrastructure/auth/client"
 import { colors } from "@/src/presentation/shared/colors"
 import { createMessageAction } from "@/src/application/actions/messages"
+import { usePendingUploads } from "@/src/presentation/resources/hooks/usePendingUploads"
 
 interface MessageInputProps {
   channelId: string
@@ -14,65 +16,187 @@ interface MessageInputProps {
 
 export function MessageInput({ channelId, buildUnitId, projectId }: MessageInputProps) {
   const [text, setText] = useState("")
+  // Generated lazily on the first attachment so files can be enqueued against
+  // the message id BEFORE the message itself is sent. Passed to
+  // createMessageAction on send so the message and its resources agree on the id.
+  const [draftMessageId, setDraftMessageId] = useState<string | null>(null)
   const { bottom } = useSafeAreaInsets()
   const { data: session } = useSession()
 
+  const { pendingUploads, enqueue, start, cancel } = usePendingUploads({
+    messageId: draftMessageId ?? undefined,
+  })
+
+  async function handleAttach() {
+    const userId = session?.user?.id
+    if (!userId) {
+      Alert.alert("Cannot attach", "Your session is still loading — try again.")
+      return
+    }
+    try {
+      const result = await DocumentPicker.getDocumentAsync({
+        copyToCacheDirectory: true,
+      })
+      if (result.canceled) return
+      const asset = result.assets[0]
+      if (!asset) return
+
+      let messageId = draftMessageId
+      if (!messageId) {
+        messageId = Crypto.randomUUID()
+        setDraftMessageId(messageId)
+      }
+      // autoStart: false — the upload waits in `awaiting_schedule` until the
+      // message is sent (handleSend → start), so the server's 15s parent-poll
+      // finds the message row.
+      await enqueue(
+        asset.uri,
+        {
+          name: asset.name,
+          mimeType: asset.mimeType ?? "application/octet-stream",
+          channelId,
+          buildUnitId,
+          projectId,
+          createdById: userId,
+          messageId,
+        },
+        { autoStart: false },
+      )
+    } catch (err) {
+      Alert.alert("Attach failed", String(err))
+    }
+  }
+
   function handleSend() {
     const trimmed = text.trim()
-    if (!trimmed || !session?.user?.id) return
+    const userId = session?.user?.id
+    if ((!trimmed && pendingUploads.length === 0) || !userId) return
 
-    NetInfo.fetch().then((s) =>
-      console.log("[netinfo]", { isConnected: s.isConnected, isInternetReachable: s.isInternetReachable, type: s.type }),
-    )
-
+    const messageId = draftMessageId ?? Crypto.randomUUID()
     try {
       createMessageAction({
+        id: messageId,
         text: trimmed,
         channel_id: channelId,
         buildunit_id: buildUnitId,
         project_id: projectId,
-        createdby_id: session.user.id,
+        createdby_id: userId,
       })
+      // Release the attachments now that the message transaction exists.
+      pendingUploads.forEach((u) => start(u.id))
       setText("")
+      setDraftMessageId(null)
     } catch (err) {
       console.error("Failed to send message:", err)
     }
   }
 
+  const canSend = !!text.trim() || pendingUploads.length > 0
+
   return (
-    <View style={[styles.container, { paddingBottom: 10 + bottom }]}>
-      <TextInput
-        style={styles.input}
-        value={text}
-        onChangeText={setText}
-        placeholder="Type a message…"
-        placeholderTextColor={colors.mutedForeground}
-        multiline
-        returnKeyType="default"
-        blurOnSubmit={false}
-      />
-      <TouchableOpacity
-        style={[styles.sendButton, !text.trim() && styles.sendButtonDisabled]}
-        onPress={handleSend}
-        disabled={!text.trim()}
-        activeOpacity={0.7}
-      >
-        <Text style={styles.sendButtonText}>Send</Text>
-      </TouchableOpacity>
+    <View style={[styles.outer, { paddingBottom: 10 + bottom }]}>
+      {pendingUploads.length > 0 && (
+        <View style={styles.chips}>
+          {pendingUploads.map((u) => (
+            <View key={u.id} style={styles.chip}>
+              <Text style={styles.chipText} numberOfLines={1}>
+                📎 {u.name}
+              </Text>
+              <TouchableOpacity
+                onPress={() => cancel(u.id)}
+                hitSlop={{ top: 6, bottom: 6, left: 6, right: 6 }}
+                activeOpacity={0.6}
+              >
+                <Text style={styles.chipRemove}>✕</Text>
+              </TouchableOpacity>
+            </View>
+          ))}
+        </View>
+      )}
+      <View style={styles.container}>
+        <TouchableOpacity
+          style={styles.attachButton}
+          onPress={handleAttach}
+          activeOpacity={0.7}
+        >
+          <Text style={styles.attachIcon}>＋</Text>
+        </TouchableOpacity>
+        <TextInput
+          style={styles.input}
+          value={text}
+          onChangeText={setText}
+          placeholder="Type a message…"
+          placeholderTextColor={colors.mutedForeground}
+          multiline
+          returnKeyType="default"
+          blurOnSubmit={false}
+        />
+        <TouchableOpacity
+          style={[styles.sendButton, !canSend && styles.sendButtonDisabled]}
+          onPress={handleSend}
+          disabled={!canSend}
+          activeOpacity={0.7}
+        >
+          <Text style={styles.sendButtonText}>Send</Text>
+        </TouchableOpacity>
+      </View>
     </View>
   )
 }
 
 const styles = StyleSheet.create({
+  outer: {
+    borderTopWidth: 1,
+    borderTopColor: colors.border,
+    backgroundColor: colors.background,
+  },
+  chips: {
+    flexDirection: "row",
+    flexWrap: "wrap",
+    gap: 6,
+    paddingHorizontal: 12,
+    paddingTop: 10,
+  },
+  chip: {
+    flexDirection: "row",
+    alignItems: "center",
+    gap: 6,
+    maxWidth: 200,
+    backgroundColor: colors.muted,
+    borderRadius: 14,
+    paddingHorizontal: 10,
+    paddingVertical: 6,
+  },
+  chipText: {
+    flexShrink: 1,
+    fontSize: 12,
+    fontFamily: "InstrumentSans_400Regular",
+    color: colors.foreground,
+  },
+  chipRemove: {
+    fontSize: 12,
+    color: colors.mutedForeground,
+    fontFamily: "InstrumentSans_600SemiBold",
+  },
   container: {
     flexDirection: "row",
     alignItems: "flex-end",
     paddingHorizontal: 12,
     paddingVertical: 10,
-    borderTopWidth: 1,
-    borderTopColor: colors.border,
-    backgroundColor: colors.background,
     gap: 8,
+  },
+  attachButton: {
+    width: 40,
+    height: 40,
+    borderRadius: 20,
+    backgroundColor: colors.muted,
+    alignItems: "center",
+    justifyContent: "center",
+  },
+  attachIcon: {
+    fontSize: 20,
+    color: colors.mutedForeground,
+    lineHeight: 22,
   },
   input: {
     flex: 1,

--- a/mobile-app/src/presentation/messages/components/MessageList.tsx
+++ b/mobile-app/src/presentation/messages/components/MessageList.tsx
@@ -1,16 +1,61 @@
-import { FlatList, View, StyleSheet } from "react-native"
+import { useMemo } from "react"
+import { FlatList, StyleSheet } from "react-native"
+import { useLiveQuery, eq } from "@tanstack/react-db"
 import { MessageBubble } from "./MessageBubble"
-import type { Message } from "@buildinlime/domain-types"
+import { resourcesCollection } from "@/src/application/collections/communication"
+import { useChannelMessageUploads } from "@/src/presentation/resources/hooks/usePendingUploads"
+import type { PendingUpload } from "@/src/infrastructure/offline/upload-manager"
+import type { Message, Resource } from "@buildinlime/domain-types"
 
 interface MessageListProps {
+  channelId: string
   messages: Message[]
   currentUserId: string
   usersMap: Record<string, string>
 }
 
-export function MessageList({ messages, currentUserId, usersMap }: MessageListProps) {
+function groupBy<T>(items: T[], key: (item: T) => string | null | undefined) {
+  const map = new Map<string, T[]>()
+  for (const item of items) {
+    const k = key(item)
+    if (!k) continue
+    const arr = map.get(k)
+    if (arr) arr.push(item)
+    else map.set(k, [item])
+  }
+  return map
+}
+
+export function MessageList({
+  channelId,
+  messages,
+  currentUserId,
+  usersMap,
+}: MessageListProps) {
+  // Synced resources for this channel, and the still-uploading attachments —
+  // both grouped by message id so each bubble can render its own attachments.
+  const { data: resourceData } = useLiveQuery(
+    (q) =>
+      q
+        .from({ resourcesCollection })
+        .where(({ resourcesCollection: r }) => eq(r.channel_id, channelId)),
+    [channelId]
+  )
+  const messageUploads = useChannelMessageUploads(channelId)
+
+  const resourcesByMessage = useMemo(
+    () => groupBy((resourceData ?? []) as Resource[], (r) => r.message_id),
+    [resourceData]
+  )
+  const uploadsByMessage = useMemo(
+    () => groupBy(messageUploads, (u) => u.messageId),
+    [messageUploads]
+  )
+
   // Reverse for inverted FlatList (newest at bottom)
   const reversed = [...messages].reverse()
+  const EMPTY_RESOURCES: Resource[] = []
+  const EMPTY_UPLOADS: PendingUpload[] = []
 
   return (
     <FlatList
@@ -21,6 +66,8 @@ export function MessageList({ messages, currentUserId, usersMap }: MessageListPr
           message={item}
           senderName={usersMap[item.createdby_id] ?? "Unknown"}
           isOwn={item.createdby_id === currentUserId}
+          attachments={resourcesByMessage.get(item.id) ?? EMPTY_RESOURCES}
+          pendingAttachments={uploadsByMessage.get(item.id) ?? EMPTY_UPLOADS}
         />
       )}
       inverted

--- a/mobile-app/src/presentation/resources/components/MessageAttachments.tsx
+++ b/mobile-app/src/presentation/resources/components/MessageAttachments.tsx
@@ -1,0 +1,150 @@
+import { View, Text, TouchableOpacity, StyleSheet } from "react-native"
+import { mimeEmoji } from "@/src/presentation/resources/lib/attachment-format"
+import { useResourceDownload } from "@/src/presentation/resources/hooks/useResourceDownload"
+import type { PendingUpload } from "@/src/infrastructure/offline/upload-manager"
+import { colors } from "@/src/presentation/shared/colors"
+import type { Resource } from "@buildinlime/domain-types"
+
+// Attachments rendered INSIDE a message bubble: synced resources (tappable to
+// download) and still-uploading attachments (status only). `isOwn` flips the
+// palette so chips stay readable on both the dark own-bubble and the light
+// other-bubble.
+
+interface MessageAttachmentsProps {
+  resources: Resource[]
+  pendingUploads: PendingUpload[]
+  isOwn: boolean
+}
+
+function pendingLabel(status: PendingUpload["status"]): string {
+  switch (status) {
+    case "uploading":
+      return "Uploading…"
+    case "awaiting_network":
+      return "Waiting for network"
+    case "error":
+      return "Upload failed"
+    case "scheduled":
+      return "Scheduled"
+    default:
+      return "Queued"
+  }
+}
+
+function SyncedAttachment({
+  resource,
+  isOwn,
+}: {
+  resource: Resource
+  isOwn: boolean
+}) {
+  const { download, downloading } = useResourceDownload()
+  return (
+    <TouchableOpacity
+      style={[styles.chip, isOwn ? styles.chipOwn : styles.chipOther]}
+      onPress={() => download(resource)}
+      disabled={downloading}
+      activeOpacity={0.6}
+    >
+      <Text style={styles.emoji}>{mimeEmoji(resource.mime_type)}</Text>
+      <Text
+        style={[styles.name, isOwn ? styles.textOwn : styles.textOther]}
+        numberOfLines={1}
+      >
+        {resource.name}
+      </Text>
+      <Text style={[styles.trailing, isOwn ? styles.textOwn : styles.textOther]}>
+        {downloading ? "…" : "↓"}
+      </Text>
+    </TouchableOpacity>
+  )
+}
+
+function PendingAttachment({
+  upload,
+  isOwn,
+}: {
+  upload: PendingUpload
+  isOwn: boolean
+}) {
+  return (
+    <View style={[styles.chip, isOwn ? styles.chipOwn : styles.chipOther]}>
+      <Text style={styles.emoji}>{mimeEmoji(upload.mimeType)}</Text>
+      <Text
+        style={[styles.name, isOwn ? styles.textOwn : styles.textOther]}
+        numberOfLines={1}
+      >
+        {upload.name}
+      </Text>
+      <Text
+        style={[
+          styles.trailing,
+          isOwn ? styles.textOwn : styles.textOther,
+          upload.status === "error" && styles.errorTrailing,
+        ]}
+      >
+        {pendingLabel(upload.status)}
+      </Text>
+    </View>
+  )
+}
+
+export function MessageAttachments({
+  resources,
+  pendingUploads,
+  isOwn,
+}: MessageAttachmentsProps) {
+  if (resources.length === 0 && pendingUploads.length === 0) return null
+  return (
+    <View style={styles.list}>
+      {pendingUploads.map((u) => (
+        <PendingAttachment key={u.id} upload={u} isOwn={isOwn} />
+      ))}
+      {resources.map((r) => (
+        <SyncedAttachment key={r.id} resource={r} isOwn={isOwn} />
+      ))}
+    </View>
+  )
+}
+
+const styles = StyleSheet.create({
+  list: {
+    gap: 4,
+    marginTop: 6,
+  },
+  chip: {
+    flexDirection: "row",
+    alignItems: "center",
+    gap: 6,
+    borderRadius: 8,
+    paddingHorizontal: 8,
+    paddingVertical: 6,
+  },
+  chipOwn: {
+    backgroundColor: "rgba(255,255,255,0.18)",
+  },
+  chipOther: {
+    backgroundColor: colors.background,
+  },
+  emoji: {
+    fontSize: 14,
+  },
+  name: {
+    flex: 1,
+    fontSize: 12,
+    fontFamily: "InstrumentSans_500Medium",
+  },
+  trailing: {
+    fontSize: 11,
+    fontFamily: "InstrumentSans_600SemiBold",
+  },
+  textOwn: {
+    color: colors.primaryForeground,
+  },
+  textOther: {
+    color: colors.foreground,
+  },
+  errorTrailing: {
+    color: colors.destructive,
+  },
+})

--- a/mobile-app/src/presentation/resources/components/ResourcesSection.tsx
+++ b/mobile-app/src/presentation/resources/components/ResourcesSection.tsx
@@ -1,85 +1,19 @@
 import { View, Text, TouchableOpacity, StyleSheet, Alert } from "react-native"
 import { useState } from "react"
 import { useLiveQuery, eq } from "@tanstack/react-db"
-import * as FileSystem from "expo-file-system/legacy"
-import * as Sharing from "expo-sharing"
+import * as DocumentPicker from "expo-document-picker"
 import { resourcesCollection } from "@/src/application/collections/communication"
-import { createCookieFetch } from "@/src/infrastructure/auth/cookie-fetch"
+import { useSession } from "@/src/infrastructure/auth/client"
+import { usePendingUploads } from "@/src/presentation/resources/hooks/usePendingUploads"
+import { useResourceDownload } from "@/src/presentation/resources/hooks/useResourceDownload"
+import { UploadScheduleModal } from "@/src/presentation/resources/components/UploadScheduleModal"
+import { mimeEmoji, formatBytes } from "@/src/presentation/resources/lib/attachment-format"
+import type { PendingUpload } from "@/src/infrastructure/offline/upload-manager"
 import { colors } from "@/src/presentation/shared/colors"
 import type { Resource } from "@buildinlime/domain-types"
 
-const API_URL = process.env.EXPO_PUBLIC_API_URL ?? "http://10.0.2.2:3000"
-
-function formatBytes(bytes: number | bigint): string {
-  const n = Number(bytes)
-  if (n < 1024) return `${n} B`
-  if (n < 1024 * 1024) return `${(n / 1024).toFixed(1)} KB`
-  return `${(n / (1024 * 1024)).toFixed(1)} MB`
-}
-
-function mimeEmoji(mimeType: string): string {
-  if (mimeType.startsWith("image/")) return "🖼️"
-  if (mimeType.startsWith("video/")) return "🎬"
-  if (mimeType.startsWith("audio/")) return "🎵"
-  if (mimeType === "application/pdf") return "📄"
-  if (mimeType.includes("word") || mimeType.includes("text")) return "📝"
-  return "📎"
-}
-
 function ResourceRow({ resource }: { resource: Resource }) {
-  const [downloading, setDownloading] = useState(false)
-
-  async function handleDownload() {
-    if (downloading) return
-    setDownloading(true)
-    try {
-      const url = `${API_URL}${resource.file_location}`
-      const localUri = `${FileSystem.cacheDirectory}${resource.name}`
-
-      // Use the same cookieFetch that tRPC uses — it sends the Origin header
-      // and any stored session cookies, matching how all other auth requests work.
-      const cookieFetch = createCookieFetch()
-      const response = await cookieFetch(url)
-      if (!response.ok) {
-        Alert.alert("Download failed", `Server returned ${response.status}`)
-        return
-      }
-
-      const blob = await response.blob()
-      const base64 = await new Promise<string>((resolve, reject) => {
-        const reader = new FileReader()
-        reader.onloadend = () => {
-          const result = reader.result as string
-          resolve(result.split(",")[1]) // strip the data URL prefix
-        }
-        reader.onerror = reject
-        reader.readAsDataURL(blob)
-      })
-
-      await FileSystem.writeAsStringAsync(localUri, base64, {
-        encoding: FileSystem.EncodingType.Base64,
-      })
-
-      Alert.alert("Downloaded", `"${resource.name}" saved to device.`, [
-        { text: "Dismiss", style: "cancel" },
-        {
-          text: "Open With…",
-          onPress: async () => {
-            const canShare = await Sharing.isAvailableAsync()
-            if (canShare) {
-              // shareAsync wraps Intent.createChooser on Android, always showing
-              // the full chooser sheet (open with + share options)
-              await Sharing.shareAsync(localUri, { mimeType: resource.mime_type })
-            }
-          },
-        },
-      ])
-    } catch (err) {
-      Alert.alert("Download failed", String(err))
-    } finally {
-      setDownloading(false)
-    }
-  }
+  const { download, downloading } = useResourceDownload()
 
   return (
     <View style={styles.row}>
@@ -93,7 +27,7 @@ function ResourceRow({ resource }: { resource: Resource }) {
       </View>
       <TouchableOpacity
         style={[styles.downloadBtn, downloading && styles.downloadBtnActive]}
-        onPress={handleDownload}
+        onPress={() => download(resource)}
         disabled={downloading}
         hitSlop={{ top: 8, bottom: 8, left: 8, right: 8 }}
         activeOpacity={0.6}
@@ -104,12 +38,80 @@ function ResourceRow({ resource }: { resource: Resource }) {
   )
 }
 
-interface ResourcesSectionProps {
-  channelId: string
+const STATUS_LABEL: Record<PendingUpload["status"], string> = {
+  awaiting_schedule: "Queued",
+  scheduled: "Scheduled",
+  uploading: "Uploading…",
+  awaiting_network: "Waiting for network",
+  error: "Upload failed",
 }
 
-export function ResourcesSection({ channelId }: ResourcesSectionProps) {
+function PendingUploadRow({
+  upload,
+  onRetry,
+  onCancel,
+}: {
+  upload: PendingUpload
+  onRetry: (id: string) => void
+  onCancel: (id: string) => void
+}) {
+  const retryable = upload.status === "error" || upload.status === "awaiting_network"
+  let label: string
+  if (upload.status === "error" && upload.errorMessage) {
+    label = upload.errorMessage
+  } else if (upload.status === "scheduled" && upload.scheduledAt) {
+    label = `Scheduled · ${upload.scheduledAt.toLocaleString()}`
+  } else {
+    label = STATUS_LABEL[upload.status]
+  }
+
+  return (
+    <View style={[styles.row, styles.pendingRow]}>
+      <Text style={styles.emoji}>{mimeEmoji(upload.mimeType)}</Text>
+      <View style={styles.info}>
+        <Text style={styles.name} numberOfLines={1}>{upload.name}</Text>
+        <Text
+          style={[styles.meta, upload.status === "error" && styles.errorMeta]}
+          numberOfLines={1}
+        >
+          {label}
+        </Text>
+      </View>
+      {retryable && (
+        <TouchableOpacity
+          style={styles.downloadBtn}
+          onPress={() => onRetry(upload.id)}
+          hitSlop={{ top: 8, bottom: 8, left: 8, right: 8 }}
+          activeOpacity={0.6}
+        >
+          <Text style={styles.downloadIcon}>↻</Text>
+        </TouchableOpacity>
+      )}
+      <TouchableOpacity
+        style={styles.downloadBtn}
+        onPress={() => onCancel(upload.id)}
+        hitSlop={{ top: 8, bottom: 8, left: 8, right: 8 }}
+        activeOpacity={0.6}
+      >
+        <Text style={styles.downloadIcon}>✕</Text>
+      </TouchableOpacity>
+    </View>
+  )
+}
+
+interface ResourcesSectionProps {
+  channelId: string
+  buildUnitId: string
+  projectId: string
+}
+
+export function ResourcesSection({
+  channelId,
+  buildUnitId,
+  projectId,
+}: ResourcesSectionProps) {
   const [expanded, setExpanded] = useState(true)
+  const { data: session } = useSession()
 
   const { data } = useLiveQuery(
     (q) =>
@@ -118,26 +120,107 @@ export function ResourcesSection({ channelId }: ResourcesSectionProps) {
         .where(({ resourcesCollection: r }) => eq(r.channel_id, channelId)),
     [channelId]
   )
-  const resources = (data ?? []) as Resource[]
+  // Standalone channel resources only — message attachments render inside
+  // their message bubble (see MessageAttachments), not here.
+  const resources = ((data ?? []) as Resource[]).filter((r) => !r.message_id)
 
-  if (resources.length === 0) return null
+  const { pendingUploads, enqueue, start, retry, cancel, schedule } =
+    usePendingUploads({ channelId })
 
+  // The just-picked file, parked in `awaiting_schedule` while the user decides
+  // upload-now vs. schedule-for-later in the modal.
+  const [scheduleTarget, setScheduleTarget] = useState<{
+    id: string
+    name: string
+  } | null>(null)
+
+  async function handleAttach() {
+    const userId = session?.user?.id
+    if (!userId) {
+      Alert.alert("Cannot attach", "Your session is still loading — try again.")
+      return
+    }
+    try {
+      const result = await DocumentPicker.getDocumentAsync({
+        copyToCacheDirectory: true,
+      })
+      if (result.canceled) return
+      const asset = result.assets[0]
+      if (!asset) return
+      // autoStart: false — hold in `awaiting_schedule` until the modal resolves.
+      const id = await enqueue(
+        asset.uri,
+        {
+          name: asset.name,
+          mimeType: asset.mimeType ?? "application/octet-stream",
+          channelId,
+          buildUnitId,
+          projectId,
+          createdById: userId,
+        },
+        { autoStart: false },
+      )
+      setScheduleTarget({ id, name: asset.name })
+    } catch (err) {
+      Alert.alert("Attach failed", String(err))
+    }
+  }
+
+  // Always render: the attach button must be reachable even with no resources.
   return (
     <View style={styles.wrapper}>
-      <TouchableOpacity
-        style={styles.header}
-        onPress={() => setExpanded((v) => !v)}
-        activeOpacity={0.7}
-      >
-        <Text style={styles.label}>Resources</Text>
-        <Text style={styles.chevron}>{expanded ? "⌄" : "›"}</Text>
-      </TouchableOpacity>
+      <View style={styles.header}>
+        <TouchableOpacity
+          style={styles.headerLabel}
+          onPress={() => setExpanded((v) => !v)}
+          activeOpacity={0.7}
+        >
+          <Text style={styles.label}>Resources</Text>
+          <Text style={styles.chevron}>{expanded ? "⌄" : "›"}</Text>
+        </TouchableOpacity>
+        <TouchableOpacity
+          onPress={handleAttach}
+          hitSlop={{ top: 8, bottom: 8, left: 8, right: 8 }}
+          activeOpacity={0.6}
+        >
+          <Text style={styles.attach}>+ Attach</Text>
+        </TouchableOpacity>
+      </View>
       {expanded && (
         <View style={styles.list}>
+          {pendingUploads.map((u) => (
+            <PendingUploadRow
+              key={u.id}
+              upload={u}
+              onRetry={retry}
+              onCancel={cancel}
+            />
+          ))}
           {resources.map((r) => (
             <ResourceRow key={r.id} resource={r} />
           ))}
+          {resources.length === 0 && pendingUploads.length === 0 && (
+            <Text style={styles.empty}>No resources yet.</Text>
+          )}
         </View>
+      )}
+      {scheduleTarget && (
+        <UploadScheduleModal
+          visible
+          fileName={scheduleTarget.name}
+          onUploadNow={() => {
+            start(scheduleTarget.id)
+            setScheduleTarget(null)
+          }}
+          onSchedule={(when) => {
+            void schedule(scheduleTarget.id, when)
+            setScheduleTarget(null)
+          }}
+          onCancel={() => {
+            void cancel(scheduleTarget.id)
+            setScheduleTarget(null)
+          }}
+        />
       )}
     </View>
   )
@@ -157,6 +240,11 @@ const styles = StyleSheet.create({
     justifyContent: "space-between",
     marginBottom: 6,
   },
+  headerLabel: {
+    flexDirection: "row",
+    alignItems: "center",
+    gap: 4,
+  },
   label: {
     fontSize: 11,
     fontFamily: "InstrumentSans_500Medium",
@@ -169,8 +257,19 @@ const styles = StyleSheet.create({
     color: colors.mutedForeground,
     lineHeight: 20,
   },
+  attach: {
+    fontSize: 12,
+    fontFamily: "InstrumentSans_600SemiBold",
+    color: colors.primary,
+  },
   list: {
     gap: 6,
+  },
+  empty: {
+    fontSize: 12,
+    fontFamily: "InstrumentSans_400Regular",
+    color: colors.mutedForeground,
+    paddingVertical: 4,
   },
   row: {
     flexDirection: "row",
@@ -180,6 +279,9 @@ const styles = StyleSheet.create({
     borderRadius: 6,
     paddingHorizontal: 10,
     paddingVertical: 8,
+  },
+  pendingRow: {
+    opacity: 0.85,
   },
   emoji: {
     fontSize: 16,
@@ -197,6 +299,9 @@ const styles = StyleSheet.create({
     fontSize: 11,
     fontFamily: "InstrumentSans_400Regular",
     color: colors.mutedForeground,
+  },
+  errorMeta: {
+    color: colors.destructive,
   },
   downloadBtn: {
     width: 28,

--- a/mobile-app/src/presentation/resources/components/UploadScheduleModal.tsx
+++ b/mobile-app/src/presentation/resources/components/UploadScheduleModal.tsx
@@ -1,0 +1,204 @@
+import { useState } from "react"
+import { Modal, View, Text, TouchableOpacity, StyleSheet } from "react-native"
+import DateTimePicker, {
+  type DateTimePickerEvent,
+} from "@react-native-community/datetimepicker"
+import { colors } from "@/src/presentation/shared/colors"
+
+// Choose when a freshly-picked file uploads: immediately, or at a future
+// date/time. Mobile counterpart of web's upload-schedule-popover.
+//
+// The native picker only handles one field at a time, so a scheduled time is
+// collected in two steps: date, then time.
+
+interface UploadScheduleModalProps {
+  visible: boolean
+  fileName: string
+  onUploadNow: () => void
+  onSchedule: (when: Date) => void
+  /** Dismiss without uploading — the caller cancels the pending upload. */
+  onCancel: () => void
+}
+
+type PickerStage = "date" | "time" | null
+
+function defaultFuture(): Date {
+  return new Date(Date.now() + 60 * 60 * 1000) // one hour out
+}
+
+export function UploadScheduleModal({
+  visible,
+  fileName,
+  onUploadNow,
+  onSchedule,
+  onCancel,
+}: UploadScheduleModalProps) {
+  const [stage, setStage] = useState<PickerStage>(null)
+  const [draftDate, setDraftDate] = useState<Date>(defaultFuture())
+  const [selected, setSelected] = useState<Date | null>(null)
+
+  function reset() {
+    setStage(null)
+    setDraftDate(defaultFuture())
+    setSelected(null)
+  }
+
+  function handlePickerChange(event: DateTimePickerEvent, value?: Date) {
+    if (event.type === "dismissed" || !value) {
+      setStage(null)
+      return
+    }
+    if (stage === "date") {
+      // Carry the Y/M/D; the time step overwrites H:M next.
+      setDraftDate(value)
+      setStage("time")
+      return
+    }
+    // stage === "time"
+    const merged = new Date(draftDate)
+    merged.setHours(value.getHours(), value.getMinutes(), 0, 0)
+    setSelected(merged)
+    setStage(null)
+  }
+
+  const canSchedule = selected !== null && selected.getTime() > Date.now()
+
+  return (
+    <Modal
+      visible={visible}
+      transparent
+      animationType="fade"
+      onRequestClose={() => {
+        reset()
+        onCancel()
+      }}
+    >
+      <View style={styles.backdrop}>
+        <View style={styles.sheet}>
+          <Text style={styles.title} numberOfLines={1}>
+            Upload “{fileName}”
+          </Text>
+
+          <TouchableOpacity
+            style={styles.primaryBtn}
+            activeOpacity={0.8}
+            onPress={() => {
+              reset()
+              onUploadNow()
+            }}
+          >
+            <Text style={styles.primaryBtnText}>Upload now</Text>
+          </TouchableOpacity>
+
+          <View style={styles.divider} />
+
+          <TouchableOpacity
+            style={styles.secondaryBtn}
+            activeOpacity={0.7}
+            onPress={() => setStage("date")}
+          >
+            <Text style={styles.secondaryBtnText}>
+              {selected
+                ? `📅 ${selected.toLocaleString()}`
+                : "📅 Pick a date & time"}
+            </Text>
+          </TouchableOpacity>
+
+          <TouchableOpacity
+            style={[styles.primaryBtn, !canSchedule && styles.disabledBtn]}
+            activeOpacity={0.8}
+            disabled={!canSchedule}
+            onPress={() => {
+              if (!selected) return
+              const when = selected
+              reset()
+              onSchedule(when)
+            }}
+          >
+            <Text style={styles.primaryBtnText}>Schedule upload</Text>
+          </TouchableOpacity>
+
+          <TouchableOpacity
+            style={styles.cancelBtn}
+            activeOpacity={0.7}
+            onPress={() => {
+              reset()
+              onCancel()
+            }}
+          >
+            <Text style={styles.cancelBtnText}>Cancel</Text>
+          </TouchableOpacity>
+
+          {stage && (
+            <DateTimePicker
+              value={stage === "time" ? draftDate : selected ?? draftDate}
+              mode={stage}
+              minimumDate={stage === "date" ? new Date() : undefined}
+              onChange={handlePickerChange}
+            />
+          )}
+        </View>
+      </View>
+    </Modal>
+  )
+}
+
+const styles = StyleSheet.create({
+  backdrop: {
+    flex: 1,
+    backgroundColor: "rgba(0,0,0,0.4)",
+    justifyContent: "center",
+    paddingHorizontal: 24,
+  },
+  sheet: {
+    backgroundColor: colors.background,
+    borderRadius: 12,
+    padding: 20,
+    gap: 10,
+  },
+  title: {
+    fontSize: 15,
+    fontFamily: "InstrumentSans_600SemiBold",
+    color: colors.foreground,
+    marginBottom: 4,
+  },
+  primaryBtn: {
+    backgroundColor: colors.primary,
+    borderRadius: 8,
+    paddingVertical: 12,
+    alignItems: "center",
+  },
+  primaryBtnText: {
+    color: colors.primaryForeground,
+    fontSize: 14,
+    fontFamily: "InstrumentSans_600SemiBold",
+  },
+  disabledBtn: {
+    opacity: 0.4,
+  },
+  secondaryBtn: {
+    backgroundColor: colors.muted,
+    borderRadius: 8,
+    paddingVertical: 12,
+    alignItems: "center",
+  },
+  secondaryBtnText: {
+    color: colors.foreground,
+    fontSize: 14,
+    fontFamily: "InstrumentSans_500Medium",
+  },
+  divider: {
+    height: 1,
+    backgroundColor: colors.border,
+    marginVertical: 2,
+  },
+  cancelBtn: {
+    paddingVertical: 8,
+    alignItems: "center",
+  },
+  cancelBtnText: {
+    color: colors.mutedForeground,
+    fontSize: 13,
+    fontFamily: "InstrumentSans_500Medium",
+  },
+})

--- a/mobile-app/src/presentation/resources/hooks/usePendingUploads.ts
+++ b/mobile-app/src/presentation/resources/hooks/usePendingUploads.ts
@@ -1,0 +1,57 @@
+import { useEffect, useState } from "react"
+import {
+  subscribe,
+  enqueueUpload,
+  startUpload,
+  retryUpload,
+  cancelUpload,
+  scheduleUpload,
+  type PendingUpload,
+} from "@/src/infrastructure/offline/upload-manager"
+
+// Thin observer over the upload-manager service. All logic — copying files,
+// uploading, retrying, persistence — lives in the service so uploads survive
+// screen unmounts; this hook only exposes the slice of pending state a screen
+// cares about and re-renders on change.
+
+export interface UsePendingUploadsFilter {
+  /** Standalone (channel-level) uploads: those with no message association. */
+  channelId?: string
+  /** Uploads attached to a specific message. */
+  messageId?: string
+}
+
+export function usePendingUploads(filter: UsePendingUploadsFilter) {
+  const [all, setAll] = useState<PendingUpload[]>([])
+
+  useEffect(() => subscribe(setAll), [])
+
+  const { channelId, messageId } = filter
+  const pendingUploads = all.filter((u) => {
+    if (messageId) return u.messageId === messageId
+    if (channelId) return u.channelId === channelId && !u.messageId
+    return false
+  })
+
+  return {
+    pendingUploads,
+    enqueue: enqueueUpload,
+    start: startUpload,
+    retry: retryUpload,
+    cancel: cancelUpload,
+    schedule: scheduleUpload,
+  }
+}
+
+/**
+ * All in-flight uploads in a channel that are attached to a message — used by
+ * MessageList to show attachments inside their message bubble before the
+ * server-created `resources` row has synced back.
+ */
+export function useChannelMessageUploads(channelId: string): PendingUpload[] {
+  const [all, setAll] = useState<PendingUpload[]>([])
+
+  useEffect(() => subscribe(setAll), [])
+
+  return all.filter((u) => u.channelId === channelId && !!u.messageId)
+}

--- a/mobile-app/src/presentation/resources/hooks/useResourceDownload.ts
+++ b/mobile-app/src/presentation/resources/hooks/useResourceDownload.ts
@@ -1,0 +1,116 @@
+import { useState } from "react"
+import { Alert, Platform } from "react-native"
+import * as FileSystem from "expo-file-system/legacy"
+import * as Sharing from "expo-sharing"
+import { getAuthHeaders } from "@/src/infrastructure/auth/cookie-fetch"
+import type { Resource } from "@buildinlime/domain-types"
+
+// Shared resource-download logic — used by both the Resources section and
+// message attachments. Streams the file to disk, then makes it user-visible:
+// a public folder on Android (Storage Access Framework), the share sheet's
+// "Save to Files" on iOS.
+
+const API_URL = process.env.EXPO_PUBLIC_API_URL ?? "http://10.0.2.2:3000"
+
+// A folder the user granted write access to via the Android Storage Access
+// Framework. Cached for the session so repeat downloads don't re-prompt.
+let androidPublicDir: string | null = null
+
+/**
+ * Copy a downloaded cache file into a user-chosen public folder on Android.
+ * Returns true on success, false if the user declined / it failed (the caller
+ * then falls back to the share sheet).
+ *
+ * The SAF write itself goes base64 (SAF content URIs only accept string
+ * writes) — a local disk copy, NOT the network transfer, which was already
+ * streamed by downloadAsync.
+ */
+async function saveToAndroidPublicDir(
+  cacheUri: string,
+  name: string,
+  mimeType: string,
+): Promise<boolean> {
+  const SAF = FileSystem.StorageAccessFramework
+  try {
+    if (!androidPublicDir) {
+      const perm = await SAF.requestDirectoryPermissionsAsync()
+      if (!perm.granted) return false
+      androidPublicDir = perm.directoryUri
+    }
+    const base64 = await FileSystem.readAsStringAsync(cacheUri, {
+      encoding: FileSystem.EncodingType.Base64,
+    })
+    const destUri = await SAF.createFileAsync(androidPublicDir, name, mimeType)
+    await FileSystem.writeAsStringAsync(destUri, base64, {
+      encoding: FileSystem.EncodingType.Base64,
+    })
+    return true
+  } catch {
+    // Permission revoked or write failed — drop the cached grant and let the
+    // caller fall back to sharing.
+    androidPublicDir = null
+    return false
+  }
+}
+
+type DownloadableResource = Pick<
+  Resource,
+  "name" | "file_location" | "mime_type"
+>
+
+export function useResourceDownload() {
+  const [downloading, setDownloading] = useState(false)
+
+  async function download(resource: DownloadableResource) {
+    if (downloading) return
+    setDownloading(true)
+    try {
+      const url = `${API_URL}${resource.file_location}`
+      const cacheUri = `${FileSystem.cacheDirectory}${resource.name}`
+
+      // Stream the response straight to disk. downloadAsync does its own native
+      // networking, so it bypasses cookieFetch — auth headers (session cookie +
+      // Origin) are passed explicitly via the shared getAuthHeaders builder.
+      const headers = await getAuthHeaders()
+      const { status } = await FileSystem.downloadAsync(url, cacheUri, { headers })
+      if (status !== 200) {
+        Alert.alert("Download failed", `Server returned ${status}`)
+        return
+      }
+
+      // Android: copy into a user-picked public folder so it shows up in the
+      // Files app. iOS has no writable public folder — the OS pattern there is
+      // the share sheet's "Save to Files", so we share instead.
+      if (Platform.OS === "android") {
+        const saved = await saveToAndroidPublicDir(
+          cacheUri,
+          resource.name,
+          resource.mime_type,
+        )
+        if (saved) {
+          Alert.alert("Saved", `"${resource.name}" saved to your chosen folder.`)
+          return
+        }
+        // declined / failed — fall through to the share sheet
+      }
+
+      const canShare = await Sharing.isAvailableAsync()
+      if (canShare) {
+        // shareAsync wraps Intent.createChooser on Android, always showing the
+        // full chooser sheet (open with + "Save to Files"/Drive/etc.)
+        await Sharing.shareAsync(cacheUri, { mimeType: resource.mime_type })
+      } else {
+        Alert.alert(
+          "Downloaded",
+          `"${resource.name}" downloaded, but sharing is unavailable on this device.`,
+        )
+      }
+    } catch (err) {
+      Alert.alert("Download failed", String(err))
+    } finally {
+      setDownloading(false)
+    }
+  }
+
+  return { download, downloading }
+}

--- a/mobile-app/src/presentation/resources/lib/attachment-format.ts
+++ b/mobile-app/src/presentation/resources/lib/attachment-format.ts
@@ -1,0 +1,18 @@
+// Shared display helpers for attachments — used by the Resources section and
+// by message attachments.
+
+export function formatBytes(bytes: number | bigint): string {
+  const n = Number(bytes)
+  if (n < 1024) return `${n} B`
+  if (n < 1024 * 1024) return `${(n / 1024).toFixed(1)} KB`
+  return `${(n / (1024 * 1024)).toFixed(1)} MB`
+}
+
+export function mimeEmoji(mimeType: string): string {
+  if (mimeType.startsWith("image/")) return "🖼️"
+  if (mimeType.startsWith("video/")) return "🎬"
+  if (mimeType.startsWith("audio/")) return "🎵"
+  if (mimeType === "application/pdf") return "📄"
+  if (mimeType.includes("word") || mimeType.includes("text")) return "📝"
+  return "📎"
+}

--- a/web-app/code/src/infrastructure/database/schema/communication-tables.ts
+++ b/web-app/code/src/infrastructure/database/schema/communication-tables.ts
@@ -130,6 +130,11 @@ export const createMessageSchema = createInsertSchema(messagesTable).omit({
   created_at: true,
 }).extend({
   parent_id: z.string().nullish(),
+  // Accept the client's optimistic send time. Without it, offline-transactions
+  // replay stamps the row with the (much later) server insert time, so a
+  // message jumps position when it transitions optimistic→synced. Optional —
+  // falls back to the column's defaultNow() when the client omits it.
+  created_at: z.coerce.date().optional(),
 })
 export const updateMessageSchema = createUpdateSchema(messagesTable)
 

--- a/web-app/code/src/infrastructure/offline/mutation-fns.ts
+++ b/web-app/code/src/infrastructure/offline/mutation-fns.ts
@@ -111,6 +111,10 @@ const createMessage: MutationFn = async ({ transaction }) => {
     await trpc.messages.create.mutate({
       id: m.id as string,
       text: m.text as string,
+      // Forward the client's optimistic send time so the synced row keeps the
+      // same created_at the UI sorted on — see createMessageSchema. Serialised
+      // through the outbox as an ISO string; the server coerces it back.
+      created_at: m.created_at as string,
       channel_id: m.channel_id as string,
       buildunit_id: m.buildunit_id as string,
       project_id: m.project_id as string,


### PR DESCRIPTION
## Summary

Adds file attachment support to the mobile app, plus a message-ordering fix that also lands on the web client.

Attachments are handled by a **standalone upload manager**, deliberately kept separate from the `@tanstack/offline-transactions` outbox — multi-MB binaries don't belong in a JSON-serialised mutation queue. The upload *is* the resource "create": the server creates the `resources` row on a successful upload and Electric syncs it back.

## What's included

**Upload manager** (`upload-manager.ts`)
- Singleton service (not a hook) so uploads survive screen unmounts
- Copies picked files into durable storage, multipart-POSTs via `cookieFetch`, retries with exponential backoff (cap 30s, 5 auto-retries), auto-retries on reconnect
- Supports immediate, deferred (message-attached), and scheduled uploads

**Dedicated SQLite DB** (`pending-uploads-db.ts`)
- Attachment metadata lives in its **own** database file. Sharing the main collections DB caused `database is locked` / `Failed to persist wrapped sync transaction` against Electric's sync persistence — the same contention that forced the offline outbox into its own file.

**UI**
- Channel-level attachments in `ResourcesSection` with an upload-now / schedule modal
- Message attachments in `MessageInput` (chips), rendered inside message bubbles via `MessageAttachments`
- Streamed downloads saved to a user-visible public location: Android Storage Access Framework, iOS share sheet

**Shared infrastructure**
- Single shared online-detector singleton for the executor + upload manager
- `getAuthHeaders()` extracted from `cookieFetch` so streamed file transfers send consistent auth

**Message ordering fix**
- The client now sends its optimistic `created_at`; the server schema accepts it (`z.coerce.date().optional()`, falls back to `defaultNow()`). A message keeps its sort position across the optimistic→synced transition instead of jumping to the server replay time. Applied to both the mobile and web clients.

## Testing

- `tsc --noEmit`, `eslint`, and `expo export` all clean for the changed files (pre-existing repo-wide type/lint noise excluded)
- No full `vite build` run on the web app; the web change is a single additive optional schema field plus a one-line client change

🤖 Generated with [Claude Code](https://claude.com/claude-code)