### PR TITLE
feat(web/auth): cache session in signed cookie to cut per-poll DB reads

### DIFF
--- a/web-app/code/src/infrastructure/auth/server.ts
+++ b/web-app/code/src/infrastructure/auth/server.ts
@@ -50,6 +50,43 @@ export const auth = betterAuth({
     updateAge: 60 * 60 * 24,
     // Store sessions in database (recommended for production)
     storeSessionInDatabase: true,
+    // Serve the session from a signed cookie for up to `maxAge` seconds so
+    // getSession skips the DB on the hot path. The Electric shape routes call
+    // getSession on every long-poll across every collection, so this takes the
+    // per-poll session read off the critical path (reduction ~= maxAge / poll
+    // interval; with ~20s long-polls, 50s ≈ 3x fewer session DB reads).
+    //
+    // SECURITY TRADEOFF — session-revocation lag (accepted for now, POC):
+    // While a cached cookie is valid, getSession trusts it WITHOUT consulting
+    // the DB, so anything that revokes a session server-side is delayed by up
+    // to maxAge. In a sync app this means a de-authorized identity can keep
+    // streaming Electric data for up to ~maxAge. Blast radius is limited here
+    // because authorization is membership/ownership-driven (checked server-side
+    // per shape and re-verified against the DB in tRPC mutations) and the
+    // session only vouches for the immutable user id — a stale cookie cannot
+    // ELEVATE privileges, only extend an already-authenticated identity.
+    //
+    // The cache uses better-auth's default `compact` strategy: the payload is
+    // HMAC-SIGNED (tamper-proof) but NOT encrypted, so it is readable by anyone
+    // who obtains the cookie. It is httpOnly (not JS/XSS-readable) and carries
+    // only identity, so this is acceptable; switch strategy to `jwe` if the
+    // payload ever needs confidentiality.
+    //
+    // FUTURE WORK — the severe edge cases where the lag matters and should be
+    // hardened before this is treated as production-grade:
+    //   1. Account ban / disable and "sign out everywhere" — revoked user keeps
+    //      access for up to maxAge. Consider a fast revocation path or
+    //      bypassing the cache (disableCookieCache) for these flows. Bumping
+    //      `cookieCache.version` invalidates ALL cached sessions immediately and
+    //      is the blunt global escape hatch.
+    //   2. Password reset after credential compromise — old sessions stay valid
+    //      for up to maxAge.
+    //   3. Account deletion / email change (both enabled below) — force fresh
+    //      session validation on these actions rather than trusting the cache.
+    //   4. BETTER_AUTH_SECRET is now the sole integrity backstop (no DB check
+    //      within the TTL) — ensure it stays >=32 chars, high-entropy, secret,
+    //      and rotate on any suspected exposure.
+    cookieCache: { enabled: true, maxAge: 50 },
   },
   
   // User configuration


### PR DESCRIPTION
## What

Enable better-auth session `cookieCache` (`maxAge: 50s`) so `getSession` is served from a signed cookie on the hot path instead of querying the `sessions` table.

## Why

The Electric shape routes call `getSession` on **every** long-poll, across **every** collection (~11 collections re-polling ~every 20s per open tab). That makes the per-request session lookup the dominant direct DB query on the sync/poll path. Caching it in a signed cookie takes that read off the critical path.

- Reduction ≈ `maxAge / poll-interval` → with ~20s long-polls, 50s ≈ **~3× fewer session DB reads**.
- 50s is deliberately **tighter** than better-auth's 300s default, to bound revocation lag.

## Security tradeoff (documented inline)

While a cached cookie is valid, `getSession` trusts it **without** a DB check, so session revocation is delayed by up to `maxAge`. Blast radius is limited here because authorization is **membership/ownership-driven** (checked server-side per Electric shape and re-verified against the DB in tRPC mutations); the session only vouches for the **immutable user id**, so a stale cookie cannot elevate privileges.

The code comment lists the **severe edge cases** to harden before this is production-grade: ban / "sign out everywhere", password reset after compromise, account deletion / email change, and `BETTER_AUTH_SECRET` criticality (with `cookieCache.version` noted as the global invalidate-all lever). Cache uses the default `compact` strategy (HMAC-signed, not encrypted; httpOnly; identity-only payload).

## Scope

Single file, config-only: `web-app/code/src/infrastructure/auth/server.ts`. Type-checked against installed better-auth 1.5.5.

## Verify

DevTools → Network: confirm a `better-auth`-prefixed session-cache cookie is set, and `sessions`-table reads drop off during steady polling. Confirm normal login/logout still works.

🤖 Generated with [Claude Code](https://claude.com/claude-code)