### PR TITLE
fix(web): pre-rollout minor fixes — reload data loss, offline dup, property/panel bugs

### DIFF
--- a/web-app/code/drizzle/0002_slow_king_bedlam.sql
+++ b/web-app/code/drizzle/0002_slow_king_bedlam.sql
@@ -1,0 +1,2 @@
+ALTER TABLE "properties" ADD COLUMN "createdby_id" text;--> statement-breakpoint
+ALTER TABLE "properties" ADD CONSTRAINT "properties_createdby_id_users_id_fk" FOREIGN KEY ("createdby_id") REFERENCES "public"."users"("id") ON DELETE cascade ON UPDATE no action;

--- a/web-app/code/drizzle/meta/0002_snapshot.json
+++ b/web-app/code/drizzle/meta/0002_snapshot.json
@@ -1,0 +1,1442 @@
+{
+  "id": "020a867c-e0de-4684-8be6-b60393b9708b",
+  "prevId": "431ee848-8afb-4a95-9506-d4c8fff4d681",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.accounts": {
+      "name": "accounts",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "access_token": {
+          "name": "access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token": {
+          "name": "refresh_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "id_token": {
+          "name": "id_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "access_token_expires_at": {
+          "name": "access_token_expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token_expires_at": {
+          "name": "refresh_token_expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "password": {
+          "name": "password",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "accounts_user_id_users_id_fk": {
+          "name": "accounts_user_id_users_id_fk",
+          "tableFrom": "accounts",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.sessions": {
+      "name": "sessions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ip_address": {
+          "name": "ip_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "sessions_user_id_users_id_fk": {
+          "name": "sessions_user_id_users_id_fk",
+          "tableFrom": "sessions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "sessions_token_unique": {
+          "name": "sessions_token_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "token"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.users": {
+      "name": "users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email_verified": {
+          "name": "email_verified",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "image": {
+          "name": "image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "users_email_unique": {
+          "name": "users_email_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "email"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.verifications": {
+      "name": "verifications",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "identifier": {
+          "name": "identifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.build_units": {
+      "name": "build_units",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "health": {
+          "name": "health",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "priority": {
+          "name": "priority",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "task_name": {
+          "name": "task_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "task_assignee": {
+          "name": "task_assignee",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "task_since": {
+          "name": "task_since",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "target_date": {
+          "name": "target_date",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status_percent": {
+          "name": "status_percent",
+          "type": "varchar(10)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "owner_id": {
+          "name": "owner_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "build_units_project_id_projects_id_fk": {
+          "name": "build_units_project_id_projects_id_fk",
+          "tableFrom": "build_units",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "build_units_owner_id_users_id_fk": {
+          "name": "build_units_owner_id_users_id_fk",
+          "tableFrom": "build_units",
+          "tableTo": "users",
+          "columnsFrom": [
+            "owner_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.channels": {
+      "name": "channels",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "buildunit_id": {
+          "name": "buildunit_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "owner_id": {
+          "name": "owner_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "channels_buildunit_id_build_units_id_fk": {
+          "name": "channels_buildunit_id_build_units_id_fk",
+          "tableFrom": "channels",
+          "tableTo": "build_units",
+          "columnsFrom": [
+            "buildunit_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "channels_owner_id_users_id_fk": {
+          "name": "channels_owner_id_users_id_fk",
+          "tableFrom": "channels",
+          "tableTo": "users",
+          "columnsFrom": [
+            "owner_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.memberships": {
+      "name": "memberships",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "channel_id": {
+          "name": "channel_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "buildunit_id": {
+          "name": "buildunit_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "member_flag": {
+          "name": "member_flag",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'viewer'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "memberships_user_channel_unique": {
+          "name": "memberships_user_channel_unique",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "channel_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "memberships_user_id_users_id_fk": {
+          "name": "memberships_user_id_users_id_fk",
+          "tableFrom": "memberships",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "memberships_channel_id_channels_id_fk": {
+          "name": "memberships_channel_id_channels_id_fk",
+          "tableFrom": "memberships",
+          "tableTo": "channels",
+          "columnsFrom": [
+            "channel_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "memberships_buildunit_id_build_units_id_fk": {
+          "name": "memberships_buildunit_id_build_units_id_fk",
+          "tableFrom": "memberships",
+          "tableTo": "build_units",
+          "columnsFrom": [
+            "buildunit_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "memberships_project_id_projects_id_fk": {
+          "name": "memberships_project_id_projects_id_fk",
+          "tableFrom": "memberships",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.projects": {
+      "name": "projects",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "priority": {
+          "name": "priority",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "target_date": {
+          "name": "target_date",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "owner_id": {
+          "name": "owner_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status_percent": {
+          "name": "status_percent",
+          "type": "varchar(10)",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "projects_owner_id_users_id_fk": {
+          "name": "projects_owner_id_users_id_fk",
+          "tableFrom": "projects",
+          "tableTo": "users",
+          "columnsFrom": [
+            "owner_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.messages": {
+      "name": "messages",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "text": {
+          "name": "text",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "channel_id": {
+          "name": "channel_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "buildunit_id": {
+          "name": "buildunit_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "createdby_id": {
+          "name": "createdby_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "mention_ids": {
+          "name": "mention_ids",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "resource_ids": {
+          "name": "resource_ids",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "parent_id": {
+          "name": "parent_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "messages_channel_id_channels_id_fk": {
+          "name": "messages_channel_id_channels_id_fk",
+          "tableFrom": "messages",
+          "tableTo": "channels",
+          "columnsFrom": [
+            "channel_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "messages_buildunit_id_build_units_id_fk": {
+          "name": "messages_buildunit_id_build_units_id_fk",
+          "tableFrom": "messages",
+          "tableTo": "build_units",
+          "columnsFrom": [
+            "buildunit_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "messages_project_id_projects_id_fk": {
+          "name": "messages_project_id_projects_id_fk",
+          "tableFrom": "messages",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "messages_createdby_id_users_id_fk": {
+          "name": "messages_createdby_id_users_id_fk",
+          "tableFrom": "messages",
+          "tableTo": "users",
+          "columnsFrom": [
+            "createdby_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "messages_parent_id_messages_id_fk": {
+          "name": "messages_parent_id_messages_id_fk",
+          "tableFrom": "messages",
+          "tableTo": "messages",
+          "columnsFrom": [
+            "parent_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.properties": {
+      "name": "properties",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "entity": {
+          "name": "entity",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "entity_id": {
+          "name": "entity_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "channel_id": {
+          "name": "channel_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdby_id": {
+          "name": "createdby_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status_value": {
+          "name": "status_value",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "priority_value": {
+          "name": "priority_value",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "target_date": {
+          "name": "target_date",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "start_date": {
+          "name": "start_date",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "pending_task": {
+          "name": "pending_task",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "label_value": {
+          "name": "label_value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "properties_channel_id_channels_id_fk": {
+          "name": "properties_channel_id_channels_id_fk",
+          "tableFrom": "properties",
+          "tableTo": "channels",
+          "columnsFrom": [
+            "channel_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "properties_createdby_id_users_id_fk": {
+          "name": "properties_createdby_id_users_id_fk",
+          "tableFrom": "properties",
+          "tableTo": "users",
+          "columnsFrom": [
+            "createdby_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.resources_raw": {
+      "name": "resources_raw",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "resource_id": {
+          "name": "resource_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "storage_path": {
+          "name": "storage_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "original_filename": {
+          "name": "original_filename",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "mime_type": {
+          "name": "mime_type",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "file_size_bytes": {
+          "name": "file_size_bytes",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "uploaded_at": {
+          "name": "uploaded_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "resources_raw_resource_id_resources_id_fk": {
+          "name": "resources_raw_resource_id_resources_id_fk",
+          "tableFrom": "resources_raw",
+          "tableTo": "resources",
+          "columnsFrom": [
+            "resource_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.resources": {
+      "name": "resources",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "file_location": {
+          "name": "file_location",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "mime_type": {
+          "name": "mime_type",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "file_size_bytes": {
+          "name": "file_size_bytes",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "uploaded_at": {
+          "name": "uploaded_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "message_id": {
+          "name": "message_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "task_id": {
+          "name": "task_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "channel_id": {
+          "name": "channel_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "buildunit_id": {
+          "name": "buildunit_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "createdby_id": {
+          "name": "createdby_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "resources_message_id_messages_id_fk": {
+          "name": "resources_message_id_messages_id_fk",
+          "tableFrom": "resources",
+          "tableTo": "messages",
+          "columnsFrom": [
+            "message_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "resources_task_id_tasks_id_fk": {
+          "name": "resources_task_id_tasks_id_fk",
+          "tableFrom": "resources",
+          "tableTo": "tasks",
+          "columnsFrom": [
+            "task_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "resources_channel_id_channels_id_fk": {
+          "name": "resources_channel_id_channels_id_fk",
+          "tableFrom": "resources",
+          "tableTo": "channels",
+          "columnsFrom": [
+            "channel_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "resources_buildunit_id_build_units_id_fk": {
+          "name": "resources_buildunit_id_build_units_id_fk",
+          "tableFrom": "resources",
+          "tableTo": "build_units",
+          "columnsFrom": [
+            "buildunit_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "resources_project_id_projects_id_fk": {
+          "name": "resources_project_id_projects_id_fk",
+          "tableFrom": "resources",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "resources_createdby_id_users_id_fk": {
+          "name": "resources_createdby_id_users_id_fk",
+          "tableFrom": "resources",
+          "tableTo": "users",
+          "columnsFrom": [
+            "createdby_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.tasks": {
+      "name": "tasks",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "completed": {
+          "name": "completed",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "opened_at": {
+          "name": "opened_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "closed_at": {
+          "name": "closed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "channel_id": {
+          "name": "channel_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "buildunit_id": {
+          "name": "buildunit_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "createdby_id": {
+          "name": "createdby_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "assignee_id": {
+          "name": "assignee_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "tasks_channel_id_channels_id_fk": {
+          "name": "tasks_channel_id_channels_id_fk",
+          "tableFrom": "tasks",
+          "tableTo": "channels",
+          "columnsFrom": [
+            "channel_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "tasks_buildunit_id_build_units_id_fk": {
+          "name": "tasks_buildunit_id_build_units_id_fk",
+          "tableFrom": "tasks",
+          "tableTo": "build_units",
+          "columnsFrom": [
+            "buildunit_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "tasks_createdby_id_users_id_fk": {
+          "name": "tasks_createdby_id_users_id_fk",
+          "tableFrom": "tasks",
+          "tableTo": "users",
+          "columnsFrom": [
+            "createdby_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "tasks_assignee_id_users_id_fk": {
+          "name": "tasks_assignee_id_users_id_fk",
+          "tableFrom": "tasks",
+          "tableTo": "users",
+          "columnsFrom": [
+            "assignee_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.teams": {
+      "name": "teams",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "owner_id": {
+          "name": "owner_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "member_ids": {
+          "name": "member_ids",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "teams_owner_id_users_id_fk": {
+          "name": "teams_owner_id_users_id_fk",
+          "tableFrom": "teams",
+          "tableTo": "users",
+          "columnsFrom": [
+            "owner_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "teams_project_id_projects_id_fk": {
+          "name": "teams_project_id_projects_id_fk",
+          "tableFrom": "teams",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {},
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/web-app/code/drizzle/meta/_journal.json
+++ b/web-app/code/drizzle/meta/_journal.json
@@ -15,6 +15,13 @@
       "when": 1783345271870,
       "tag": "0001_striped_punisher",
       "breakpoints": true
+    },
+    {
+      "idx": 2,
+      "version": "7",
+      "when": 1783362775307,
+      "tag": "0002_slow_king_bedlam",
+      "breakpoints": true
     }
   ]
 }

--- a/web-app/code/src/application/collections/communication.ts
+++ b/web-app/code/src/application/collections/communication.ts
@@ -99,10 +99,14 @@ function _makeResourcesCollection(memberChannelIds: string[]) {
   )
 }
 
-// Bumped 1 → 2: the properties row shape gained `channel_id` and the shape
-// scope changed (channel/task properties now sync by channel_id instead of a
-// member_task_ids snapshot), so the OPFS cache must be invalidated.
-const PROPERTIES_SCHEMA_VERSION = 2
+// MUST stay equal to every other collection's schema version. The persistence
+// coordinator holds ONE adapter shared across all collections, and adapters are
+// cached/keyed by schemaVersion — a different value here spawns a second adapter
+// that overwrites the coordinator's, which then drives the other collections'
+// offset/data through the wrong namespace and strands them on reload (Electric
+// reports "up-to-date" but OPFS has no rows). The nullable channel_id addition
+// is re-synced from Electric, so no cache-invalidation bump is needed.
+const PROPERTIES_SCHEMA_VERSION = 1
 
 function _makePropertiesCollection(
   persistence: Awaited<ReturnType<typeof getPersistence>>["persistence"],

--- a/web-app/code/src/infrastructure/database/schema/communication-tables.ts
+++ b/web-app/code/src/infrastructure/database/schema/communication-tables.ts
@@ -114,6 +114,11 @@ export const propertiesTable = pgTable(`properties`, {
   // of a per-task id snapshot, so a new task's properties in a visible channel
   // are covered with no collection rebuild.
   channel_id: text(`channel_id`).references(() => channelsTable.id, { onDelete: `cascade` }),
+  // The user who created the property. Acts as an owner escape hatch in the
+  // properties shape (OR createdby_id = me), so properties on an entity you own
+  // but that has no membership yet — e.g. a build-unit/project with no channel —
+  // still sync. Mirrors the `owner_id = me` clause on the entity shapes.
+  createdby_id: text(`createdby_id`).references(() => users.id, { onDelete: `cascade` }),
   status_value: jsonb(`status_value`).$type<typeof STATUS_VALUES[number]>(),
   priority_value: jsonb(`priority_value`).$type<typeof PRIORITY_VALUES[number]>(),
   target_date: text(`target_date`),
@@ -166,6 +171,7 @@ export const selectPropertySchema = createSelectSchema(propertiesTable).extend({
   pending_task: z.string().nullish(),
   label_value: z.string().nullish(),
   channel_id: z.string().nullish(),
+  createdby_id: z.string().nullish(),
 })
 export const createPropertySchema = createInsertSchema(propertiesTable).omit({ created_at: true })
 export const updatePropertySchema = createUpdateSchema(propertiesTable)

--- a/web-app/code/src/infrastructure/storage/fileStorage.ts
+++ b/web-app/code/src/infrastructure/storage/fileStorage.ts
@@ -97,7 +97,7 @@ export async function handleFileUpload(request: Request): Promise<Response> {
       )
       const txid = parseInt(txidResult.rows[0]?.txid as string, 10)
 
-      const [resource] = await tx
+      const [inserted] = await tx
         .insert(resourcesTable)
         .values({
           id: resourceId,
@@ -113,16 +113,34 @@ export async function handleFileUpload(request: Request): Promise<Response> {
           project_id: projectId,
           createdby_id: session.user.id,
         })
+        .onConflictDoNothing()
         .returning()
 
-      await tx.insert(resourcesRawTable).values({
-        id: rawId,
-        resource_id: resourceId,
-        storage_path: storagePath,
-        original_filename: originalFilename,
-        mime_type: mimeType,
-        file_size_bytes: fileSizeBytes,
-      })
+      // Idempotent retry: a prior attempt may have already committed this
+      // resource — the client never received the 201 and retried, or a remount
+      // / reconnect re-fired the upload. onConflictDoNothing turns the duplicate
+      // into a no-op; we reuse the existing row and skip the raw insert rather
+      // than PK-conflicting. The old behavior threw here → 500 → the catch
+      // deleted the file → the pending entry stayed "failed" next to the already
+      // synced resource (the reported double entry).
+      let resource = inserted
+      if (resource) {
+        await tx.insert(resourcesRawTable).values({
+          id: rawId,
+          resource_id: resourceId,
+          storage_path: storagePath,
+          original_filename: originalFilename,
+          mime_type: mimeType,
+          file_size_bytes: fileSizeBytes,
+        })
+      } else {
+        const [existing] = await tx
+          .select()
+          .from(resourcesTable)
+          .where(eq(resourcesTable.id, resourceId))
+          .limit(1)
+        resource = existing
+      }
 
       return { resource, txid }
     })

--- a/web-app/code/src/infrastructure/trpc/routers/properties.ts
+++ b/web-app/code/src/infrastructure/trpc/routers/properties.ts
@@ -15,9 +15,12 @@ export const propertiesRouter = router({
       const result = await ctx.db.transaction(async (tx) => {
         const txid = await generateTxId(tx)
         // ON CONFLICT DO NOTHING — outbox retries become idempotent.
+        // createdby_id is stamped server-side (never trusted from the client)
+        // so the properties shape's `OR createdby_id = me` owner escape hatch is
+        // reliable.
         const [inserted] = await tx
           .insert(propertiesTable)
-          .values(input)
+          .values({ ...input, createdby_id: ctx.session.user.id })
           .onConflictDoNothing()
           .returning()
         if (inserted) return { item: inserted, txid }

--- a/web-app/code/src/presentation/pages/BuildUnitPage.tsx
+++ b/web-app/code/src/presentation/pages/BuildUnitPage.tsx
@@ -82,6 +82,7 @@ export function BuildUnitPage({ projectId, buildUnitName, buildUnitId, projectNa
                 <PropertiesPanel
                   properties={dbProperties ?? []}
                   entityId={buildUnitId}
+                  hideAddButton
                 />
 
                 {/* Activity */}

--- a/web-app/code/src/presentation/routes/api/properties.ts
+++ b/web-app/code/src/presentation/routes/api/properties.ts
@@ -33,10 +33,14 @@ const serve = async ({ request }: { request: Request }) => {
   if (channelIds.length > 0) {
     clauses.push(`channel_id = ANY(ARRAY[${channelIds.map(id => `'${id}'`).join(`,`)}]::text[])`)
   }
+  // Owner escape hatch (always present, session-derived): properties YOU created
+  // sync even on an entity with no membership yet — e.g. a build-unit or project
+  // that has no channel. Mirrors the `owner_id = me` clause on the entity shapes.
+  clauses.push(`createdby_id = '${session.user.id}'`)
 
   const originUrl = prepareElectricUrl(request.url)
   originUrl.searchParams.set(`table`, `properties`)
-  originUrl.searchParams.set(`where`, clauses.length === 0 ? `1 = 0` : clauses.join(` OR `))
+  originUrl.searchParams.set(`where`, clauses.join(` OR `))
 
   return proxyElectricRequest(originUrl)
 }


### PR DESCRIPTION
Four pre-rollout fixes. The headline is the reload data-loss bug (#0).

## #0 — Data wiped on reload (`832f165`)

Reloading dropped most collections' data — Electric reported `up-to-date` but OPFS had no rows — recoverable only by clearing OPFS + a fresh login.

**Root cause:** the browser SQLite persistence caches **one adapter per distinct `schemaVersion`**, and `BrowserCollectionCoordinator` holds a **single** adapter (`setAdapter` is last-writer-wins) that it uses for *every* collection's offset/data ops. A prior change set `PROPERTIES_SCHEMA_VERSION = 2` while every other collection stayed at `1`, so properties' v2 adapter overwrote the coordinator's shared adapter and drove the v1 collections' persistence through the wrong schema namespace — their offsets advanced but rows were never durably written, so on reload they resumed to a valid offset with **no data**.

**Fix:** revert properties to `schemaVersion: 1` so all collections share one adapter and the coordinator stays consistent. (The `channel_id` column added alongside the bump is nullable and re-synced from Electric, so no cache-invalidation bump is needed.)

## #3 — Property on a channel-less build-unit/project doesn't show (`508717a`)

A property added to a build unit (or project) with no channel didn't appear until a channel was created. Build-unit/project properties sync via `entity_id ∈ (member_project_ids ∪ member_buildunit_ids)`, and those id sets come from **memberships** — which only exist once a channel is created. The entity itself still shows via its `owner_id = me` shape clause; properties had no equivalent escape hatch.

**Fix:** add a nullable `createdby_id` to `properties`, stamp it server-side in `properties.create` (never trusted from the client), and add a static `OR createdby_id = '<me>'` clause to the properties shape. It doesn't depend on baked membership ids, so properties you create sync immediately — no channel, no rebuild. Fixes the same bug for channel-less projects.

## #1 — Offline attachment stranded as a duplicate (`45c9935`)

Attaching a file to a message while offline could leave two entries after reconnect (a "failed" pending item beside the synced resource). The upload inserted with a fixed `resourceId` and no conflict handling, and its catch block deleted the file on any error — so a retry after a response the client never received hit a PK conflict → 500 → stranded pending entry (and could delete the file).

**Fix:** `onConflictDoNothing` on the resource insert — a duplicate upload is now a no-op that returns the existing row (success), so the client clears the pending entry and the file is never deleted from under a committed resource.

## #2 — Redundant add-property plus on the build-unit panel (`4a6f299`)

The build-unit page creates properties via the inline component; the panel below it is display-only. Pass `hideAddButton` to remove the redundant plus (matches the channel/task panels).

## Migrations

Adds **`0002_slow_king_bedlam.sql`** (`properties.createdby_id`). Backfill-free only because the dev DB was wiped — a real environment would need `createdby_id` backfilled (e.g. from an audit trail) or left null and re-synced.

## Verification

- #0 confirmed (data persists across reload). #2 verified by design.
- #1 / #3 are server-side (restart the dev server to test): #1 — offline attach → reconnect → one resource, no stranded entry; #3 — property on a channel-less build unit shows immediately.

## Known follow-up (not in this PR)

A separate, pre-existing offline bug: an offline attachment doesn't retry its upload on reconnect until a page reload. Both replay mechanisms exist (executor `WebOnlineDetector` + `usePendingResources` online handler), so it's a timing/ordering issue — being investigated separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)