### PR TITLE
chore(mobile): retire the sync-stall instrumentation

### DIFF
--- a/mobile-app/src/application/collections/_shared.ts
+++ b/mobile-app/src/application/collections/_shared.ts
@@ -34,9 +34,11 @@ export function safeCleanup(
 }
 
 export const retryOnError = async (error: Error) => {
-  // TEMP DEBUG (sync-stall investigation): surface shape errors that trigger a
-  // retry — a repeating line here means a shape is stuck retrying and never
-  // advancing. Remove once resolved.
+  // Kept deliberately. A shape that fails is otherwise SILENT — electric-db-collection
+  // marks the collection ready from this very error path, so the app carries on as if
+  // the shape had synced, just with no rows (see retryOnMembershipsError). A repeating
+  // line here is the only outward sign that a shape is stuck retrying and never
+  // advancing, and it is what identifies which one.
   if (__DEV__) console.log(`[shape-retry] ${error?.message ?? String(error)}`)
   const delay = error.message.includes("401") ? 2000 : 5000
   await new Promise((resolve) => setTimeout(resolve, delay))

--- a/mobile-app/src/infrastructure/auth/cookie-fetch.ts
+++ b/mobile-app/src/infrastructure/auth/cookie-fetch.ts
@@ -66,42 +66,6 @@ function parseSetCookieHeader(raw: string): { name: string; value: string } | nu
   return { name, value }
 }
 
-// TEMP DEBUG (sync-stall investigation): in-flight request tracker.
-//
-// Hypothesis under test: React Native's HTTP stack caps concurrent requests per
-// host (OkHttp Dispatcher.maxRequestsPerHost = 5 on Android; NSURLSession's
-// HTTPMaximumConnectionsPerHost = 4 on iOS). The app keeps ~10 Electric live
-// long-polls open at once, so those slots are permanently occupied and a tRPC
-// mutation POST sits in the client's queue until one long-poll returns — which
-// is why a message sent from mobile takes ~20s to reach other devices.
-//
-// What to look for in the Metro logs:
-//   1. `inflight=` on `[net] →` lines climbing and PINNING at 5 (or 4 on iOS)
-//      actually-issued requests while more are outstanding.
-//   2. A `[net] ←` line for /api/trpc/messages.create with a multi-second time,
-//      immediately preceded by a `[net] ←` for a shape poll — i.e. the POST
-//      only ran once a slot freed.
-//   3. The `[net] SLOW` block, which dumps everything that was outstanding when
-//      the slow request finished, with each entry's age.
-//
-// If the messages.create POST instead returns in ~50ms, the hypothesis is WRONG
-// and the latency is downstream (Postgres → Electric → web). Remove once resolved.
-type InFlightEntry = { path: string; t0: number; live: boolean }
-const _inFlight = new Map<number, InFlightEntry>()
-let _reqSeq = 0
-
-/** A request this slow is the symptom we're hunting — dump the pool state. */
-const SLOW_MS = 1000
-
-function dumpInFlight(label: string): void {
-  const now = Date.now()
-  const rows = [..._inFlight.values()]
-    .sort((a, b) => a.t0 - b.t0)
-    .map((e) => `    ${e.live ? "live" : "    "} ${now - e.t0}ms  ${e.path}`)
-    .join(`\n`)
-  console.log(`[net] ${label} — ${_inFlight.size} still in flight:\n${rows}`)
-}
-
 /**
  * Returns a fetch-compatible function that attaches stored cookies to every
  * request and persists any Set-Cookie values from every response.
@@ -116,47 +80,7 @@ export function createCookieFetch(): typeof fetch {
     }
 
     // 2. Make the actual request
-    // TEMP DEBUG (sync-stall investigation): log every shape/API request, its
-    // status, and how many other API requests were outstanding alongside it —
-    // see the in-flight tracker above for what the numbers mean. Remove once
-    // resolved.
-    const _dbgUrl =
-      typeof input === "string" ? input : input instanceof URL ? input.toString() : (input as Request).url
-    const _dbgIsApi = __DEV__ && _dbgUrl.includes("/api/") && !_dbgUrl.includes("/api/auth")
-    const _dbgPath = _dbgIsApi ? _dbgUrl.replace(API_URL, "").slice(0, 140) : ""
-    // Electric's live long-poll — the request we suspect is hogging the pool.
-    const _dbgLive = _dbgIsApi && _dbgUrl.includes("live=true")
-    const _dbgId = _dbgIsApi ? ++_reqSeq : 0
-    const _dbgT0 = Date.now()
-    if (_dbgIsApi) {
-      _inFlight.set(_dbgId, { path: _dbgPath, t0: _dbgT0, live: _dbgLive })
-      console.log(`[net] → inflight=${_inFlight.size} ${_dbgLive ? "live " : ""}${_dbgPath}`)
-    }
-    let response: Response
-    try {
-      response = await fetch(input, { ...init, headers })
-    } catch (err) {
-      if (_dbgIsApi) {
-        _inFlight.delete(_dbgId)
-        console.log(
-          `[net] ✗ (${Date.now() - _dbgT0}ms) ${_dbgPath} -> ${String((err as Error)?.message ?? err)}`,
-        )
-      }
-      throw err
-    }
-    if (_dbgIsApi) {
-      _inFlight.delete(_dbgId)
-      const elapsed = Date.now() - _dbgT0
-      const utd = response.headers.get("electric-up-to-date") !== null ? " up-to-date" : ""
-      console.log(
-        `[net] ← ${response.status} (${elapsed}ms) inflight=${_inFlight.size}${utd} ${_dbgPath}`,
-      )
-      // A non-live request that took this long was almost certainly waiting for
-      // a connection slot, not for the server. Show what it was waiting behind.
-      if (!_dbgLive && elapsed >= SLOW_MS) {
-        dumpInFlight(`SLOW ${elapsed}ms ${_dbgPath}`)
-      }
-    }
+    const response = await fetch(input, { ...init, headers })
 
     // 3. Parse Set-Cookie headers and persist them
     // In React Native, Headers.getAll is not available; we use get() which

--- a/mobile-app/src/infrastructure/trpc/client.ts
+++ b/mobile-app/src/infrastructure/trpc/client.ts
@@ -7,11 +7,6 @@ export type AppRouter = any
 
 const apiUrl = process.env.EXPO_PUBLIC_API_URL ?? "http://10.0.2.2:3000"
 
-// TEMP DEBUG (network-stall investigation): confirm the URL this singleton is
-// pinned to. A stale value here (old LAN IP) after an env change means the
-// module wasn't re-evaluated — do a full reload, not Fast Refresh. Remove once resolved.
-console.log(`>>> TRPC API URL: ${apiUrl}/api/trpc`)
-
 // Single shared instance — cookie fetch handles auth on every request
 const cookieFetch = createCookieFetch()
 


### PR DESCRIPTION
Three `TEMP DEBUG` blocks from `69b61ad`, each carrying its own *"remove once resolved"*. They are resolved.

| Removed | Why |
|---|---|
| `cookie-fetch.ts` — in-flight request tracker | Tested one hypothesis: OkHttp's `maxRequestsPerHost` starving tRPC mutations behind Electric long-polls. It was right, and `aee3b43` raised the cap. Still cost a Map insert/delete + timestamp on every API request in dev. |
| `cookie-fetch.ts` — per-request `[net]` logging | Went with the tracker. |
| `trpc/client.ts` — `>>> TRPC API URL` banner | **Had no `__DEV__` guard** — printed the API URL on every launch of a production build. |

**`[shape-retry]` stays**, re-commented to stop calling itself temporary. It earns its place: a failing shape is otherwise *silent*, because `electric-db-collection` marks a collection `ready` from its error path — the app carries on as though the shape synced, just with no rows. That line is the only outward sign a shape is stuck retrying, and the only thing that says which one. It's exactly what would have identified the memberships shape failure behind `b09c6bb`.

Net: **-85 / +6**. Android bundle builds clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GHvtHhMh1YySuWgmcDBEd3