### PR TITLE
refactor: modularize the mobile presentation layer + share upload policy and collection specs

### DIFF
--- a/mobile-app/MOBILE_LAZY_LOAD_PLAN.md
+++ b/mobile-app/MOBILE_LAZY_LOAD_PLAN.md
@@ -1,0 +1,177 @@
+# Mobile lazy-load migration plan
+
+Porting the web `web-mobile/infrastructure/lazy-loads` work (idle-GC of heavy
+collections, seen-markers, tiny badge shapes) to the mobile app.
+
+**Status:** ALL STEPS DONE (client-side). Steps 1–2 in commit b5b07aa
+(properties + resources idle-GC; resources persisted). Steps 3–5 in commit
+249b715 (seen_state replaces reads, inbox-mentions/my-tasks badge slices,
+messages/tasks idle-GC). Not yet runtime-verified — see §7.
+
+## TL;DR
+
+- The **entire server side is already done**. Mobile hits the same server as web,
+  so the `seen_state` table, the `seen` tRPC router, and the `/api/seen-state`,
+  `/api/inbox-mentions`, `/api/my-tasks` shape routes web added already exist.
+  **Mobile's work is purely client-side.**
+- Mobile is at the *pre*-optimization state on all three axes: old per-item
+  `reads`, full-collection badge scans, everything `NEVER_GC`.
+- The phase order is **forced and identical to web**: the badge rework must land
+  before the heavy collections can idle, because an always-mounted subscriber
+  pins them today.
+- One extra prerequisite web didn't have: **mobile `resources` is not persisted**,
+  so it needs `persistedCollectionOptions` before idle-GC is cheap.
+
+---
+
+## 1. Subscriber audit — what pins what
+
+Navigation: mobile uses an expo-router **Drawer** (`app/(tabs)/_layout.tsx`).
+`DrawerContent` is the always-mounted equivalent of web's `<Sidebar>`.
+
+| Collection | Persisted? | GC today | Always-mounted subscriber? | Can idle after rework? |
+|---|---|---|---|---|
+| projects, build_units, channels, users, teams, memberships, channel_members | yes | NEVER_GC | Drawer / spine | no — leave NEVER_GC |
+| **messages** | yes | NEVER_GC | **yes — `DrawerContent → useReads` scans full collection** | yes, once badge pin removed |
+| **tasks** | yes | NEVER_GC | **yes — same `useReads` scan** | yes, once badge pin removed |
+| **properties** | yes | NEVER_GC | no (only channel/task screens) | **yes — can idle immediately** |
+| **resources** | **NO** | NEVER_GC | no (only `ResourcesSheet`, mounted on open) | yes, *after* persistence added |
+| reads | yes | NEVER_GC | yes (`useReads`) | replaced by seen_state |
+
+**The pin:** `mobile-app/src/presentation/shared/hooks/useReads.ts` runs
+`useLiveQuery(messagesCollection)` and `useLiveQuery(tasksCollection)` — full
+scans — and `DrawerContent` calls it to render the My Tasks / Inbox badges. As
+long as the Drawer is mounted (always), messages and tasks have a live query and
+cannot GC. This is exactly the dependency web removed in `fb474e6`.
+
+**`properties` is free right now** — nothing always-mounted subscribes to it
+(only channel/build-unit/task screens). It can move to idle-GC independently of
+the badge/seen work, as a low-risk first step.
+
+---
+
+## 2. seen_state migration shape (Phase A)
+
+Web replaced the per-item `reads` collection (one row per user×item) with
+`seen_state`: one timestamp marker per `(user, scope, scope_id)` — "seen up to
+time T in this scope" — making unread an O(scopes) check instead of O(items).
+
+**Server:** already migrated (web's drizzle `0007`, shared DB). Mobile does **not**
+need a DB migration or any server change.
+
+Client-side parity to build, mirroring the web files:
+
+| Web file (template) | Mobile target |
+|---|---|
+| `application/collections/communication.ts` `_makeSeenStateCollection` | add to mobile `collections/communication.ts` (or `admin.ts`, where `reads` lives) |
+| `application/actions/seen.ts` | new `application/actions/seen.ts` (optimistic upsert; keyed by `(user, scope, scope_id)`) |
+| `presentation/hooks/use-seen.ts` | new `presentation/shared/hooks/useSeen.ts` |
+| `routes/api/seen-state.ts` (server) | **none — reuse existing server route** |
+
+Then delete mobile `actions/reads.ts`, `collections` `reads` entry, and
+`useReads.ts`; repoint `MessageList`, `MessageItem`, `TasksSheet` at `useSeen`.
+
+**Schema-version caveat (load-bearing):** every mobile collection shares one
+`schemaVersion` (currently **3**) because the persistence adapter is cached by
+that key — bumping one spawns a second adapter over the same SQLite file and
+strands all collections (documented in `communication.ts:192`). Adding
+`seen_state` / removing `reads` changes the collection set, so **bump every mobile
+collection's `schemaVersion` together** (3 → 4).
+
+---
+
+## 3. Tiny badge shapes (Phase B)
+
+Replace the full-collection scan in the Drawer badges with the two small
+user-scoped shapes web added:
+
+- `inbox_mentions` collection → `/api/inbox-mentions` (already on server)
+- `my_tasks` collection → `/api/my-tasks` (already on server)
+
+`DrawerContent`'s `UnreadBadge` reads counts from these tiny always-mounted
+collections instead of scanning messages/tasks. **This is the step that removes
+the pin** — after it, nothing always-mounted holds messages/tasks.
+
+Keep `seen_state`, `inbox_mentions`, `my_tasks` at `NEVER_GC`: they *are* the
+always-mounted subscription (tiny, user-scoped), exactly as on web.
+
+---
+
+## 4. Idle-GC the heavy collections (Phase C)
+
+Introduce `IDLE_GC_MS = 60_000` in mobile `collections/_shared.ts` (mirror web),
+then:
+
+1. **properties → IDLE_GC_MS** — can be done first/independently (no pin).
+2. **messages, tasks → IDLE_GC_MS** — only after Phase B removes the badge pin.
+3. **resources:** first wrap `_makeResourcesCollection` in
+   `persistedCollectionOptions` (it currently uses bare `electricCollectionOptions`
+   — see `communication.ts:169`), *then* IDLE_GC_MS. Without persistence,
+   resurrection refetches the whole shape rather than resuming from offset — the
+   opposite of the intended win. **Done in step 2** — added at the shared
+   `schemaVersion` 3 (NOT bumped 3→4: adding a collection at the *existing* shared
+   version preserves the "all equal" adapter invariant, whereas a global bump would
+   force an unnecessary full re-sync of every collection). resources has no
+   always-mounted subscriber, so it was flipped to IDLE_GC_MS in the same step
+   rather than deferred to phase C-final.
+
+The resurrection mechanism (verified on web against `@tanstack/db@0.6.5`:
+`addSubscriber → startSync` on a cleaned-up collection, resuming from the
+persisted offset) is the same library on mobile, so the behavior transfers.
+
+---
+
+## 5. Mobile-specific tradeoffs & risks
+
+- **Idle-GC is *more* valuable on mobile.** Closing idle shape long-polls saves
+  battery and cellular data, not just server load. This argues for doing the full
+  migration, not just the cheap subset.
+- **App backgrounding.** When the OS suspends the app, GC timers and network
+  pause. GC firing is best-effort cleanup, and correctness rests on
+  resurrection-on-foreground, so backgrounding doesn't threaten correctness — but
+  it's worth verifying a shape resumes cleanly after a long background period
+  (token refresh / 401 retry path).
+- **Flaky connections raise the resurrection cost**, which is exactly why
+  persisting `resources` first (so resume is from-offset, not full-refetch) matters
+  more on mobile than it did on web.
+- **Mobile is still being finalized** (pending stashes). A collections migration
+  touching every `schemaVersion` and the read model is broad; sequence it so each
+  phase is independently shippable and verifiable, and coordinate with the
+  finalization work to avoid a stash collision.
+- **No automated tests** cover sync/offline on either app (ARCHITECTURE §12.7), so
+  each phase needs a runtime verify pass on device/simulator.
+
+---
+
+## 6. Recommended phase order
+
+1. **[DONE] Phase C-partial (properties → idle-GC).** Smallest, no dependencies,
+   proves the `IDLE_GC_MS` mechanism on mobile.
+2. **[DONE] Phase C-resources (persist + idle-GC).** Added
+   `persistedCollectionOptions` to resources at the shared v3 (no global bump — see
+   §4.3), and — since resources has no always-mounted subscriber — flipped it to
+   IDLE_GC_MS in the same step. `messages`/`tasks` remain `NEVER_GC` (still pinned
+   by the DrawerContent badge scan).
+3. **Phase A (seen_state).** Replace `reads` with seen-markers, client-side only.
+   Largest single step; carries the first real schema bump (adding seen_state /
+   removing reads changes the collection set → bump every collection together).
+4. **Phase B (badge shapes).** Repoint Drawer badges at `inbox_mentions` /
+   `my_tasks`; delete the full-scan path. Removes the pin.
+5. **Phase C-final (messages, tasks → idle-GC).** Now safe (resources already
+   done in step 2). One commit + verify navigation resume.
+
+Steps 1–2 are complete. Steps 3–5 are the larger, schema-touching migration.
+
+## 7. Verification status
+
+**VERIFIED ON DEVICE.** All steps (1–5) were built and verified on a physical
+device by the author. This included the follow-up fix in commit 35f3baa
+(mark-seen on blur via useFocusEffect rather than unmount) — the original
+unmount-based marking left the drawer badges stale because the Drawer keeps
+inbox/my-tasks mounted across navigation.
+
+Commits on this branch:
+- b5b07aa — steps 1–2 (properties + resources idle-GC; resources persisted)
+- 249b715 — steps 3–5 (seen_state replaces reads; inbox-mentions/my-tasks badge
+  slices; messages/tasks idle-GC)
+- 35f3baa — badge-staleness fix (blur-based seen marking)

--- a/mobile-app/app/(tabs)/_layout.tsx
+++ b/mobile-app/app/(tabs)/_layout.tsx
@@ -9,7 +9,7 @@ import {
   membershipSetsChanged,
   resyncProjectCollections,
 } from "@/src/application/collections/init"
-import { membershipsCollection } from "@/src/application/collections/admin"
+import { membershipsCollection } from "@/src/application/collections/organization"
 import { waitForLiveQueryRelease } from "@/src/application/collections/live-query-release"
 import { initOfflineExecutor } from "@/src/infrastructure/offline/executor"
 import { initUploadManager } from "@/src/infrastructure/offline/upload-manager"

--- a/mobile-app/app/(tabs)/_layout.tsx
+++ b/mobile-app/app/(tabs)/_layout.tsx
@@ -70,14 +70,14 @@ export default function DrawerLayout() {
     initProjectCollections(projectId)
       .then(async () => {
         // Executor must init AFTER project collections so it can register them.
-        // Re-runs on project switch — initOfflineExecutor disposes the previous
-        // instance internally before constructing a new one; clear cached
-        // action references so the next call binds against the new executor.
+        // This block runs ONCE per mount — there is no project switch (the
+        // drawer says "Sign out to switch project"). The executor's rebuild
+        // path is the resync effect below, not here. resetAllOfflineActions
+        // clears cached action references so they bind against this executor.
         resetAllOfflineActions()
         await initOfflineExecutor()
         // Upload manager: a separate service from the executor (binaries do not
-        // belong in the outbox). initUploadManager is idempotent, so re-running
-        // it on project switch is a no-op.
+        // belong in the outbox). Idempotent, so the guard costs nothing.
         await initUploadManager()
         if (__DEV__) console.log(`[layout] Project collections + offline executor ready`)
         setProjectReady(true)

--- a/mobile-app/app/(tabs)/inbox.tsx
+++ b/mobile-app/app/(tabs)/inbox.tsx
@@ -1,19 +1,12 @@
-import {
-  View,
-  Text,
-  FlatList,
-  TouchableOpacity,
-  ActivityIndicator,
-  StyleSheet,
-} from "react-native"
+import { View, StyleSheet } from "react-native"
 import { useCallback } from "react"
 import { useRouter, useFocusEffect } from "expo-router"
-import { useSafeAreaInsets } from "react-native-safe-area-context"
 import { useLiveQuery } from "@tanstack/react-db"
 import { MessageSquare } from "lucide-react-native"
 import { ScreenHeader } from "@/src/presentation/shared/components/ScreenHeader"
-import { Breadcrumb } from "@/src/presentation/shared/components/Breadcrumb"
-import { formatDateTime } from "@/src/presentation/shared/lib/datetime"
+import { CardList } from "@/src/presentation/shared/components/CardList"
+import { LoadingState, EmptyState } from "@/src/presentation/shared/components/ScreenStates"
+import { MentionRow } from "@/src/presentation/messages/components/MentionRow"
 import { useLookups } from "@/src/presentation/shared/hooks/useLookups"
 import { useSeen } from "@/src/presentation/shared/hooks/useSeen"
 import { useSession } from "@/src/infrastructure/auth/client"
@@ -22,64 +15,8 @@ import { messagesCollection } from "@/src/application/collections/communication"
 import { colors } from "@/src/presentation/shared/colors"
 import type { Message } from "@buildinlime/domain-types"
 
-function MentionRow({
-  message,
-  lookups,
-  unread,
-  onPress,
-}: {
-  message: Message
-  lookups: ReturnType<typeof useLookups>
-  unread: boolean
-  onPress: () => void
-}) {
-  const { getUserName, getChannel, getBuildUnit, getProject } = lookups
-
-  const senderName = getUserName(message.createdby_id)
-  const initial = (senderName[0] ?? "?").toUpperCase()
-  const channel = getChannel(message.channel_id)
-  const buildUnit = getBuildUnit(message.buildunit_id)
-  const project = getProject(message.project_id)
-
-  return (
-    <TouchableOpacity
-      style={[styles.row, unread && styles.rowUnread]}
-      onPress={onPress}
-      activeOpacity={0.75}
-    >
-      <View style={styles.avatar}>
-        <Text style={styles.avatarText}>{initial}</Text>
-      </View>
-      <View style={styles.rowBody}>
-        <View style={styles.rowHeader}>
-          {/* Marks unread ONLY — a dot on every row signals nothing. Read rows
-              stay in the list, de-emphasised: the Inbox is a record of what
-              needed you, not a queue to drain. */}
-          {unread ? <View style={styles.unreadDot} /> : null}
-          <Text style={[styles.sender, unread && styles.senderUnread]} numberOfLines={1}>
-            {senderName}
-          </Text>
-          <Text style={styles.timestamp}>{formatDateTime(message.created_at)}</Text>
-        </View>
-        <Text
-          style={[styles.messageText, !unread && styles.messageTextRead]}
-          numberOfLines={3}
-        >
-          {message.text}
-        </Text>
-        <Breadcrumb
-          projectName={project?.name}
-          buildUnitName={buildUnit?.name}
-          channelName={channel?.name}
-        />
-      </View>
-    </TouchableOpacity>
-  )
-}
-
 function InboxContent() {
   const router = useRouter()
-  const insets = useSafeAreaInsets()
   const { data: session } = useSession()
   const currentUserId = session?.user?.id
   const lookups = useLookups()
@@ -112,33 +49,23 @@ function InboxContent() {
     )
     .sort((a, b) => new Date(b.created_at).getTime() - new Date(a.created_at).getTime())
 
-  if (isLoading) {
-    return (
-      <View style={styles.centered}>
-        <ActivityIndicator size="large" color={colors.primary} />
-      </View>
-    )
-  }
+  if (isLoading) return <LoadingState />
 
   if (mentions.length === 0) {
     return (
-      <View style={styles.centered}>
-        <MessageSquare size={40} color={colors.cardBorder} strokeWidth={1.5} />
-        <Text style={styles.emptyTitle}>No one has mentioned you yet</Text>
-        <Text style={styles.emptyText}>
-          Messages where you're mentioned will appear here.
-        </Text>
-      </View>
+      <EmptyState
+        icon={MessageSquare}
+        title="No one has mentioned you yet"
+        message="Messages where you're mentioned will appear here."
+      />
     )
   }
 
   return (
-    <FlatList
+    <CardList
       data={mentions}
       keyExtractor={(item) => item.id}
-      contentContainerStyle={[styles.listContent, { paddingBottom: insets.bottom + 24 }]}
-      ItemSeparatorComponent={() => <View style={styles.gap} />}
-      renderItem={({ item }) => (
+      renderItem={(item) => (
         <MentionRow
           message={item}
           lookups={lookups}
@@ -155,7 +82,6 @@ function InboxContent() {
           }}
         />
       )}
-      showsVerticalScrollIndicator={false}
     />
   )
 }
@@ -170,9 +96,7 @@ export default function InboxScreen() {
       {projectId ? (
         <InboxContent />
       ) : (
-        <View style={styles.centered}>
-          <Text style={styles.emptyText}>Select a project to see your mentions.</Text>
-        </View>
+        <EmptyState message="Select a project to see your mentions." />
       )}
     </View>
   )
@@ -182,101 +106,5 @@ const styles = StyleSheet.create({
   container: {
     flex: 1,
     backgroundColor: colors.background,
-  },
-  centered: {
-    flex: 1,
-    alignItems: "center",
-    justifyContent: "center",
-    paddingHorizontal: 24,
-    gap: 6,
-  },
-  emptyTitle: {
-    fontSize: 14,
-    fontFamily: "InstrumentSans_600SemiBold",
-    color: colors.mutedForeground,
-    marginTop: 6,
-  },
-  emptyText: {
-    fontSize: 12,
-    fontFamily: "InstrumentSans_400Regular",
-    color: colors.mutedForeground,
-    textAlign: "center",
-  },
-  listContent: {
-    paddingHorizontal: 16,
-    paddingVertical: 16,
-  },
-  gap: {
-    height: 8,
-  },
-  row: {
-    flexDirection: "row",
-    alignItems: "flex-start",
-    gap: 12,
-    paddingHorizontal: 14,
-    paddingVertical: 12,
-    backgroundColor: colors.background,
-    borderWidth: 1,
-    borderColor: colors.cardBorder,
-    borderRadius: 12,
-  },
-  rowUnread: {
-    backgroundColor: colors.cardSurface,
-    borderColor: colors.secondary,
-  },
-  avatar: {
-    width: 32,
-    height: 32,
-    borderRadius: 16,
-    backgroundColor: colors.iconChip,
-    alignItems: "center",
-    justifyContent: "center",
-    marginTop: 2,
-  },
-  avatarText: {
-    fontSize: 12,
-    fontFamily: "InstrumentSans_600SemiBold",
-    color: colors.primary,
-  },
-  rowBody: {
-    flex: 1,
-  },
-  rowHeader: {
-    flexDirection: "row",
-    alignItems: "center",
-    justifyContent: "space-between",
-    gap: 8,
-    marginBottom: 3,
-  },
-  sender: {
-    flex: 1,
-    fontSize: 13,
-    fontFamily: "InstrumentSans_500Medium",
-    color: colors.mutedForeground,
-  },
-  senderUnread: {
-    fontFamily: "InstrumentSans_600SemiBold",
-    color: colors.foreground,
-  },
-  unreadDot: {
-    width: 8,
-    height: 8,
-    borderRadius: 4,
-    backgroundColor: colors.primary,
-    flexShrink: 0,
-  },
-  timestamp: {
-    fontSize: 11,
-    fontFamily: "InstrumentSans_400Regular",
-    color: colors.mutedForeground,
-  },
-  messageTextRead: {
-    color: colors.mutedForeground,
-  },
-  messageText: {
-    fontSize: 13,
-    fontFamily: "InstrumentSans_400Regular",
-    color: colors.foreground,
-    lineHeight: 19,
   },
 })

--- a/mobile-app/app/(tabs)/my-tasks.tsx
+++ b/mobile-app/app/(tabs)/my-tasks.tsx
@@ -1,84 +1,20 @@
 import { useCallback } from "react"
-import {
-  View,
-  Text,
-  FlatList,
-  TouchableOpacity,
-  ActivityIndicator,
-  StyleSheet,
-} from "react-native"
+import { View, StyleSheet } from "react-native"
 import { useRouter, useFocusEffect } from "expo-router"
-import { useSafeAreaInsets } from "react-native-safe-area-context"
-import { CheckSquare, Square } from "lucide-react-native"
+import { CheckSquare } from "lucide-react-native"
 import { ScreenHeader } from "@/src/presentation/shared/components/ScreenHeader"
-import { Breadcrumb } from "@/src/presentation/shared/components/Breadcrumb"
-import { formatDateTime } from "@/src/presentation/shared/lib/datetime"
+import { CardList } from "@/src/presentation/shared/components/CardList"
+import { LoadingState, EmptyState } from "@/src/presentation/shared/components/ScreenStates"
+import { MyTaskRow } from "@/src/presentation/tasks/components/MyTaskRow"
 import { useLookups } from "@/src/presentation/shared/hooks/useLookups"
 import { useTasks } from "@/src/presentation/tasks/hooks/useTasks"
 import { useSeen } from "@/src/presentation/shared/hooks/useSeen"
 import { useSession } from "@/src/infrastructure/auth/client"
 import { useProjectContext } from "@/src/application/context/ProjectContext"
 import { colors } from "@/src/presentation/shared/colors"
-import type { Task } from "@buildinlime/domain-types"
-
-function TaskRow({
-  task,
-  lookups,
-  onPress,
-}: {
-  task: Task
-  lookups: ReturnType<typeof useLookups>
-  onPress: () => void
-}) {
-  const { getChannel, getBuildUnit, getProject } = lookups
-
-  const channel = getChannel(task.channel_id)
-  const buildUnit = getBuildUnit(task.buildunit_id)
-  const project = getProject(buildUnit?.project_id)
-
-  return (
-    <TouchableOpacity
-      style={[styles.row, task.completed && styles.rowCompleted]}
-      onPress={onPress}
-      activeOpacity={0.75}
-    >
-      <View style={styles.checkbox}>
-        {task.completed ? (
-          <CheckSquare size={16} color={colors.primary} strokeWidth={2} />
-        ) : (
-          <Square size={16} color={colors.primary} strokeWidth={2} />
-        )}
-      </View>
-      <View style={styles.rowBody}>
-        <Text
-          style={[styles.taskName, task.completed && styles.taskNameCompleted]}
-          numberOfLines={2}
-        >
-          {task.name}
-        </Text>
-        {task.description ? (
-          <Text style={styles.taskDescription} numberOfLines={1}>
-            {task.description}
-          </Text>
-        ) : null}
-        <Text style={styles.taskDate}>
-          {task.completed
-            ? `Completed ${formatDateTime(task.closed_at)}`
-            : `Opened ${formatDateTime(task.opened_at)}`}
-        </Text>
-        <Breadcrumb
-          projectName={project?.name}
-          buildUnitName={buildUnit?.name}
-          channelName={channel?.name}
-        />
-      </View>
-    </TouchableOpacity>
-  )
-}
 
 function MyTasksContent() {
   const router = useRouter()
-  const insets = useSafeAreaInsets()
   const { data: session } = useSession()
   const currentUserId = session?.user?.id
   const { tasks, isLoading } = useTasks(currentUserId)
@@ -101,32 +37,24 @@ function MyTasksContent() {
     return new Date(b.opened_at).getTime() - new Date(a.opened_at).getTime()
   })
 
-  if (isLoading) {
-    return (
-      <View style={styles.centered}>
-        <ActivityIndicator size="large" color={colors.primary} />
-      </View>
-    )
-  }
+  if (isLoading) return <LoadingState />
 
   if (sorted.length === 0) {
     return (
-      <View style={styles.centered}>
-        <CheckSquare size={40} color={colors.cardBorder} strokeWidth={1.5} />
-        <Text style={styles.emptyTitle}>No tasks assigned to you</Text>
-        <Text style={styles.emptyText}>Tasks assigned to you will appear here.</Text>
-      </View>
+      <EmptyState
+        icon={CheckSquare}
+        title="No tasks assigned to you"
+        message="Tasks assigned to you will appear here."
+      />
     )
   }
 
   return (
-    <FlatList
+    <CardList
       data={sorted}
       keyExtractor={(item) => item.id}
-      contentContainerStyle={[styles.listContent, { paddingBottom: insets.bottom + 24 }]}
-      ItemSeparatorComponent={() => <View style={styles.gap} />}
-      renderItem={({ item }) => (
-        <TaskRow
+      renderItem={(item) => (
+        <MyTaskRow
           task={item}
           lookups={lookups}
           onPress={() => {
@@ -140,7 +68,6 @@ function MyTasksContent() {
           }}
         />
       )}
-      showsVerticalScrollIndicator={false}
     />
   )
 }
@@ -151,12 +78,7 @@ function MyTasksHeader() {
   const openCount = tasks.filter((t) => !t.completed).length
   const doneCount = tasks.length - openCount
 
-  return (
-    <ScreenHeader
-      title="My Tasks"
-      subtitle={`${openCount} open · ${doneCount} done`}
-    />
-  )
+  return <ScreenHeader title="My Tasks" subtitle={`${openCount} open · ${doneCount} done`} />
 }
 
 export default function MyTasksScreen() {
@@ -167,9 +89,7 @@ export default function MyTasksScreen() {
     return (
       <View style={styles.container}>
         <ScreenHeader title="My Tasks" subtitle="Your assigned tasks" />
-        <View style={styles.centered}>
-          <Text style={styles.emptyText}>Select a project to see your tasks.</Text>
-        </View>
+        <EmptyState message="Select a project to see your tasks." />
       </View>
     )
   }
@@ -186,74 +106,5 @@ const styles = StyleSheet.create({
   container: {
     flex: 1,
     backgroundColor: colors.background,
-  },
-  centered: {
-    flex: 1,
-    alignItems: "center",
-    justifyContent: "center",
-    paddingHorizontal: 24,
-    gap: 6,
-  },
-  emptyTitle: {
-    fontSize: 14,
-    fontFamily: "InstrumentSans_600SemiBold",
-    color: colors.mutedForeground,
-    marginTop: 6,
-  },
-  emptyText: {
-    fontSize: 12,
-    fontFamily: "InstrumentSans_400Regular",
-    color: colors.mutedForeground,
-    textAlign: "center",
-  },
-  listContent: {
-    paddingHorizontal: 16,
-    paddingVertical: 16,
-  },
-  gap: {
-    height: 8,
-  },
-  row: {
-    flexDirection: "row",
-    alignItems: "flex-start",
-    gap: 12,
-    paddingHorizontal: 14,
-    paddingVertical: 12,
-    backgroundColor: colors.cardSurface,
-    borderWidth: 1,
-    borderColor: colors.cardBorder,
-    borderRadius: 12,
-  },
-  rowCompleted: {
-    backgroundColor: colors.background,
-    opacity: 0.6,
-  },
-  checkbox: {
-    marginTop: 2,
-  },
-  rowBody: {
-    flex: 1,
-  },
-  taskName: {
-    fontSize: 13,
-    fontFamily: "InstrumentSans_600SemiBold",
-    color: colors.foreground,
-    lineHeight: 19,
-  },
-  taskNameCompleted: {
-    color: colors.mutedForeground,
-    textDecorationLine: "line-through",
-  },
-  taskDescription: {
-    fontSize: 12,
-    fontFamily: "InstrumentSans_400Regular",
-    color: colors.mutedForeground,
-    marginTop: 2,
-  },
-  taskDate: {
-    fontSize: 11,
-    fontFamily: "InstrumentSans_400Regular",
-    color: colors.mutedForeground,
-    marginTop: 3,
   },
 })

--- a/mobile-app/app/(tabs)/project/[projectId]/[buildUnitId]/[channelId]/[taskId].tsx
+++ b/mobile-app/app/(tabs)/project/[projectId]/[buildUnitId]/[channelId]/[taskId].tsx
@@ -26,7 +26,7 @@ import { updateTaskAction, deleteTaskAction } from "@/src/application/actions/ta
 import { createMessageAction } from "@/src/application/actions/messages"
 import { usePropertiesByEntity } from "@/src/presentation/properties/hooks/useProperties"
 import { ResourcesSheet } from "@/src/presentation/resources/components/ResourcesSheet"
-import { TaskScreenHeader } from "@/src/presentation/tasks/components/TaskScreenHeader"
+import { BackHeader } from "@/src/presentation/shared/components/BackHeader"
 import { TaskStatusControl } from "@/src/presentation/tasks/components/TaskStatusControl"
 import { TaskDetailsFields } from "@/src/presentation/tasks/components/TaskDetailsFields"
 import { TaskStatusHistory } from "@/src/presentation/tasks/components/TaskStatusHistory"
@@ -220,7 +220,7 @@ export default function TaskScreen() {
       behavior="padding"
       keyboardVerticalOffset={0}
     >
-      <TaskScreenHeader
+      <BackHeader
         title={task.name}
         onBack={() => router.back()}
         onDelete={canDelete ? confirmDelete : undefined}

--- a/mobile-app/app/(tabs)/project/[projectId]/[buildUnitId]/[channelId]/[taskId].tsx
+++ b/mobile-app/app/(tabs)/project/[projectId]/[buildUnitId]/[channelId]/[taskId].tsx
@@ -2,11 +2,7 @@ import { useState } from "react"
 import {
   View,
   Text,
-  TextInput,
-  TouchableOpacity,
   ScrollView,
-  Modal,
-  Pressable,
   ActivityIndicator,
   StyleSheet,
   Keyboard,
@@ -17,7 +13,6 @@ import { useLocalSearchParams, useRouter } from "expo-router"
 import { useSafeAreaInsets } from "react-native-safe-area-context"
 import { useLiveQuery, eq } from "@tanstack/react-db"
 import * as Crypto from "expo-crypto"
-import { CheckCircle2, Circle, UserPlus, X, Trash2 } from "lucide-react-native"
 import {
   tasksCollection,
   messagesCollection,
@@ -30,10 +25,14 @@ import {
 import { updateTaskAction, deleteTaskAction } from "@/src/application/actions/tasks"
 import { createMessageAction } from "@/src/application/actions/messages"
 import { usePropertiesByEntity } from "@/src/presentation/properties/hooks/useProperties"
-import { PropertyPill } from "@/src/presentation/properties/components/PropertyPill"
 import { ResourcesSheet } from "@/src/presentation/resources/components/ResourcesSheet"
+import { TaskScreenHeader } from "@/src/presentation/tasks/components/TaskScreenHeader"
+import { TaskStatusControl } from "@/src/presentation/tasks/components/TaskStatusControl"
+import { TaskDetailsFields } from "@/src/presentation/tasks/components/TaskDetailsFields"
+import { TaskStatusHistory } from "@/src/presentation/tasks/components/TaskStatusHistory"
+import { AssigneePickerModal } from "@/src/presentation/tasks/components/AssigneePickerModal"
+import { buildStatusNoteText } from "@/src/presentation/tasks/lib/status-note"
 import { useUsers } from "@/src/presentation/shared/hooks/useUsers"
-import { formatDateTime } from "@/src/presentation/shared/lib/datetime"
 import { useSession } from "@/src/infrastructure/auth/client"
 import { colors } from "@/src/presentation/shared/colors"
 import type { Message, Property, Task } from "@buildinlime/domain-types"
@@ -127,11 +126,10 @@ export default function TaskScreen() {
     ? taskStatus.task_status_value === "completed"
     : task.completed
 
-  // Only the creator may assign. The server enforces this (tasks.update returns
-  // FORBIDDEN otherwise) — hiding the button is courtesy, not the control.
+  // Only the creator may assign or delete. The server enforces this (tasks.update
+  // and tasks.delete return FORBIDDEN otherwise) — hiding the buttons is courtesy,
+  // not the control.
   const canAssign = !!task.createdby_id && task.createdby_id === currentUserId
-  // Creator only. The server enforces it (tasks.delete returns FORBIDDEN otherwise);
-  // hiding the button is courtesy, not the control.
   const canDelete = canAssign
 
   function confirmDelete() {
@@ -175,33 +173,16 @@ export default function TaskScreen() {
     })
   }
 
-  /**
-   * A status change must be explained. The note is posted as an ordinary channel
-   * message — tasks have no notes table, and messages carry no task_id, so this
-   * is a record in the channel rather than a history on the task. That is the
-   * accepted trade: zero schema change, and the team sees the reason in context.
-   *
-   * The note is REQUIRED: Confirm stays disabled until it is non-empty.
-   */
+  /** A status change must be explained — see buildStatusNoteText. */
   function confirmStatusChange() {
     const trimmed = note.trim()
     if (!trimmed || !currentUserId || submitting) return
     const next: "open" | "completed" = completed ? "open" : "completed"
     setSubmitting(true)
     try {
-      // messages.text is varchar(500). The note is the part worth keeping, so the
-      // task name is what gets truncated if the two together would overflow.
-      const label = next === "completed" ? `completed` : `reopened`
-      const prefix = `Task ${label}: `
-      const suffix = ` — ${trimmed}`
-      const room = 500 - prefix.length - suffix.length
-      const name =
-        task.name.length > room && room > 1
-          ? `${task.name.slice(0, room - 1)}…`
-          : task.name
       createMessageAction({
         id: Crypto.randomUUID(),
-        text: `${prefix}${name}${suffix}`.slice(0, 500),
+        text: buildStatusNoteText({ taskName: task.name, next, note: trimmed }),
         channel_id: channelId,
         buildunit_id: buildUnitId,
         project_id: projectId,
@@ -213,21 +194,22 @@ export default function TaskScreen() {
       // Status flips only after the note is recorded, so a task can never end up
       // completed with no explanation in the channel.
       applyStatus(next)
-      setNote("")
-      setNoteOpen(false)
-      Keyboard.dismiss()
+      closeNote()
     } finally {
       setSubmitting(false)
     }
+  }
+
+  function closeNote() {
+    setNote("")
+    setNoteOpen(false)
+    Keyboard.dismiss()
   }
 
   function assignTo(userId: string | null) {
     updateTaskAction({ id: taskId, patch: { assignee_id: userId } })
     setAssignOpen(false)
   }
-
-  const assigneeName = task.assignee_id ? usersMap[task.assignee_id] : undefined
-  const creatorName = usersMap[task.createdby_id] ?? "Unknown"
 
   return (
     // "padding", not "height" — under edge-to-edge the window does not resize for
@@ -238,36 +220,20 @@ export default function TaskScreen() {
       behavior="padding"
       keyboardVerticalOffset={0}
     >
-      <View style={[styles.header, { paddingTop: insets.top + 8 }]}>
-        <TouchableOpacity
-          style={styles.backButton}
-          onPress={() => router.back()}
-          hitSlop={{ top: 10, bottom: 10, left: 10, right: 10 }}
-          activeOpacity={0.6}
-        >
-          <Text style={styles.backArrow}>‹</Text>
-        </TouchableOpacity>
-        <Text style={styles.headerTitle} numberOfLines={1}>
-          {task.name}
-        </Text>
-        {/* Attachments for THIS task — same sheet as the channel's, in task mode. */}
-        <ResourcesSheet
-          channelId={channelId}
-          buildUnitId={buildUnitId}
-          projectId={projectId}
-          taskId={taskId}
-        />
-        {canDelete && (
-          <TouchableOpacity
-            onPress={confirmDelete}
-            hitSlop={{ top: 8, bottom: 8, left: 8, right: 8 }}
-            activeOpacity={0.6}
-            style={styles.headerAction}
-          >
-            <Trash2 size={18} color={colors.mutedForeground} strokeWidth={2} />
-          </TouchableOpacity>
-        )}
-      </View>
+      <TaskScreenHeader
+        title={task.name}
+        onBack={() => router.back()}
+        onDelete={canDelete ? confirmDelete : undefined}
+        // Attachments for THIS task — same sheet as the channel's, in task mode.
+        actions={
+          <ResourcesSheet
+            channelId={channelId}
+            buildUnitId={buildUnitId}
+            projectId={projectId}
+            taskId={taskId}
+          />
+        }
+      />
 
       <ScrollView
         contentContainerStyle={[styles.content, { paddingBottom: insets.bottom + 24 }]}
@@ -278,184 +244,37 @@ export default function TaskScreen() {
           <Text style={styles.description}>{task.description}</Text>
         ) : null}
 
-        {/* Status — the one interactive control on this screen. It no longer flips
-            on tap: it opens the note step below, and the note is what commits it. */}
-        <TouchableOpacity
-          style={[styles.statusBtn, completed && styles.statusBtnDone]}
-          onPress={() => setNoteOpen((v) => !v)}
-          activeOpacity={0.75}
-        >
-          {completed ? (
-            <CheckCircle2 size={18} color="#166534" strokeWidth={2} />
-          ) : (
-            <Circle size={18} color={colors.primary} strokeWidth={2} />
-          )}
-          <Text style={[styles.statusText, completed && styles.statusTextDone]}>
-            {completed ? "Completed" : "Open"}
-          </Text>
-          <Text style={styles.statusHint}>
-            {completed ? "Tap to reopen" : "Tap to complete"}
-          </Text>
-        </TouchableOpacity>
+        <TaskStatusControl
+          completed={completed}
+          noteOpen={noteOpen}
+          onToggleNote={() => setNoteOpen((v) => !v)}
+          note={note}
+          onNoteChange={setNote}
+          submitting={submitting}
+          onCancel={closeNote}
+          onConfirm={confirmStatusChange}
+        />
 
-        {noteOpen && (
-          <View style={styles.noteSection}>
-            <Text style={styles.noteTitle}>
-              {completed ? "Why are you reopening this?" : "What was done?"}
-            </Text>
-            <Text style={styles.noteHint}>
-              Required. Posted to the channel so the team sees the reason.
-            </Text>
-            <TextInput
-              style={styles.noteInput}
-              value={note}
-              onChangeText={setNote}
-              placeholder={
-                completed
-                  ? "e.g. Rebar spacing is off, needs redoing"
-                  : "e.g. Slab poured, cured 48h"
-              }
-              placeholderTextColor={colors.mutedForeground}
-              multiline
-              numberOfLines={3}
-              maxLength={400}
-              autoFocus
-              textAlignVertical="top"
-            />
-            <View style={styles.noteActions}>
-              <TouchableOpacity
-                onPress={() => {
-                  setNote("")
-                  setNoteOpen(false)
-                  Keyboard.dismiss()
-                }}
-                activeOpacity={0.7}
-              >
-                <Text style={styles.noteCancel}>Cancel</Text>
-              </TouchableOpacity>
-              <TouchableOpacity
-                style={[
-                  styles.noteSubmit,
-                  (!note.trim() || submitting) && styles.noteSubmitDisabled,
-                ]}
-                onPress={confirmStatusChange}
-                disabled={!note.trim() || submitting}
-                activeOpacity={0.8}
-              >
-                <Text style={styles.noteSubmitText}>
-                  {completed ? "Reopen Task" : "Mark Completed"}
-                </Text>
-              </TouchableOpacity>
-            </View>
-          </View>
-        )}
+        <TaskDetailsFields
+          creatorName={usersMap[task.createdby_id] ?? "Unknown"}
+          openedAt={task.opened_at}
+          assigneeName={task.assignee_id ? usersMap[task.assignee_id] : undefined}
+          canAssign={canAssign}
+          onAssignPress={() => setAssignOpen(true)}
+          properties={properties}
+        />
 
-        <View style={styles.field}>
-          <Text style={styles.fieldLabel}>Created By</Text>
-          <Text style={styles.fieldValue}>
-            {creatorName} · {formatDateTime(task.opened_at)}
-          </Text>
-        </View>
-
-        <View style={styles.field}>
-          <Text style={styles.fieldLabel}>Assigned To</Text>
-          <View style={styles.assignRow}>
-            <Text style={styles.fieldValue}>{assigneeName ?? "Unassigned"}</Text>
-            {canAssign && (
-              <TouchableOpacity
-                style={styles.assignBtn}
-                onPress={() => setAssignOpen(true)}
-                hitSlop={{ top: 8, bottom: 8, left: 8, right: 8 }}
-                activeOpacity={0.7}
-              >
-                <UserPlus size={14} color={colors.primary} strokeWidth={2} />
-                <Text style={styles.assignBtnText}>Assign</Text>
-              </TouchableOpacity>
-            )}
-          </View>
-          {!canAssign && (
-            <Text style={styles.fieldHint}>Only the task's creator can assign it.</Text>
-          )}
-        </View>
-
-        {properties.length > 0 && (
-          <View style={styles.field}>
-            <Text style={styles.fieldLabel}>Properties</Text>
-            <View style={styles.pillRow}>
-              {properties.map((p: Property) => (
-                <PropertyPill key={p.id} property={p} />
-              ))}
-            </View>
-          </View>
-        )}
-
-        {/* Status history — the notes posted with each status change, newest first.
-            The message text is shown verbatim: it is the same message the channel
-            shows, and re-parsing our own wording back apart would be a data model
-            made of prose. */}
-        <View style={styles.field}>
-          <Text style={styles.fieldLabel}>Status History</Text>
-          {history.length === 0 ? (
-            <Text style={styles.fieldHint}>
-              No status changes yet. Notes appear here when the status is changed.
-            </Text>
-          ) : (
-            history.map((m) => (
-              <View key={m.id} style={styles.historyRow}>
-                <Text style={styles.historyText}>{m.text}</Text>
-                <Text style={styles.historyMeta}>
-                  {usersMap[m.createdby_id] ?? "Unknown"} ·{" "}
-                  {formatDateTime(m.created_at)}
-                </Text>
-              </View>
-            ))
-          )}
-        </View>
+        <TaskStatusHistory history={history} usersMap={usersMap} />
       </ScrollView>
 
-      {/* Assignee picker */}
-      <Modal
+      <AssigneePickerModal
         visible={assignOpen}
-        transparent
-        animationType="fade"
-        onRequestClose={() => setAssignOpen(false)}
-      >
-        <Pressable style={styles.backdrop} onPress={() => setAssignOpen(false)} />
-        <View style={styles.sheet}>
-          <View style={styles.sheetHeader}>
-            <Text style={styles.sheetTitle}>Assign To</Text>
-            <TouchableOpacity
-              onPress={() => setAssignOpen(false)}
-              hitSlop={{ top: 8, bottom: 8, left: 8, right: 8 }}
-              activeOpacity={0.6}
-            >
-              <X size={18} color={colors.mutedForeground} strokeWidth={2} />
-            </TouchableOpacity>
-          </View>
-          <ScrollView style={styles.sheetScroll}>
-            <TouchableOpacity
-              style={styles.memberRow}
-              onPress={() => assignTo(null)}
-              activeOpacity={0.7}
-            >
-              <Text style={styles.memberName}>Unassigned</Text>
-            </TouchableOpacity>
-            {memberIds.map((id) => (
-              <TouchableOpacity
-                key={id}
-                style={styles.memberRow}
-                onPress={() => assignTo(id)}
-                activeOpacity={0.7}
-              >
-                <Text style={styles.memberName}>{usersMap[id] ?? "Unknown"}</Text>
-                {task.assignee_id === id && (
-                  <CheckCircle2 size={16} color={colors.primary} strokeWidth={2} />
-                )}
-              </TouchableOpacity>
-            ))}
-          </ScrollView>
-        </View>
-      </Modal>
+        onClose={() => setAssignOpen(false)}
+        memberIds={memberIds}
+        assigneeId={task.assignee_id ?? null}
+        usersMap={usersMap}
+        onAssign={assignTo}
+      />
     </KeyboardAvoidingView>
   )
 }
@@ -465,121 +284,11 @@ const styles = StyleSheet.create({
     flex: 1,
     backgroundColor: colors.background,
   },
-  headerAction: {
-    padding: 6,
-  },
-  historyRow: {
-    gap: 3,
-    marginTop: 8,
-    paddingHorizontal: 10,
-    paddingVertical: 8,
-    backgroundColor: colors.cardSurface,
-    borderWidth: 1,
-    borderColor: colors.cardBorder,
-    borderRadius: 10,
-  },
-  historyText: {
-    fontSize: 13,
-    fontFamily: "InstrumentSans_400Regular",
-    color: colors.foreground,
-    lineHeight: 18,
-  },
-  historyMeta: {
-    fontSize: 11,
-    fontFamily: "InstrumentSans_400Regular",
-    color: colors.mutedForeground,
-  },
-  noteSection: {
-    gap: 6,
-    marginTop: 10,
-    padding: 12,
-    backgroundColor: colors.cardSurface,
-    borderWidth: 1,
-    borderColor: colors.cardBorder,
-    borderRadius: 12,
-  },
-  noteTitle: {
-    fontSize: 14,
-    fontFamily: "InstrumentSans_600SemiBold",
-    color: colors.foreground,
-  },
-  noteHint: {
-    fontSize: 11,
-    fontFamily: "InstrumentSans_400Regular",
-    color: colors.mutedForeground,
-  },
-  noteInput: {
-    minHeight: 72,
-    marginTop: 4,
-    borderWidth: 1,
-    borderColor: colors.cardBorder,
-    borderRadius: 8,
-    backgroundColor: colors.background,
-    paddingHorizontal: 10,
-    paddingVertical: 8,
-    fontSize: 13,
-    fontFamily: "InstrumentSans_400Regular",
-    color: colors.foreground,
-  },
-  noteActions: {
-    flexDirection: "row",
-    alignItems: "center",
-    justifyContent: "flex-end",
-    gap: 14,
-    marginTop: 4,
-  },
-  noteCancel: {
-    fontSize: 13,
-    fontFamily: "InstrumentSans_500Medium",
-    color: colors.mutedForeground,
-  },
-  noteSubmit: {
-    backgroundColor: colors.primary,
-    paddingHorizontal: 12,
-    paddingVertical: 8,
-    borderRadius: 8,
-  },
-  noteSubmitDisabled: {
-    opacity: 0.4,
-  },
-  noteSubmitText: {
-    fontSize: 13,
-    fontFamily: "InstrumentSans_600SemiBold",
-    color: colors.primaryForeground,
-  },
   centered: {
     flex: 1,
     alignItems: "center",
     justifyContent: "center",
     backgroundColor: colors.background,
-  },
-  header: {
-    flexDirection: "row",
-    alignItems: "center",
-    // paddingTop applied inline from useSafeAreaInsets().top (real device inset).
-    paddingBottom: 16,
-    paddingHorizontal: 16,
-    backgroundColor: colors.background,
-    borderBottomWidth: 1,
-    borderBottomColor: colors.border,
-    gap: 8,
-  },
-  backButton: {
-    padding: 4,
-    marginRight: 4,
-  },
-  backArrow: {
-    fontSize: 32,
-    color: colors.primary,
-    fontFamily: "InstrumentSans_400Regular",
-    lineHeight: 32,
-  },
-  headerTitle: {
-    flex: 1,
-    fontSize: 18,
-    fontFamily: "InstrumentSans_600SemiBold",
-    color: colors.foreground,
-    lineHeight: 22,
   },
   content: {
     paddingHorizontal: 16,
@@ -591,122 +300,5 @@ const styles = StyleSheet.create({
     fontFamily: "InstrumentSans_400Regular",
     color: colors.foreground,
     lineHeight: 20,
-  },
-  statusBtn: {
-    flexDirection: "row",
-    alignItems: "center",
-    gap: 8,
-    paddingHorizontal: 12,
-    paddingVertical: 12,
-    borderRadius: 10,
-    borderWidth: 1,
-    borderColor: colors.cardBorder,
-    backgroundColor: colors.cardSurface,
-  },
-  statusBtnDone: {
-    backgroundColor: "#16653411",
-    borderColor: "#16653455",
-  },
-  statusText: {
-    fontSize: 14,
-    fontFamily: "InstrumentSans_600SemiBold",
-    color: colors.foreground,
-  },
-  statusTextDone: {
-    color: "#166534",
-  },
-  statusHint: {
-    flex: 1,
-    textAlign: "right",
-    fontSize: 11,
-    fontFamily: "InstrumentSans_400Regular",
-    color: colors.mutedForeground,
-  },
-  field: {
-    gap: 4,
-  },
-  fieldLabel: {
-    fontSize: 11,
-    fontFamily: "InstrumentSans_500Medium",
-    color: colors.mutedForeground,
-    textTransform: "uppercase",
-    letterSpacing: 0.5,
-  },
-  fieldValue: {
-    fontSize: 14,
-    fontFamily: "InstrumentSans_500Medium",
-    color: colors.foreground,
-  },
-  fieldHint: {
-    fontSize: 11,
-    fontFamily: "InstrumentSans_400Regular",
-    color: colors.mutedForeground,
-  },
-  assignRow: {
-    flexDirection: "row",
-    alignItems: "center",
-    justifyContent: "space-between",
-    gap: 10,
-  },
-  assignBtn: {
-    flexDirection: "row",
-    alignItems: "center",
-    gap: 4,
-    paddingHorizontal: 10,
-    paddingVertical: 6,
-    borderRadius: 8,
-    borderWidth: 1,
-    borderColor: colors.primary,
-  },
-  assignBtnText: {
-    fontSize: 12,
-    fontFamily: "InstrumentSans_600SemiBold",
-    color: colors.primary,
-  },
-  pillRow: {
-    flexDirection: "row",
-    flexWrap: "wrap",
-    gap: 6,
-  },
-  backdrop: {
-    flex: 1,
-    backgroundColor: colors.scrim,
-  },
-  sheet: {
-    position: "absolute",
-    left: 24,
-    right: 24,
-    top: "30%",
-    maxHeight: "45%",
-    backgroundColor: colors.background,
-    borderRadius: 12,
-    padding: 16,
-  },
-  sheetHeader: {
-    flexDirection: "row",
-    alignItems: "center",
-    justifyContent: "space-between",
-    paddingBottom: 10,
-    borderBottomWidth: 1,
-    borderBottomColor: colors.cardBorder,
-  },
-  sheetTitle: {
-    fontSize: 15,
-    fontFamily: "InstrumentSans_600SemiBold",
-    color: colors.foreground,
-  },
-  sheetScroll: {
-    marginTop: 6,
-  },
-  memberRow: {
-    flexDirection: "row",
-    alignItems: "center",
-    justifyContent: "space-between",
-    paddingVertical: 10,
-  },
-  memberName: {
-    fontSize: 14,
-    fontFamily: "InstrumentSans_500Medium",
-    color: colors.foreground,
   },
 })

--- a/mobile-app/app/(tabs)/project/[projectId]/[buildUnitId]/[channelId]/index.tsx
+++ b/mobile-app/app/(tabs)/project/[projectId]/[buildUnitId]/[channelId]/index.tsx
@@ -1,18 +1,11 @@
-import {
-  View,
-  Text,
-  TouchableOpacity,
-  KeyboardAvoidingView,
-  StyleSheet,
-  ActivityIndicator,
-} from "react-native"
+import { View, KeyboardAvoidingView, StyleSheet, ActivityIndicator } from "react-native"
 import { useCallback, useState } from "react"
 import { useLocalSearchParams, useRouter, useFocusEffect } from "expo-router"
-import { useSafeAreaInsets } from "react-native-safe-area-context"
 import { useMessages } from "@/src/presentation/messages/hooks/useMessages"
 import { MessageList } from "@/src/presentation/messages/components/MessageList"
 import { MessageInput } from "@/src/presentation/messages/components/MessageInput"
 import { ResourcesSheet } from "@/src/presentation/resources/components/ResourcesSheet"
+import { BackHeader } from "@/src/presentation/shared/components/BackHeader"
 import { useUsers } from "@/src/presentation/shared/hooks/useUsers"
 import { useSeen } from "@/src/presentation/shared/hooks/useSeen"
 import { TasksSheet } from "@/src/presentation/tasks/components/TasksSheet"
@@ -32,7 +25,6 @@ export default function ChannelScreen() {
   }>()
   const router = useRouter()
   const { data: session } = useSession()
-  const insets = useSafeAreaInsets()
 
   // Look up channel name from channelsCollection
   const { data: channelsData } = useLiveQuery(
@@ -82,32 +74,26 @@ export default function ChannelScreen() {
       behavior="padding"
       keyboardVerticalOffset={0}
     >
-      {/* Inline header with back button */}
-      <View style={[styles.header, { paddingTop: insets.top + 8 }]}>
-        <TouchableOpacity
-          style={styles.backButton}
-          onPress={() => router.back()}
-          hitSlop={{ top: 10, bottom: 10, left: 10, right: 10 }}
-          activeOpacity={0.6}
-        >
-          <Text style={styles.backArrow}>‹</Text>
-        </TouchableOpacity>
-        <Text style={styles.headerTitle} numberOfLines={1}>
-          {channel?.name ?? "Channel"}
-        </Text>
-        {/* Tasks and Resources both live behind header buttons — half-screen
-            sheets, so neither competes with the message list for vertical space. */}
-        <TasksSheet
-          channelId={channelId}
-          buildUnitId={buildUnitId}
-          projectId={projectId}
-        />
-        <ResourcesSheet
-          channelId={channelId}
-          buildUnitId={buildUnitId}
-          projectId={projectId}
-        />
-      </View>
+      <BackHeader
+        title={channel?.name ?? "Channel"}
+        onBack={() => router.back()}
+        // Tasks and Resources both live behind header buttons — half-screen
+        // sheets, so neither competes with the message list for vertical space.
+        actions={
+          <>
+            <TasksSheet
+              channelId={channelId}
+              buildUnitId={buildUnitId}
+              projectId={projectId}
+            />
+            <ResourcesSheet
+              channelId={channelId}
+              buildUnitId={buildUnitId}
+              projectId={projectId}
+            />
+          </>
+        }
+      />
 
       {/* Messages */}
       {isLoading ? (
@@ -143,34 +129,9 @@ const styles = StyleSheet.create({
     flex: 1,
     backgroundColor: colors.background,
   },
-  header: {
-    flexDirection: "row",
-    alignItems: "center",
-    // paddingTop applied inline from useSafeAreaInsets().top (real device inset).
-    paddingBottom: 16,
-    paddingHorizontal: 16,
-    backgroundColor: colors.background,
-    borderBottomWidth: 1,
-    borderBottomColor: colors.border,
-    gap: 8,
-  },
-  backButton: {
-    padding: 4,
-    marginRight: 4,
-  },
-  backArrow: {
-    fontSize: 32,
-    color: colors.primary,
-    fontFamily: "InstrumentSans_400Regular",
-    lineHeight: 32,
-  },
-  headerTitle: {
-    flex: 1,
-    fontSize: 18,
-    fontFamily: "InstrumentSans_600SemiBold",
-    color: colors.foreground,
-    lineHeight: 22,
-  },
+  // Deliberately NOT shared/ScreenStates' LoadingState: that one carries
+  // paddingHorizontal + gap for its icon/title/message stack, and is scoped to the
+  // Inbox and My Tasks screens. This is a bare centred spinner.
   centered: {
     flex: 1,
     alignItems: "center",

--- a/mobile-app/src/application/actions/seen.ts
+++ b/mobile-app/src/application/actions/seen.ts
@@ -1,5 +1,5 @@
 import { makeSeenActions } from "@buildinlime/sync-core"
-import { seenStateCollection, seenKey } from "../collections/admin"
+import { seenStateCollection, seenKey } from "../collections/communication"
 import { getOfflineExecutor } from "../../infrastructure/offline/executor"
 
 const { markSeenAction, resetSeenActions } = makeSeenActions({

--- a/mobile-app/src/application/collections/admin.ts
+++ b/mobile-app/src/application/collections/admin.ts
@@ -1,9 +1,9 @@
-import { userRowSchema } from "@buildinlime/contracts"
+import { usersSpec } from "@buildinlime/sync-core"
 import { getPersistence } from "../../infrastructure/persistence/expo-persistence"
-import { defineCollection, NEVER_GC, safeCleanup } from "./_shared"
+import { defineCollection, safeCleanup } from "./_shared"
 
-// Row schemas come from @buildinlime/contracts — one copy, shared with web and
-// asserted against the drizzle tables server-side. See ARCHITECTURE.md §10.
+// The descriptors live once in @buildinlime/sync-core — see collection-specs.ts.
+// This file supplies only mobile's persistence handle.
 //
 // This file holds the collections that belong to no single domain — users.
 // memberships and seen_state used to live here too, which put them in a
@@ -16,14 +16,7 @@ import { defineCollection, NEVER_GC, safeCleanup } from "./_shared"
 function _makeUsersCollection(
   persistence: ReturnType<typeof getPersistence>["persistence"],
 ) {
-  return defineCollection({
-    id: `users`,
-    path: `/api/users`,
-    schema: userRowSchema,
-    getKey: (item: { id: string }) => item.id,
-    gcTime: NEVER_GC,
-    persistence,
-  })
+  return defineCollection({ ...usersSpec(), persistence })
 }
 
 // ---------------------------------------------------------------------------

--- a/mobile-app/src/application/collections/admin.ts
+++ b/mobile-app/src/application/collections/admin.ts
@@ -1,13 +1,15 @@
-import {
-  userRowSchema,
-  membershipRowSchema,
-  seenStateRowSchema,
-} from "@buildinlime/contracts"
+import { userRowSchema } from "@buildinlime/contracts"
 import { getPersistence } from "../../infrastructure/persistence/expo-persistence"
-import { defineCollection, retryOnMembershipsError, NEVER_GC, safeCleanup } from "./_shared"
+import { defineCollection, NEVER_GC, safeCleanup } from "./_shared"
 
 // Row schemas come from @buildinlime/contracts — one copy, shared with web and
 // asserted against the drizzle tables server-side. See ARCHITECTURE.md §10.
+//
+// This file holds the collections that belong to no single domain — users.
+// memberships and seen_state used to live here too, which put them in a
+// different module than web keeps them in. They now sit where their tables do
+// (organization-tables.ts / communication-tables.ts) and where web already had
+// them: memberships in ./organization, seen_state in ./communication.
 
 // --- Factories ---
 
@@ -24,56 +26,11 @@ function _makeUsersCollection(
   })
 }
 
-/**
- * The current user's "last seen" markers — the timestamp successor to the reads
- * collection. Shape scoped `user_id = me` server-side (web-app
- * routes/api/seen-state.ts) with no query parameter able to widen it — so it
- * takes no membership ids and never rebuilds on scope change, exactly like reads.
- *
- * Key is composite: one row per (user, scope, scope_id). NEVER_GC because the
- * always-mounted DrawerContent badges subscribe to it, so it never idles.
- */
-export const seenKey = (userId: string, scope: string, scopeId: string) =>
-  `${userId}:${scope}:${scopeId}`
-
-function _makeSeenStateCollection(
-  persistence: ReturnType<typeof getPersistence>["persistence"],
-) {
-  return defineCollection({
-    id: `seen-state`,
-    path: `/api/seen-state`,
-    schema: seenStateRowSchema,
-    getKey: (item: { user_id: string; scope: string; scope_id: string }) =>
-      seenKey(item.user_id, item.scope, item.scope_id),
-    gcTime: NEVER_GC,
-    persistence,
-  })
-}
-
-function _makeMembershipsCollection(
-  persistence: ReturnType<typeof getPersistence>["persistence"],
-) {
-  return defineCollection({
-    id: `memberships`,
-    path: `/api/memberships`,
-    schema: membershipRowSchema,
-    getKey: (item: { id: string }) => item.id,
-    gcTime: NEVER_GC,
-    persistence,
-    // Reports the error before retrying, so the bootstrap can tell a clean empty
-    // sync apart from a shape that failed and was marked ready anyway — see
-    // retryOnMembershipsError.
-    onError: retryOnMembershipsError,
-  })
-}
-
 // ---------------------------------------------------------------------------
 // Deferred exports — initialized by the orchestrator in application/collections/init.ts
 // ES-module live bindings ensure importers always read the current value.
 // ---------------------------------------------------------------------------
 export let usersCollection: ReturnType<typeof _makeUsersCollection> = null!
-export let membershipsCollection: ReturnType<typeof _makeMembershipsCollection> = null!
-export let seenStateCollection: ReturnType<typeof _makeSeenStateCollection> = null!
 
 export function initializeUsersCollection() {
   const { persistence } = getPersistence()
@@ -81,24 +38,8 @@ export function initializeUsersCollection() {
   usersCollection = _makeUsersCollection(persistence)
 }
 
-export function initializeSeenStateCollection() {
-  const { persistence } = getPersistence()
-  safeCleanup(seenStateCollection)
-  seenStateCollection = _makeSeenStateCollection(persistence)
-}
-
-export function initializeMembershipsCollection() {
-  const { persistence } = getPersistence()
-  safeCleanup(membershipsCollection)
-  membershipsCollection = _makeMembershipsCollection(persistence)
-}
-
 export function resetAdminCollections() {
   // Stop sync before dropping the references (GC won't do it — it's disabled).
   safeCleanup(usersCollection)
-  safeCleanup(membershipsCollection)
-  safeCleanup(seenStateCollection)
   usersCollection = null!
-  membershipsCollection = null!
-  seenStateCollection = null!
 }

--- a/mobile-app/src/application/collections/communication.ts
+++ b/mobile-app/src/application/collections/communication.ts
@@ -3,6 +3,7 @@ import {
   messageRowSchema,
   resourceRowSchema,
   propertyRowSchema,
+  seenStateRowSchema,
 } from "@buildinlime/contracts"
 import { trpc } from "../../infrastructure/trpc/client"
 import { getPersistence } from "../../infrastructure/persistence/expo-persistence"
@@ -198,16 +199,52 @@ function _makeMyTasksCollection(
   })
 }
 
+/**
+ * The current user's "last seen" markers — the timestamp successor to the reads
+ * collection. Shape scoped `user_id = me` server-side (web-app
+ * routes/api/seen-state.ts) with no query parameter able to widen it — so it
+ * takes no membership ids and never rebuilds on scope change, exactly like reads.
+ *
+ * Key is composite: one row per (user, scope, scope_id). NEVER_GC because the
+ * always-mounted DrawerContent badges subscribe to it, so it never idles.
+ */
+export const seenKey = (userId: string, scope: string, scopeId: string) =>
+  `${userId}:${scope}:${scopeId}`
+
+function _makeSeenStateCollection(
+  persistence: ReturnType<typeof getPersistence>["persistence"],
+) {
+  return defineCollection({
+    id: `seen-state`,
+    path: `/api/seen-state`,
+    schema: seenStateRowSchema,
+    getKey: (item: { user_id: string; scope: string; scope_id: string }) =>
+      seenKey(item.user_id, item.scope, item.scope_id),
+    gcTime: NEVER_GC,
+    persistence,
+  })
+}
+
 // ---------------------------------------------------------------------------
 // Deferred exports — initialized by initializeCommunicationCollections()
 // and initializePropertiesCollection() after memberships and tasks preload.
 // ---------------------------------------------------------------------------
+export let seenStateCollection: ReturnType<typeof _makeSeenStateCollection> = null!
 export let tasksCollection: ReturnType<typeof _makeTasksCollection> = null!
 export let messagesCollection: ReturnType<typeof _makeMessagesCollection> = null!
 export let resourcesCollection: ReturnType<typeof _makeResourcesCollection> = null!
 export let propertiesCollection: ReturnType<typeof _makePropertiesCollection> = null!
 export let inboxMentionsCollection: ReturnType<typeof _makeInboxMentionsCollection> = null!
 export let myTasksCollection: ReturnType<typeof _makeMyTasksCollection> = null!
+
+// Seen state is scoped `user_id = me` server-side, not by membership, so it is
+// initialized during BOOTSTRAP alongside users — not with the channel-scoped
+// collections below, and it never rebuilds on a scope change.
+export function initializeSeenStateCollection() {
+  const { persistence } = getPersistence()
+  safeCleanup(seenStateCollection)
+  seenStateCollection = _makeSeenStateCollection(persistence)
+}
 
 export function initializeCommunicationCollections(params: {
   memberChannelIds: string[]
@@ -242,6 +279,8 @@ export function initializePropertiesCollection(params: {
 
 export function resetCommunicationCollections() {
   // Stop sync before dropping the references (GC won't do it — it's disabled).
+  safeCleanup(seenStateCollection)
+  seenStateCollection = null!
   safeCleanup(tasksCollection)
   safeCleanup(messagesCollection)
   safeCleanup(resourcesCollection)

--- a/mobile-app/src/application/collections/communication.ts
+++ b/mobile-app/src/application/collections/communication.ts
@@ -161,8 +161,11 @@ export function initializeCommunicationCollections(params: {
   memberChannelIds: string[]
 }) {
   const { persistence } = getPersistence()
-  // On a project switch / channel-set resync these hold the previous instances;
-  // stop their sync before replacing (GC is disabled, so nothing else will).
+  // On a channel-set resync (resyncProjectCollections re-enters this function)
+  // these hold the previous instances; stop their sync before replacing, since
+  // GC is disabled and nothing else will. Unlike the organization equivalent,
+  // this cleanup IS live — a membership change rebuilds the channel-scoped
+  // collections mid-session.
   safeCleanup(tasksCollection)
   safeCleanup(messagesCollection)
   safeCleanup(resourcesCollection)

--- a/mobile-app/src/application/collections/communication.ts
+++ b/mobile-app/src/application/collections/communication.ts
@@ -1,21 +1,24 @@
 import {
-  taskRowSchema,
-  messageRowSchema,
-  resourceRowSchema,
-  propertyRowSchema,
-  seenStateRowSchema,
-} from "@buildinlime/contracts"
+  tasksSpec,
+  messagesSpec,
+  resourcesSpec,
+  propertiesSpec,
+  seenStateSpec,
+  inboxMentionsSpec,
+  myTasksSpec,
+  seenKey,
+} from "@buildinlime/sync-core"
 import { trpc } from "../../infrastructure/trpc/client"
 import { getPersistence } from "../../infrastructure/persistence/expo-persistence"
-import { defineCollection, NEVER_GC, IDLE_GC_MS, safeCleanup } from "./_shared"
+import { defineCollection, safeCleanup } from "./_shared"
 
-// Row schemas come from @buildinlime/contracts — one copy, shared with web and
-// asserted against the drizzle tables server-side. See ARCHITECTURE.md §10.
-//
-// Zod strips unknown keys, so a column missing from a row schema is DROPPED from
-// the synced row rather than merely untyped. That is why the schemas are no longer
-// maintained here by hand: this file had already lost properties.channel_id and
-// properties.createdby_id that way.
+// The descriptors (id, route, shape params, row schema, key, GC tier) live once
+// in @buildinlime/sync-core — see collection-specs.ts, which also carries the
+// reasoning for each GC tier. This file supplies only what is mobile's own: the
+// persistence handle, and the properties onUpdate handler.
+
+// seenKey is re-exported because application/actions/seen.ts imports it from here.
+export { seenKey }
 
 // ---------------------------------------------------------------------------
 // Factory functions — collections are created AFTER memberships load so that
@@ -26,68 +29,31 @@ function _makeTasksCollection(
   persistence: ReturnType<typeof getPersistence>["persistence"],
   memberChannelIds: string[],
 ) {
-  return defineCollection({
-    id: `tasks`,
-    path: `/api/tasks`,
-    params: { member_channel_ids: memberChannelIds },
-    schema: taskRowSchema,
-    getKey: (item: { id: string }) => item.id,
-    // Idle-GC: with the DrawerContent My-Tasks badge now reading the tiny
-    // my-tasks slice (not scanning this full collection), nothing
-    // always-mounted holds tasks. It idles on the drawer / home / inbox
-    // screens and resurrects + resumes from the SQLite offset when a channel /
-    // My-Tasks view opens. See IDLE_GC_MS.
-    gcTime: IDLE_GC_MS,
-    persistence,
-    // No handlers — writes routed through @tanstack/offline-transactions
-    // (see application/actions/tasks.ts).
-  })
+  // No handlers — writes routed through @tanstack/offline-transactions
+  // (see application/actions/tasks.ts).
+  return defineCollection({ ...tasksSpec(memberChannelIds), persistence })
 }
 
 function _makeMessagesCollection(
   persistence: ReturnType<typeof getPersistence>["persistence"],
   memberChannelIds: string[],
 ) {
-  return defineCollection({
-    id: `messages`,
-    path: `/api/messages`,
-    params: { member_channel_ids: memberChannelIds },
-    schema: messageRowSchema,
-    getKey: (item: { id: string }) => item.id,
-    // Idle-GC: with the DrawerContent inbox badge now reading the tiny
-    // inbox-mentions slice (not scanning this full collection), nothing
-    // always-mounted holds messages. It idles off the channel / inbox screens
-    // and resurrects + resumes from the SQLite offset on return. See IDLE_GC_MS.
-    gcTime: IDLE_GC_MS,
-    persistence,
-    // No handlers. onInsert is routed through @tanstack/offline-transactions
-    // (see application/actions/messages.ts → createMessageAction), and onDelete is
-    // omitted DELIBERATELY: deleting a message is a soft delete, which is an UPDATE
-    // (the row survives so its replies keep a parent) — see deleteMessageAction. A
-    // delete handler here would let messagesCollection.delete() drop the row
-    // optimistically and orphan the thread. With none it fails loudly instead.
-  })
+  // No handlers. onInsert is routed through @tanstack/offline-transactions
+  // (see application/actions/messages.ts → createMessageAction), and onDelete is
+  // omitted DELIBERATELY: deleting a message is a soft delete, which is an UPDATE
+  // (the row survives so its replies keep a parent) — see deleteMessageAction. A
+  // delete handler here would let messagesCollection.delete() drop the row
+  // optimistically and orphan the thread. With none it fails loudly instead.
+  return defineCollection({ ...messagesSpec(memberChannelIds), persistence })
 }
 
 function _makeResourcesCollection(
   persistence: ReturnType<typeof getPersistence>["persistence"],
   memberChannelIds: string[],
 ) {
-  return defineCollection({
-    id: `resources`,
-    path: `/api/resources`,
-    params: { member_channel_ids: memberChannelIds },
-    schema: resourceRowSchema,
-    getKey: (item: { id: string }) => item.id,
-    // Idle-GC: resources has NO always-mounted subscriber (only the
-    // ResourcesSheet and in-message attachment views, both mounted on
-    // demand), so it idles off-screen. Persisted, so resurrection resumes from
-    // the SQLite offset rather than refetching. See IDLE_GC_MS.
-    gcTime: IDLE_GC_MS,
-    persistence,
-    // No handlers — onDelete routed through @tanstack/offline-transactions
-    // (see application/actions/resources.ts → deleteResourceAction).
-  })
+  // No handlers — onDelete routed through @tanstack/offline-transactions
+  // (see application/actions/resources.ts → deleteResourceAction).
+  return defineCollection({ ...resourcesSpec(memberChannelIds), persistence })
 }
 
 function _makePropertiesCollection(
@@ -99,26 +65,7 @@ function _makePropertiesCollection(
   },
 ) {
   return defineCollection({
-    id: `properties`,
-    path: `/api/properties`,
-    // The /api/properties shape OR's two scopes: project/build-unit properties by
-    // entity_id (member_project_ids ∪ member_buildunit_ids), and channel + TASK
-    // properties by the denormalized channel_id (member_channel_ids). Task
-    // properties therefore ride the same channel scope as tasks/messages — a new
-    // task's properties in a visible channel sync with no rebuild, so no
-    // member_task_ids snapshot is needed (server ignores it).
-    params: {
-      member_project_ids: params.memberProjectIds,
-      member_buildunit_ids: params.memberBuildunitIds,
-      member_channel_ids: params.memberChannelIds,
-    },
-    schema: propertyRowSchema,
-    getKey: (item: { id: string }) => item.id,
-    // Idle-GC: properties is subscribed ONLY by the channel / build-unit /
-    // task screens — nothing always-mounted holds it (the Drawer badges scan
-    // messages/tasks/seen_state, never properties). Persisted, so the next visit
-    // resurrects it and resumes from the SQLite offset. See IDLE_GC_MS.
-    gcTime: IDLE_GC_MS,
+    ...propertiesSpec(params),
     persistence,
     handlers: {
       // onInsert/onDelete omitted — routed through @tanstack/offline-transactions
@@ -173,56 +120,20 @@ function _makeInboxMentionsCollection(
   persistence: ReturnType<typeof getPersistence>["persistence"],
   memberChannelIds: string[],
 ) {
-  return defineCollection({
-    id: `inbox-mentions`,
-    path: `/api/inbox-mentions`,
-    params: { member_channel_ids: memberChannelIds },
-    schema: messageRowSchema,
-    getKey: (item: { id: string }) => item.id,
-    gcTime: NEVER_GC,
-    persistence,
-  })
+  return defineCollection({ ...inboxMentionsSpec(memberChannelIds), persistence })
 }
 
 function _makeMyTasksCollection(
   persistence: ReturnType<typeof getPersistence>["persistence"],
   memberChannelIds: string[],
 ) {
-  return defineCollection({
-    id: `my-tasks`,
-    path: `/api/my-tasks`,
-    params: { member_channel_ids: memberChannelIds },
-    schema: taskRowSchema,
-    getKey: (item: { id: string }) => item.id,
-    gcTime: NEVER_GC,
-    persistence,
-  })
+  return defineCollection({ ...myTasksSpec(memberChannelIds), persistence })
 }
-
-/**
- * The current user's "last seen" markers — the timestamp successor to the reads
- * collection. Shape scoped `user_id = me` server-side (web-app
- * routes/api/seen-state.ts) with no query parameter able to widen it — so it
- * takes no membership ids and never rebuilds on scope change, exactly like reads.
- *
- * Key is composite: one row per (user, scope, scope_id). NEVER_GC because the
- * always-mounted DrawerContent badges subscribe to it, so it never idles.
- */
-export const seenKey = (userId: string, scope: string, scopeId: string) =>
-  `${userId}:${scope}:${scopeId}`
 
 function _makeSeenStateCollection(
   persistence: ReturnType<typeof getPersistence>["persistence"],
 ) {
-  return defineCollection({
-    id: `seen-state`,
-    path: `/api/seen-state`,
-    schema: seenStateRowSchema,
-    getKey: (item: { user_id: string; scope: string; scope_id: string }) =>
-      seenKey(item.user_id, item.scope, item.scope_id),
-    gcTime: NEVER_GC,
-    persistence,
-  })
+  return defineCollection({ ...seenStateSpec(), persistence })
 }
 
 // ---------------------------------------------------------------------------

--- a/mobile-app/src/application/collections/init.ts
+++ b/mobile-app/src/application/collections/init.ts
@@ -1,19 +1,17 @@
 import {
-  initializeMembershipsCollection,
   initializeUsersCollection,
-  initializeSeenStateCollection,
   resetAdminCollections,
-  membershipsCollection,
   usersCollection,
-  seenStateCollection,
 } from "./admin"
 import {
+  initializeMembershipsCollection,
   initializeProjectsCollection,
   initializeOrganizationCollections,
   initializeChannelMembersCollection,
   reinitializeProjectsCollection,
   reinitializeScopedOrganizationCollections,
   resetOrganizationCollections,
+  membershipsCollection,
   projectsCollection,
   buildUnitsCollection,
   channelsCollection,
@@ -22,7 +20,9 @@ import {
 import {
   initializeCommunicationCollections,
   initializePropertiesCollection,
+  initializeSeenStateCollection,
   resetCommunicationCollections,
+  seenStateCollection,
   tasksCollection,
   messagesCollection,
   resourcesCollection,

--- a/mobile-app/src/application/collections/init.ts
+++ b/mobile-app/src/application/collections/init.ts
@@ -250,8 +250,12 @@ export async function initProjectCollections(projectId: string): Promise<void> {
 // ---------------------------------------------------------------------------
 // Resync — rebuild the membership-scoped collections in place when the current
 // user's visible scope changes at runtime (they create a channel, or are added
-// to / removed from one) without a fresh login or project switch. Returns true
-// if anything was rebuilt.
+// to / removed from one) without a fresh login. Returns true if anything was
+// rebuilt.
+//
+// This is the ONLY path that rebuilds collections mid-session: there is no
+// project switch (see the drawer's "Sign out to switch project"), so anything
+// that has to survive a rebuild hangs off this, not off a project change.
 //
 // MUST run while the authenticated content is unmounted (the layout renders a
 // spinner during resync), so cleanup() never runs against a collection a

--- a/mobile-app/src/application/collections/organization.ts
+++ b/mobile-app/src/application/collections/organization.ts
@@ -106,8 +106,17 @@ export function initializeOrganizationCollections(params: {
   if (!projectsCollection) {
     projectsCollection = _makeProjectsCollection(persistence, params.memberProjectIds)
   }
-  // On a project switch these hold the previous project's collections; stop
-  // their sync before replacing (GC is disabled, so it won't happen for us).
+  // These two safeCleanup calls are currently NO-OPS, and deliberately kept.
+  //
+  // The only caller is initProjectCollections, which runs once per mount of
+  // (tabs)/_layout — there is no project SWITCH in the app any more (the drawer
+  // says "Sign out to switch project", and the picker is unreachable once a
+  // project is selected), so both refs are still null here every time.
+  //
+  // They stay because they are the correct cleanup if switching ever comes
+  // back: GC is disabled on these collections, so replacing a live instance
+  // without stopping its sync first leaks the previous project's Electric
+  // shape with nothing left to close it.
   safeCleanup(buildUnitsCollection)
   safeCleanup(channelsCollection)
   buildUnitsCollection = _makeBuildUnitsCollection(persistence, params.memberBuildunitIds)

--- a/mobile-app/src/application/collections/organization.ts
+++ b/mobile-app/src/application/collections/organization.ts
@@ -1,83 +1,50 @@
 import {
-  projectRowSchema,
-  buildUnitRowSchema,
-  channelRowSchema,
-  membershipRowSchema,
-} from "@buildinlime/contracts"
+  projectsSpec,
+  buildUnitsSpec,
+  channelsSpec,
+  channelMembersSpec,
+  membershipsSpec,
+} from "@buildinlime/sync-core"
 import { getPersistence } from "../../infrastructure/persistence/expo-persistence"
-import {
-  defineCollection,
-  retryOnMembershipsError,
-  NEVER_GC,
-  safeCleanup,
-} from "./_shared"
+import { defineCollection, retryOnMembershipsError, safeCleanup } from "./_shared"
 
-// Row schemas come from @buildinlime/contracts — one copy, shared with web and
-// asserted against the drizzle tables server-side. See ARCHITECTURE.md §10.
+// The descriptors (id, route, shape params, row schema, key, GC tier) live once
+// in @buildinlime/sync-core — see collection-specs.ts. This file supplies only
+// what is mobile's own: the persistence handle, and the memberships onError.
 
 // ---------------------------------------------------------------------------
 // Factory functions — collections are created AFTER memberships load so that
 // membership-derived IDs can be baked into the shape URLs. This eliminates
 // the per-poll membership table scan on the server side.
+//
+// None of these take handlers: the organization tables are read-only on mobile
+// (projects, build units and channels are managed on web), and a missing handler
+// makes a stray write fail loudly rather than silently no-op.
 // ---------------------------------------------------------------------------
 
 function _makeProjectsCollection(
   persistence: ReturnType<typeof getPersistence>["persistence"],
   memberProjectIds: string[],
 ) {
-  return defineCollection({
-    id: `projects`,
-    path: `/api/projects`,
-    params: { member_ids: memberProjectIds },
-    schema: projectRowSchema,
-    getKey: (item: { id: string }) => item.id,
-    gcTime: NEVER_GC,
-    persistence,
-    // No handlers — read-only on mobile; projects are managed on web.
-  })
+  return defineCollection({ ...projectsSpec(memberProjectIds), persistence })
 }
 
 function _makeBuildUnitsCollection(
   persistence: ReturnType<typeof getPersistence>["persistence"],
   memberBuildunitIds: string[],
 ) {
-  return defineCollection({
-    id: `build-units`,
-    path: `/api/buildunits`,
-    params: { member_ids: memberBuildunitIds },
-    schema: buildUnitRowSchema,
-    getKey: (item: { id: string }) => item.id,
-    gcTime: NEVER_GC,
-    persistence,
-    // No handlers — read-only on mobile; build units are managed on web.
-  })
+  return defineCollection({ ...buildUnitsSpec(memberBuildunitIds), persistence })
 }
 
 function _makeChannelsCollection(
   persistence: ReturnType<typeof getPersistence>["persistence"],
   memberChannelIds: string[],
 ) {
-  return defineCollection({
-    id: `channels`,
-    path: `/api/channels`,
-    params: { member_ids: memberChannelIds },
-    schema: channelRowSchema,
-    getKey: (item: { id: string }) => item.id,
-    gcTime: NEVER_GC,
-    persistence,
-    // No handlers — read-only on mobile; channels are managed on web.
-  })
+  return defineCollection({ ...channelsSpec(memberChannelIds), persistence })
 }
 
 /**
  * The ROSTER stream: every member of every channel this user can see.
- *
- * This is NOT membershipsCollection. That one is the SELF stream — the server
- * scopes it `user_id = me`, so it holds only your own rows and can never tell you
- * who else is in a channel. Anything that renders other people (the assignee
- * picker, member lists) needs this collection instead. Mirrors web's
- * channelMembersCollection; both hit the same `memberships` table with a wider
- * where clause, and both validate against the one shared membershipRowSchema.
  *
  * The channel ids are baked into the shape URL, so this must be rebuilt whenever
  * the visible channel set changes — same lifecycle as channelsCollection, which is
@@ -87,36 +54,14 @@ function _makeChannelMembersCollection(
   persistence: ReturnType<typeof getPersistence>["persistence"],
   memberChannelIds: string[],
 ) {
-  return defineCollection({
-    id: `channel-members`,
-    path: `/api/channel-members`,
-    // Note the param name: this route takes `channel_ids`, not the `member_ids` the
-    // projects/buildunits/channels routes take.
-    params: { channel_ids: memberChannelIds },
-    schema: membershipRowSchema,
-    getKey: (item: { id: string }) => item.id,
-    gcTime: NEVER_GC,
-    persistence,
-  })
+  return defineCollection({ ...channelMembersSpec(memberChannelIds), persistence })
 }
 
-/**
- * The current user's SELF membership stream — scoped `user_id = me` server-side,
- * so it takes no id parameters and never rebuilds on scope change.
- *
- * This is the collection every other scoped shape derives its id sets from, which
- * is why it loads first and why its errors are tracked: see loadMembershipsCollection
- * in ./init and retryOnMembershipsError in ./_shared.
- */
 function _makeMembershipsCollection(
   persistence: ReturnType<typeof getPersistence>["persistence"],
 ) {
   return defineCollection({
-    id: `memberships`,
-    path: `/api/memberships`,
-    schema: membershipRowSchema,
-    getKey: (item: { id: string }) => item.id,
-    gcTime: NEVER_GC,
+    ...membershipsSpec(),
     persistence,
     // Reports the error before retrying, so the bootstrap can tell a clean empty
     // sync apart from a shape that failed and was marked ready anyway — see

--- a/mobile-app/src/application/collections/organization.ts
+++ b/mobile-app/src/application/collections/organization.ts
@@ -5,7 +5,12 @@ import {
   membershipRowSchema,
 } from "@buildinlime/contracts"
 import { getPersistence } from "../../infrastructure/persistence/expo-persistence"
-import { defineCollection, NEVER_GC, safeCleanup } from "./_shared"
+import {
+  defineCollection,
+  retryOnMembershipsError,
+  NEVER_GC,
+  safeCleanup,
+} from "./_shared"
 
 // Row schemas come from @buildinlime/contracts — one copy, shared with web and
 // asserted against the drizzle tables server-side. See ARCHITECTURE.md §10.
@@ -95,14 +100,48 @@ function _makeChannelMembersCollection(
   })
 }
 
+/**
+ * The current user's SELF membership stream — scoped `user_id = me` server-side,
+ * so it takes no id parameters and never rebuilds on scope change.
+ *
+ * This is the collection every other scoped shape derives its id sets from, which
+ * is why it loads first and why its errors are tracked: see loadMembershipsCollection
+ * in ./init and retryOnMembershipsError in ./_shared.
+ */
+function _makeMembershipsCollection(
+  persistence: ReturnType<typeof getPersistence>["persistence"],
+) {
+  return defineCollection({
+    id: `memberships`,
+    path: `/api/memberships`,
+    schema: membershipRowSchema,
+    getKey: (item: { id: string }) => item.id,
+    gcTime: NEVER_GC,
+    persistence,
+    // Reports the error before retrying, so the bootstrap can tell a clean empty
+    // sync apart from a shape that failed and was marked ready anyway — see
+    // retryOnMembershipsError.
+    onError: retryOnMembershipsError,
+  })
+}
+
 // ---------------------------------------------------------------------------
 // Deferred exports — initialized by initializeOrganizationCollections()
 // after memberships preload.
 // ---------------------------------------------------------------------------
+export let membershipsCollection: ReturnType<typeof _makeMembershipsCollection> = null!
 export let projectsCollection: ReturnType<typeof _makeProjectsCollection> = null!
 export let buildUnitsCollection: ReturnType<typeof _makeBuildUnitsCollection> = null!
 export let channelsCollection: ReturnType<typeof _makeChannelsCollection> = null!
 export let channelMembersCollection: ReturnType<typeof _makeChannelMembersCollection> = null!
+
+// Memberships loads FIRST in bootstrap — every other scoped collection derives
+// its shape ids from it. See initBootstrapCollections in ./init.
+export function initializeMembershipsCollection() {
+  const { persistence } = getPersistence()
+  safeCleanup(membershipsCollection)
+  membershipsCollection = _makeMembershipsCollection(persistence)
+}
 
 // Standalone init for the projects collection — called during bootstrap
 // (before a project is selected) so the picker can render all user projects.
@@ -173,10 +212,12 @@ export function reinitializeScopedOrganizationCollections(params: {
 
 export function resetOrganizationCollections() {
   // Stop sync before dropping the references (GC won't do it — it's disabled).
+  safeCleanup(membershipsCollection)
   safeCleanup(projectsCollection)
   safeCleanup(buildUnitsCollection)
   safeCleanup(channelsCollection)
   safeCleanup(channelMembersCollection)
+  membershipsCollection = null!
   projectsCollection = null!
   buildUnitsCollection = null!
   channelsCollection = null!

--- a/mobile-app/src/infrastructure/offline/executor.ts
+++ b/mobile-app/src/infrastructure/offline/executor.ts
@@ -20,9 +20,13 @@ import { getOnlineDetector } from "./online-detector"
 let _executor: OfflineExecutor | null = null
 
 // Start (or restart) the offline executor with the currently-initialized
-// collections. Mobile collections are project-scoped and re-initialized on
-// project switch, so this must be called AFTER initProjectCollections() and
-// re-called whenever the project context changes.
+// collections. It captures collection instances BY VALUE, so it must be called
+// AFTER initProjectCollections() and re-called whenever those instances are
+// rebuilt.
+//
+// In practice that means once at startup, and again after a membership RESYNC
+// (see resyncProjectCollections + its caller in (tabs)/_layout). Not on a
+// project switch — there isn't one; switching projects means signing out.
 export async function initOfflineExecutor(): Promise<OfflineExecutor> {
   if (_executor) {
     _executor.dispose()

--- a/mobile-app/src/infrastructure/offline/executor.ts
+++ b/mobile-app/src/infrastructure/offline/executor.ts
@@ -5,8 +5,8 @@ import {
   messagesCollection,
   resourcesCollection,
   propertiesCollection,
+  seenStateCollection,
 } from "../../application/collections/communication"
-import { seenStateCollection } from "../../application/collections/admin"
 import { mutationFns } from "./mutation-fns"
 import { sqliteStorageAdapter } from "./storage"
 import { getOnlineDetector } from "./online-detector"

--- a/mobile-app/src/infrastructure/offline/online-detector.ts
+++ b/mobile-app/src/infrastructure/offline/online-detector.ts
@@ -69,8 +69,9 @@ function createOnlineDetector(): InternalDetector {
       return online
     },
     // No-op: the detector is a shared singleton, so a consumer disposing
-    // (e.g. the executor being torn down and rebuilt on project switch) must
-    // NOT kill the connectivity source the other consumer still depends on.
+    // (e.g. the executor being torn down and rebuilt after a membership
+    // resync) must NOT kill the connectivity source the other consumer still
+    // depends on.
     // Real teardown happens via disposeOnlineDetector() at sign-out.
     dispose() {},
     _teardown() {

--- a/mobile-app/src/infrastructure/offline/pending-uploads-db.ts
+++ b/mobile-app/src/infrastructure/offline/pending-uploads-db.ts
@@ -1,5 +1,6 @@
 import { openDatabaseSync, deleteDatabaseAsync } from "expo-sqlite"
 import type { SQLiteDatabase } from "expo-sqlite"
+import type { UploadStatus } from "@buildinlime/sync-core"
 
 // SQLite CRUD over the `pending_attachments` table — attachment METADATA only
 // (the file bytes are kept as a binary file on disk; see upload-manager.ts).
@@ -14,12 +15,10 @@ import type { SQLiteDatabase } from "expo-sqlite"
 
 const UPLOADS_DB_NAME = "buildinlime-uploads.sqlite"
 
-export type UploadStatus =
-  | "awaiting_schedule"
-  | "scheduled"
-  | "uploading"
-  | "awaiting_network"
-  | "error"
+// The status vocabulary is shared with web — see @buildinlime/sync-core's
+// upload-policy. Re-exported here so this module stays the one import site for
+// everything the pending_attachments table deals in.
+export type { UploadStatus }
 
 export interface PendingAttachmentRow {
   resource_id: string

--- a/mobile-app/src/infrastructure/offline/upload-manager.ts
+++ b/mobile-app/src/infrastructure/offline/upload-manager.ts
@@ -1,5 +1,12 @@
 import * as FileSystem from "expo-file-system/legacy"
 import * as Crypto from "expo-crypto"
+import {
+  nextRetryDelay,
+  shouldAutoRetry,
+  statusForFailure,
+  isRetryableStatus,
+  scheduleDecision,
+} from "@buildinlime/sync-core"
 import { createCookieFetch } from "../auth/cookie-fetch"
 import { getOnlineDetector } from "./online-detector"
 import {
@@ -36,9 +43,8 @@ const UPLOAD_ENDPOINT = `${API_URL}/api/resources/upload`
 // bytes after an app restart.
 const UPLOAD_DIR = `${FileSystem.documentDirectory}pending-uploads/`
 
-const MAX_AUTO_RETRIES = 5
-const MAX_BACKOFF_MS = 30_000
-
+// Retry/backoff numbers and the status vocabulary are shared with web — see
+// @buildinlime/sync-core's upload-policy.
 export type { UploadStatus }
 
 export interface PendingUpload {
@@ -198,11 +204,7 @@ export async function initUploadManager(): Promise<void> {
   for (const upload of uploads.values()) {
     // `uploading` — interrupted mid-flight by an app kill: resume it.
     // `error` / `awaiting_network` — a previous attempt failed: retry it.
-    if (
-      upload.status === "uploading" ||
-      upload.status === "error" ||
-      upload.status === "awaiting_network"
-    ) {
+    if (upload.status === "uploading" || isRetryableStatus(upload.status)) {
       void doUpload(upload.id)
     } else if (upload.status === "scheduled" && upload.scheduledAt) {
       armScheduleTimer(upload.id, upload.scheduledAt)
@@ -217,7 +219,7 @@ export async function initUploadManager(): Promise<void> {
   onlineUnsub = detector.subscribe(() => {
     if (!detector.isOnline()) return
     for (const upload of uploads.values()) {
-      if (upload.status === "error" || upload.status === "awaiting_network") {
+      if (isRetryableStatus(upload.status)) {
         retryUpload(upload.id)
       }
     }
@@ -386,7 +388,7 @@ async function doUpload(id: string): Promise<void> {
     // Offline isn't really a failure — surface a calmer "awaiting network"
     // state instead of a red error for something we will auto-retry.
     const online = getOnlineDetector().isOnline()
-    const nextStatus: UploadStatus = online ? "error" : "awaiting_network"
+    const nextStatus = statusForFailure(online)
     setStatus(id, nextStatus, message)
     await updateStatus(id, nextStatus, message).catch(() => {})
 
@@ -395,8 +397,8 @@ async function doUpload(id: string): Promise<void> {
     // transient FK races where the parent message hasn't replayed yet).
     const attempt = (retryAttempts.get(id) ?? 0) + 1
     retryAttempts.set(id, attempt)
-    if (attempt <= MAX_AUTO_RETRIES && online) {
-      const delay = Math.min(MAX_BACKOFF_MS, 1000 * 2 ** (attempt - 1))
+    if (shouldAutoRetry(attempt, online)) {
+      const delay = nextRetryDelay(attempt)
       const timer = setTimeout(() => {
         retryTimers.delete(id)
         void doUpload(id)
@@ -415,15 +417,15 @@ async function doUpload(id: string): Promise<void> {
 function armScheduleTimer(id: string, when: Date): void {
   const existing = scheduleTimers.get(id)
   if (existing) clearTimeout(existing)
-  const delay = when.getTime() - Date.now()
-  if (delay <= 0) {
+  const decision = scheduleDecision(when)
+  if (decision.kind === "now") {
     void doUpload(id)
     return
   }
   const timer = setTimeout(() => {
     scheduleTimers.delete(id)
     void doUpload(id)
-  }, delay)
+  }, decision.delayMs)
   scheduleTimers.set(id, timer)
 }
 
@@ -439,7 +441,9 @@ export async function scheduleUpload(
     clearTimeout(existing)
     scheduleTimers.delete(id)
   }
-  if (!when || when.getTime() <= Date.now()) {
+  // The `!when` arm is redundant with scheduleDecision(null), but it is what
+  // narrows `when` to a Date for the assignments below.
+  if (!when || scheduleDecision(when).kind === "now") {
     void doUpload(id)
     return
   }

--- a/mobile-app/src/presentation/build-units/components/BuildUnitCard.tsx
+++ b/mobile-app/src/presentation/build-units/components/BuildUnitCard.tsx
@@ -1,5 +1,8 @@
 import { TouchableOpacity, View, Text, StyleSheet } from "react-native"
-import { Boxes } from "lucide-react-native"
+// Package (a single box), NOT Boxes (a stack) — matching web, which uses Package
+// for build units everywhere (BuildUnitCard, BuildUnitsNav, BuildUnitsTable,
+// BuildUnitsTeamNav, BuildUnitPage) and reserves Boxes for PROJECTS.
+import { Package } from "lucide-react-native"
 import { colors } from "@/src/presentation/shared/colors"
 import { PropertyPill } from "@/src/presentation/properties/components/PropertyPill"
 import type { BuildUnit, Property } from "@buildinlime/domain-types"
@@ -20,7 +23,7 @@ export function BuildUnitCard({ buildUnit, properties, onPress }: BuildUnitCardP
     <TouchableOpacity style={styles.card} onPress={onPress} activeOpacity={0.75}>
       <View style={styles.header}>
         <View style={styles.iconChip}>
-          <Boxes size={20} color={colors.primary} strokeWidth={2} />
+          <Package size={20} color={colors.primary} strokeWidth={2} />
         </View>
         <View style={styles.headerText}>
           <Text style={styles.name} numberOfLines={1}>

--- a/mobile-app/src/presentation/messages/components/MentionRow.tsx
+++ b/mobile-app/src/presentation/messages/components/MentionRow.tsx
@@ -1,0 +1,130 @@
+import { View, Text, TouchableOpacity, StyleSheet } from "react-native"
+import { Breadcrumb } from "@/src/presentation/shared/components/Breadcrumb"
+import { formatDateTime } from "@/src/presentation/shared/lib/datetime"
+import { useLookups } from "@/src/presentation/shared/hooks/useLookups"
+import { colors } from "@/src/presentation/shared/colors"
+import type { Message } from "@buildinlime/domain-types"
+
+interface MentionRowProps {
+  message: Message
+  /** Passed in rather than called here: one hook for the list, not one per row. */
+  lookups: ReturnType<typeof useLookups>
+  unread: boolean
+  onPress: () => void
+}
+
+/** One @mention in the Inbox: who said it, what they said, and where. */
+export function MentionRow({ message, lookups, unread, onPress }: MentionRowProps) {
+  const { getUserName, getChannel, getBuildUnit, getProject } = lookups
+
+  const senderName = getUserName(message.createdby_id)
+  const initial = (senderName[0] ?? "?").toUpperCase()
+  const channel = getChannel(message.channel_id)
+  const buildUnit = getBuildUnit(message.buildunit_id)
+  const project = getProject(message.project_id)
+
+  return (
+    <TouchableOpacity
+      style={[styles.row, unread && styles.rowUnread]}
+      onPress={onPress}
+      activeOpacity={0.75}
+    >
+      <View style={styles.avatar}>
+        <Text style={styles.avatarText}>{initial}</Text>
+      </View>
+      <View style={styles.rowBody}>
+        <View style={styles.rowHeader}>
+          {/* Marks unread ONLY — a dot on every row signals nothing. Read rows
+              stay in the list, de-emphasised: the Inbox is a record of what
+              needed you, not a queue to drain. */}
+          {unread ? <View style={styles.unreadDot} /> : null}
+          <Text style={[styles.sender, unread && styles.senderUnread]} numberOfLines={1}>
+            {senderName}
+          </Text>
+          <Text style={styles.timestamp}>{formatDateTime(message.created_at)}</Text>
+        </View>
+        <Text style={[styles.messageText, !unread && styles.messageTextRead]} numberOfLines={3}>
+          {message.text}
+        </Text>
+        <Breadcrumb
+          projectName={project?.name}
+          buildUnitName={buildUnit?.name}
+          channelName={channel?.name}
+        />
+      </View>
+    </TouchableOpacity>
+  )
+}
+
+const styles = StyleSheet.create({
+  row: {
+    flexDirection: "row",
+    alignItems: "flex-start",
+    gap: 12,
+    paddingHorizontal: 14,
+    paddingVertical: 12,
+    backgroundColor: colors.background,
+    borderWidth: 1,
+    borderColor: colors.cardBorder,
+    borderRadius: 12,
+  },
+  rowUnread: {
+    backgroundColor: colors.cardSurface,
+    borderColor: colors.secondary,
+  },
+  avatar: {
+    width: 32,
+    height: 32,
+    borderRadius: 16,
+    backgroundColor: colors.iconChip,
+    alignItems: "center",
+    justifyContent: "center",
+    marginTop: 2,
+  },
+  avatarText: {
+    fontSize: 12,
+    fontFamily: "InstrumentSans_600SemiBold",
+    color: colors.primary,
+  },
+  rowBody: {
+    flex: 1,
+  },
+  rowHeader: {
+    flexDirection: "row",
+    alignItems: "center",
+    justifyContent: "space-between",
+    gap: 8,
+    marginBottom: 3,
+  },
+  sender: {
+    flex: 1,
+    fontSize: 13,
+    fontFamily: "InstrumentSans_500Medium",
+    color: colors.mutedForeground,
+  },
+  senderUnread: {
+    fontFamily: "InstrumentSans_600SemiBold",
+    color: colors.foreground,
+  },
+  unreadDot: {
+    width: 8,
+    height: 8,
+    borderRadius: 4,
+    backgroundColor: colors.primary,
+    flexShrink: 0,
+  },
+  timestamp: {
+    fontSize: 11,
+    fontFamily: "InstrumentSans_400Regular",
+    color: colors.mutedForeground,
+  },
+  messageTextRead: {
+    color: colors.mutedForeground,
+  },
+  messageText: {
+    fontSize: 13,
+    fontFamily: "InstrumentSans_400Regular",
+    color: colors.foreground,
+    lineHeight: 19,
+  },
+})

--- a/mobile-app/src/presentation/resources/components/ResourceRows.tsx
+++ b/mobile-app/src/presentation/resources/components/ResourceRows.tsx
@@ -1,0 +1,203 @@
+import { View, Text, TouchableOpacity, StyleSheet, Alert } from "react-native"
+import { Download, RotateCw, X, Trash2 } from "lucide-react-native"
+import { isRetryableStatus } from "@buildinlime/sync-core"
+import { deleteResourceAction } from "@/src/application/actions/resources"
+import { useResourceDownload } from "@/src/presentation/resources/hooks/useResourceDownload"
+import { ResourceThumbnail } from "@/src/presentation/resources/components/ResourceThumbnail"
+import { formatBytes } from "@/src/presentation/resources/lib/attachment-format"
+import { formatDateTime } from "@/src/presentation/shared/lib/datetime"
+import type { PendingUpload } from "@/src/infrastructure/offline/upload-manager"
+import { colors } from "@/src/presentation/shared/colors"
+import type { Resource } from "@buildinlime/domain-types"
+
+// The two row shapes in the Resources sheet — a synced file and a not-yet-uploaded
+// one. They share one StyleSheet because they are the same row with different
+// trailing actions; keeping two copies of `row`/`info`/`name`/`meta` is how they
+// would drift apart.
+
+interface ResourceRowProps {
+  resource: Resource
+  canDelete: boolean
+  /** Where the file came from — only set in channel mode, where the list mixes
+   *  message attachments, task attachments and legacy standalone uploads. */
+  source?: string
+}
+
+export function ResourceRow({ resource, canDelete, source }: ResourceRowProps) {
+  const { download, downloading } = useResourceDownload()
+
+  function confirmDelete() {
+    Alert.alert("Delete file?", `"${resource.name}" is removed for everyone.`, [
+      { text: "Cancel", style: "cancel" },
+      {
+        text: "Delete",
+        style: "destructive",
+        onPress: () => deleteResourceAction({ id: resource.id }),
+      },
+    ])
+  }
+
+  return (
+    <View style={styles.row}>
+      <ResourceThumbnail
+        fileLocation={resource.file_location}
+        mimeType={resource.mime_type}
+      />
+      <View style={styles.info}>
+        <Text style={styles.name} numberOfLines={1}>
+          {resource.name}
+        </Text>
+        <Text style={styles.meta} numberOfLines={1}>
+          {formatDateTime(resource.uploaded_at)}
+        </Text>
+        <Text style={styles.meta} numberOfLines={1}>
+          {formatBytes(resource.file_size_bytes)}
+          {resource.description ? ` · ${resource.description}` : ""}
+        </Text>
+        {source ? (
+          <Text style={styles.source} numberOfLines={1}>
+            {source}
+          </Text>
+        ) : null}
+      </View>
+      <TouchableOpacity
+        style={[styles.actionBtn, downloading && styles.actionBtnActive]}
+        onPress={() => download(resource)}
+        disabled={downloading}
+        hitSlop={{ top: 8, bottom: 8, left: 8, right: 8 }}
+        activeOpacity={0.6}
+      >
+        <Download size={14} color={colors.mutedForeground} strokeWidth={2} />
+      </TouchableOpacity>
+      {/* Uploader only. The server enforces it (FORBIDDEN otherwise) — hiding the
+          button is courtesy, not the control. */}
+      {canDelete && (
+        <TouchableOpacity
+          style={styles.actionBtn}
+          onPress={confirmDelete}
+          hitSlop={{ top: 8, bottom: 8, left: 8, right: 8 }}
+          activeOpacity={0.6}
+        >
+          <Trash2 size={14} color={colors.mutedForeground} strokeWidth={2} />
+        </TouchableOpacity>
+      )}
+    </View>
+  )
+}
+
+const STATUS_LABEL: Record<PendingUpload["status"], string> = {
+  awaiting_schedule: "Queued",
+  scheduled: "Scheduled",
+  uploading: "Uploading…",
+  awaiting_network: "Waiting for network",
+  error: "Upload failed",
+}
+
+interface PendingUploadRowProps {
+  upload: PendingUpload
+  onRetry: (id: string) => void
+  onCancel: (id: string) => void
+}
+
+export function PendingUploadRow({ upload, onRetry, onCancel }: PendingUploadRowProps) {
+  // Same two statuses the upload manager itself re-drives — see sync-core's
+  // upload-policy, so the button and the retry logic cannot disagree.
+  const retryable = isRetryableStatus(upload.status)
+
+  let label: string
+  if (upload.status === "error" && upload.errorMessage) {
+    label = upload.errorMessage
+  } else if (upload.status === "scheduled" && upload.scheduledAt) {
+    label = `Scheduled · ${upload.scheduledAt.toLocaleString()}`
+  } else {
+    label = STATUS_LABEL[upload.status]
+  }
+
+  return (
+    <View style={[styles.row, styles.pendingRow]}>
+      {/* Not uploaded yet — preview straight off the device. */}
+      <ResourceThumbnail localUri={upload.uri} mimeType={upload.mimeType} />
+      <View style={styles.info}>
+        <Text style={styles.name} numberOfLines={1}>
+          {upload.name}
+        </Text>
+        <Text
+          style={[styles.meta, upload.status === "error" && styles.errorMeta]}
+          numberOfLines={1}
+        >
+          {label}
+        </Text>
+      </View>
+      {retryable && (
+        <TouchableOpacity
+          style={styles.actionBtn}
+          onPress={() => onRetry(upload.id)}
+          hitSlop={{ top: 8, bottom: 8, left: 8, right: 8 }}
+          activeOpacity={0.6}
+        >
+          <RotateCw size={14} color={colors.mutedForeground} strokeWidth={2} />
+        </TouchableOpacity>
+      )}
+      <TouchableOpacity
+        style={styles.actionBtn}
+        onPress={() => onCancel(upload.id)}
+        hitSlop={{ top: 8, bottom: 8, left: 8, right: 8 }}
+        activeOpacity={0.6}
+      >
+        <X size={14} color={colors.mutedForeground} strokeWidth={2} />
+      </TouchableOpacity>
+    </View>
+  )
+}
+
+const styles = StyleSheet.create({
+  row: {
+    flexDirection: "row",
+    alignItems: "center",
+    gap: 10,
+    backgroundColor: colors.cardSurface,
+    borderWidth: 1,
+    borderColor: colors.cardBorder,
+    borderRadius: 10,
+    paddingHorizontal: 10,
+    paddingVertical: 8,
+  },
+  pendingRow: {
+    opacity: 0.85,
+  },
+  info: {
+    flex: 1,
+    gap: 2,
+  },
+  name: {
+    fontSize: 13,
+    fontFamily: "InstrumentSans_500Medium",
+    color: colors.foreground,
+  },
+  meta: {
+    fontSize: 11,
+    fontFamily: "InstrumentSans_400Regular",
+    color: colors.mutedForeground,
+  },
+  source: {
+    fontSize: 11,
+    fontFamily: "InstrumentSans_500Medium",
+    color: colors.primary,
+  },
+  errorMeta: {
+    color: colors.destructive,
+  },
+  actionBtn: {
+    width: 28,
+    height: 28,
+    borderRadius: 14,
+    backgroundColor: colors.background,
+    alignItems: "center",
+    justifyContent: "center",
+    borderWidth: 1,
+    borderColor: colors.cardBorder,
+  },
+  actionBtnActive: {
+    opacity: 0.5,
+  },
+})

--- a/mobile-app/src/presentation/resources/components/ResourcesSheet.tsx
+++ b/mobile-app/src/presentation/resources/components/ResourcesSheet.tsx
@@ -1,171 +1,24 @@
 import { useState } from "react"
-import {
-  View,
-  Text,
-  TouchableOpacity,
-  ScrollView,
-  Modal,
-  Pressable,
-  StyleSheet,
-  Alert,
-  useWindowDimensions,
-} from "react-native"
-import { useSafeAreaInsets } from "react-native-safe-area-context"
+import { Alert } from "react-native"
 import { useLiveQuery, eq } from "@tanstack/react-db"
 import * as DocumentPicker from "expo-document-picker"
-import { Paperclip, Plus, X, Download, RotateCw, Trash2 } from "lucide-react-native"
+import { Paperclip } from "lucide-react-native"
 import { resourcesCollection, tasksCollection } from "@/src/application/collections/communication"
-import { deleteResourceAction } from "@/src/application/actions/resources"
 import { useSession } from "@/src/infrastructure/auth/client"
 import { usePendingUploads } from "@/src/presentation/resources/hooks/usePendingUploads"
-import { useResourceDownload } from "@/src/presentation/resources/hooks/useResourceDownload"
 import { UploadScheduleModal } from "@/src/presentation/resources/components/UploadScheduleModal"
-import { ResourceThumbnail } from "@/src/presentation/resources/components/ResourceThumbnail"
-import { formatBytes } from "@/src/presentation/resources/lib/attachment-format"
-import { formatDateTime } from "@/src/presentation/shared/lib/datetime"
-import type { PendingUpload } from "@/src/infrastructure/offline/upload-manager"
-import { colors } from "@/src/presentation/shared/colors"
+import {
+  ResourceRow,
+  PendingUploadRow,
+} from "@/src/presentation/resources/components/ResourceRows"
+import {
+  BottomSheet,
+  SheetTrigger,
+  SheetActionButton,
+  SheetScroll,
+  SheetEmpty,
+} from "@/src/presentation/shared/components/BottomSheet"
 import type { Resource } from "@buildinlime/domain-types"
-
-function ResourceRow({
-  resource,
-  canDelete,
-  source,
-}: {
-  resource: Resource
-  canDelete: boolean
-  /** Where the file came from — only set in channel mode, where the list mixes
-   *  message attachments, task attachments and legacy standalone uploads. */
-  source?: string
-}) {
-  const { download, downloading } = useResourceDownload()
-
-  function confirmDelete() {
-    Alert.alert(
-      "Delete file?",
-      `"${resource.name}" is removed for everyone.`,
-      [
-        { text: "Cancel", style: "cancel" },
-        {
-          text: "Delete",
-          style: "destructive",
-          onPress: () => deleteResourceAction({ id: resource.id }),
-        },
-      ]
-    )
-  }
-
-  return (
-    <View style={styles.row}>
-      <ResourceThumbnail
-        fileLocation={resource.file_location}
-        mimeType={resource.mime_type}
-      />
-      <View style={styles.info}>
-        <Text style={styles.name} numberOfLines={1}>
-          {resource.name}
-        </Text>
-        <Text style={styles.meta} numberOfLines={1}>
-          {formatDateTime(resource.uploaded_at)}
-        </Text>
-        <Text style={styles.meta} numberOfLines={1}>
-          {formatBytes(resource.file_size_bytes)}
-          {resource.description ? ` · ${resource.description}` : ""}
-        </Text>
-        {source ? (
-          <Text style={styles.source} numberOfLines={1}>
-            {source}
-          </Text>
-        ) : null}
-      </View>
-      <TouchableOpacity
-        style={[styles.actionBtn, downloading && styles.actionBtnActive]}
-        onPress={() => download(resource)}
-        disabled={downloading}
-        hitSlop={{ top: 8, bottom: 8, left: 8, right: 8 }}
-        activeOpacity={0.6}
-      >
-        <Download size={14} color={colors.mutedForeground} strokeWidth={2} />
-      </TouchableOpacity>
-      {/* Uploader only. The server enforces it (FORBIDDEN otherwise) — hiding the
-          button is courtesy, not the control. */}
-      {canDelete && (
-        <TouchableOpacity
-          style={styles.actionBtn}
-          onPress={confirmDelete}
-          hitSlop={{ top: 8, bottom: 8, left: 8, right: 8 }}
-          activeOpacity={0.6}
-        >
-          <Trash2 size={14} color={colors.mutedForeground} strokeWidth={2} />
-        </TouchableOpacity>
-      )}
-    </View>
-  )
-}
-
-const STATUS_LABEL: Record<PendingUpload["status"], string> = {
-  awaiting_schedule: "Queued",
-  scheduled: "Scheduled",
-  uploading: "Uploading…",
-  awaiting_network: "Waiting for network",
-  error: "Upload failed",
-}
-
-function PendingUploadRow({
-  upload,
-  onRetry,
-  onCancel,
-}: {
-  upload: PendingUpload
-  onRetry: (id: string) => void
-  onCancel: (id: string) => void
-}) {
-  const retryable = upload.status === "error" || upload.status === "awaiting_network"
-  let label: string
-  if (upload.status === "error" && upload.errorMessage) {
-    label = upload.errorMessage
-  } else if (upload.status === "scheduled" && upload.scheduledAt) {
-    label = `Scheduled · ${upload.scheduledAt.toLocaleString()}`
-  } else {
-    label = STATUS_LABEL[upload.status]
-  }
-
-  return (
-    <View style={[styles.row, styles.pendingRow]}>
-      {/* Not uploaded yet — preview straight off the device. */}
-      <ResourceThumbnail localUri={upload.uri} mimeType={upload.mimeType} />
-      <View style={styles.info}>
-        <Text style={styles.name} numberOfLines={1}>
-          {upload.name}
-        </Text>
-        <Text
-          style={[styles.meta, upload.status === "error" && styles.errorMeta]}
-          numberOfLines={1}
-        >
-          {label}
-        </Text>
-      </View>
-      {retryable && (
-        <TouchableOpacity
-          style={styles.actionBtn}
-          onPress={() => onRetry(upload.id)}
-          hitSlop={{ top: 8, bottom: 8, left: 8, right: 8 }}
-          activeOpacity={0.6}
-        >
-          <RotateCw size={14} color={colors.mutedForeground} strokeWidth={2} />
-        </TouchableOpacity>
-      )}
-      <TouchableOpacity
-        style={styles.actionBtn}
-        onPress={() => onCancel(upload.id)}
-        hitSlop={{ top: 8, bottom: 8, left: 8, right: 8 }}
-        activeOpacity={0.6}
-      >
-        <X size={14} color={colors.mutedForeground} strokeWidth={2} />
-      </TouchableOpacity>
-    </View>
-  )
-}
 
 interface ResourcesSheetProps {
   channelId: string
@@ -194,8 +47,6 @@ export function ResourcesSheet({
   taskId,
 }: ResourcesSheetProps) {
   const [open, setOpen] = useState(false)
-  const insets = useSafeAreaInsets()
-  const { height } = useWindowDimensions()
   const { data: session } = useSession()
 
   const { data } = useLiveQuery(
@@ -310,98 +161,41 @@ export function ResourcesSheet({
 
   return (
     <>
-      <TouchableOpacity
-        style={styles.trigger}
-        onPress={() => setOpen(true)}
-        hitSlop={{ top: 8, bottom: 8, left: 8, right: 8 }}
-        activeOpacity={0.7}
-      >
-        {/* 20px to match the TasksSheet's ListTodo sitting next to it. */}
-        <Paperclip size={20} color={colors.primary} strokeWidth={2} />
-        {count > 0 ? (
-          <View style={styles.countBadge}>
-            {/* numberOfLines={1}: a constrained badge would otherwise WRAP "18" and
-                show only the "1", the 15px height hiding the rest. */}
-            <Text style={styles.countText} numberOfLines={1}>
-              {count > 99 ? "99+" : count}
-            </Text>
-          </View>
-        ) : null}
-      </TouchableOpacity>
+      <SheetTrigger icon={Paperclip} count={count} onPress={() => setOpen(true)} />
 
-      <Modal
+      <BottomSheet
         visible={open}
-        transparent
-        animationType="slide"
-        onRequestClose={() => setOpen(false)}
+        onClose={() => setOpen(false)}
+        title="Resources"
+        // Task mode only. A file enters a channel by being attached to a message
+        // or a task — the channel sheet is an index of those, not a third place to
+        // upload into (matching web, which has no channel-level upload either).
+        // The standalone rows already in the data still list.
+        headerAction={
+          taskId ? <SheetActionButton label="Attach" onPress={handleAttach} /> : undefined
+        }
       >
-        {/* Backdrop closes the sheet */}
-        <Pressable style={styles.backdrop} onPress={() => setOpen(false)} />
-
-        <View
-          style={[
-            styles.sheet,
-            { height: height * 0.5, paddingBottom: insets.bottom },
-          ]}
-        >
-          <View style={styles.grabber} />
-
-          <View style={styles.sheetHeader}>
-            <Text style={styles.sheetTitle}>Resources</Text>
-            {/* Task mode only. A file enters a channel by being attached to a
-                message or a task — the channel sheet is an index of those, not a
-                third place to upload into (matching web, which has no channel-level
-                upload either). The standalone rows already in the data still list. */}
-            {taskId && (
-              <TouchableOpacity
-                style={styles.attachBtn}
-                onPress={handleAttach}
-                activeOpacity={0.7}
-              >
-                <Plus size={14} color={colors.primaryForeground} strokeWidth={2.5} />
-                <Text style={styles.attachText}>Attach</Text>
-              </TouchableOpacity>
-            )}
-            <TouchableOpacity
-              onPress={() => setOpen(false)}
-              hitSlop={{ top: 8, bottom: 8, left: 8, right: 8 }}
-              activeOpacity={0.6}
-            >
-              <X size={18} color={colors.mutedForeground} strokeWidth={2} />
-            </TouchableOpacity>
-          </View>
-
-          <ScrollView
-            style={styles.scroll}
-            contentContainerStyle={styles.scrollContent}
-            showsVerticalScrollIndicator
-          >
-            {pendingUploads.map((u) => (
-              <PendingUploadRow
-                key={u.id}
-                upload={u}
-                onRetry={retry}
-                onCancel={cancel}
-              />
-            ))}
-            {resources.map((r) => (
-              <ResourceRow
-                key={r.id}
-                resource={r}
-                canDelete={canDelete(r)}
-                source={sourceLabel(r)}
-              />
-            ))}
-            {count === 0 && (
-              <Text style={styles.empty}>
-                {taskId
-                  ? `No resources yet. Tap Attach to add one.`
-                  : `No files in this channel yet. Attach one to a message or a task.`}
-              </Text>
-            )}
-          </ScrollView>
-        </View>
-      </Modal>
+        <SheetScroll>
+          {pendingUploads.map((u) => (
+            <PendingUploadRow key={u.id} upload={u} onRetry={retry} onCancel={cancel} />
+          ))}
+          {resources.map((r) => (
+            <ResourceRow
+              key={r.id}
+              resource={r}
+              canDelete={canDelete(r)}
+              source={sourceLabel(r)}
+            />
+          ))}
+          {count === 0 && (
+            <SheetEmpty>
+              {taskId
+                ? `No resources yet. Tap Attach to add one.`
+                : `No files in this channel yet. Attach one to a message or a task.`}
+            </SheetEmpty>
+          )}
+        </SheetScroll>
+      </BottomSheet>
 
       {scheduleTarget && (
         <UploadScheduleModal
@@ -430,147 +224,3 @@ export function ResourcesSheet({
     </>
   )
 }
-
-const styles = StyleSheet.create({
-  // The badge sits INSIDE the trigger's box. It used to be pinned outside it
-  // (top: -2, right: -4); Android clips a child that overflows its parent, so once
-  // the count went two-digit the badge grew wider, ran past the edge and lost its
-  // right half — "18" rendered as "1". Single-digit counts fit, which is why it
-  // only surfaced when the sheet started counting the whole channel instead of
-  // standalone uploads alone. The padding here is what reserves that room, so the
-  // badge has somewhere to grow (up to "99+") without leaving the bounds.
-  trigger: {
-    paddingTop: 9,
-    paddingRight: 12,
-    paddingBottom: 6,
-    paddingLeft: 6,
-  },
-  countBadge: {
-    position: "absolute",
-    top: 0,
-    right: 0,
-    minWidth: 17,
-    height: 17,
-    paddingHorizontal: 4,
-    borderRadius: 9,
-    backgroundColor: colors.primary,
-    alignItems: "center",
-    justifyContent: "center",
-  },
-  countText: {
-    fontSize: 10,
-    lineHeight: 13,
-    fontFamily: "InstrumentSans_600SemiBold",
-    color: colors.primaryForeground,
-  },
-  backdrop: {
-    flex: 1,
-    backgroundColor: colors.scrim,
-  },
-  sheet: {
-    backgroundColor: colors.background,
-    borderTopLeftRadius: 20,
-    borderTopRightRadius: 20,
-    paddingHorizontal: 16,
-  },
-  grabber: {
-    alignSelf: "center",
-    width: 36,
-    height: 4,
-    borderRadius: 2,
-    backgroundColor: colors.cardBorder,
-    marginTop: 8,
-    marginBottom: 8,
-  },
-  sheetHeader: {
-    flexDirection: "row",
-    alignItems: "center",
-    gap: 10,
-    paddingBottom: 10,
-    borderBottomWidth: 1,
-    borderBottomColor: colors.cardBorder,
-  },
-  sheetTitle: {
-    flex: 1,
-    fontSize: 16,
-    fontFamily: "InstrumentSans_600SemiBold",
-    color: colors.foreground,
-  },
-  attachBtn: {
-    flexDirection: "row",
-    alignItems: "center",
-    gap: 4,
-    backgroundColor: colors.primary,
-    paddingHorizontal: 10,
-    paddingVertical: 6,
-    borderRadius: 8,
-  },
-  attachText: {
-    fontSize: 12,
-    fontFamily: "InstrumentSans_600SemiBold",
-    color: colors.primaryForeground,
-  },
-  scroll: {
-    flex: 1,
-  },
-  scrollContent: {
-    paddingVertical: 10,
-    gap: 8,
-  },
-  empty: {
-    fontSize: 13,
-    fontFamily: "InstrumentSans_400Regular",
-    color: colors.mutedForeground,
-    textAlign: "center",
-    paddingVertical: 24,
-  },
-  row: {
-    flexDirection: "row",
-    alignItems: "center",
-    gap: 10,
-    backgroundColor: colors.cardSurface,
-    borderWidth: 1,
-    borderColor: colors.cardBorder,
-    borderRadius: 10,
-    paddingHorizontal: 10,
-    paddingVertical: 8,
-  },
-  pendingRow: {
-    opacity: 0.85,
-  },
-  info: {
-    flex: 1,
-    gap: 2,
-  },
-  name: {
-    fontSize: 13,
-    fontFamily: "InstrumentSans_500Medium",
-    color: colors.foreground,
-  },
-  meta: {
-    fontSize: 11,
-    fontFamily: "InstrumentSans_400Regular",
-    color: colors.mutedForeground,
-  },
-  source: {
-    fontSize: 11,
-    fontFamily: "InstrumentSans_500Medium",
-    color: colors.primary,
-  },
-  errorMeta: {
-    color: colors.destructive,
-  },
-  actionBtn: {
-    width: 28,
-    height: 28,
-    borderRadius: 14,
-    backgroundColor: colors.background,
-    alignItems: "center",
-    justifyContent: "center",
-    borderWidth: 1,
-    borderColor: colors.cardBorder,
-  },
-  actionBtnActive: {
-    opacity: 0.5,
-  },
-})

--- a/mobile-app/src/presentation/shared/components/BackHeader.tsx
+++ b/mobile-app/src/presentation/shared/components/BackHeader.tsx
@@ -4,28 +4,27 @@ import { useSafeAreaInsets } from "react-native-safe-area-context"
 import { Trash2 } from "lucide-react-native"
 import { colors } from "@/src/presentation/shared/colors"
 
-interface TaskScreenHeaderProps {
+interface BackHeaderProps {
   title: string
   onBack: () => void
-  /** Rendered to the left of the delete button — the task's attachments sheet. */
+  /** Trailing content before the delete button — sheet triggers, for instance. */
   actions?: ReactNode
-  /** Omitted when the viewer may not delete, which hides the button entirely. */
+  /**
+   * Omitted when the viewer may not delete, which hides the button entirely.
+   * Screens with no delete affordance simply never pass it.
+   */
   onDelete?: () => void
 }
 
 /**
- * The task screen's top bar: back arrow, task name, then the action slot and
- * delete.
+ * The top bar for a PUSHED route: back arrow, title, then actions and delete.
  *
- * Not shared/ScreenHeader — that one opens the drawer from a hamburger, and this
- * screen is a pushed route that needs a back arrow.
+ * Not shared/ScreenHeader — that one opens the drawer from a hamburger and is
+ * for the tab-level screens. This is for anything you navigated INTO and back
+ * out of: the channel and the task screen, which had the same four styles
+ * character-for-character.
  */
-export function TaskScreenHeader({
-  title,
-  onBack,
-  actions,
-  onDelete,
-}: TaskScreenHeaderProps) {
+export function BackHeader({ title, onBack, actions, onDelete }: BackHeaderProps) {
   const insets = useSafeAreaInsets()
 
   return (

--- a/mobile-app/src/presentation/shared/components/BottomSheet.tsx
+++ b/mobile-app/src/presentation/shared/components/BottomSheet.tsx
@@ -56,18 +56,19 @@ export function SheetTrigger({ icon: Icon, count, onPress }: SheetTriggerProps) 
       hitSlop={{ top: 8, bottom: 8, left: 8, right: 8 }}
       activeOpacity={0.7}
     >
-      {/* 20px so the two triggers sitting next to each other match. */}
-      <Icon size={20} color={colors.primary} strokeWidth={2} />
-      {count > 0 ? (
-        <View style={styles.countBadge}>
-          {/* numberOfLines={1}: a constrained badge would otherwise WRAP a
-              two-digit count and show only the first digit, the 17px height
-              hiding the rest. */}
-          <Text style={styles.countText} numberOfLines={1}>
-            {count > 99 ? "99+" : count}
-          </Text>
-        </View>
-      ) : null}
+      {/* The icon and badge share an explicitly-sized box — see styles.iconBox
+          for why the badge cannot simply be absolute inside the padded button. */}
+      <View style={styles.iconBox}>
+        {/* 20px so the two triggers sitting next to each other match. */}
+        <Icon size={20} color={colors.primary} strokeWidth={2} />
+        {count > 0 ? (
+          <View style={styles.countBadge}>
+            <Text style={styles.countText} numberOfLines={1}>
+              {count > 99 ? "99+" : count}
+            </Text>
+          </View>
+        ) : null}
+      </View>
     </TouchableOpacity>
   )
 }
@@ -205,26 +206,39 @@ export function SheetEmpty({ children }: { children: ReactNode }) {
 }
 
 const styles = StyleSheet.create({
-  // The badge sits INSIDE the trigger's box. It used to be pinned outside it
-  // (top: -2, right: -4); Android clips a child that overflows its parent, so once
-  // the count went two-digit the badge grew wider, ran past the edge and lost its
-  // right half — "18" rendered as "1". The padding here is what reserves that
-  // room, so the badge has somewhere to grow (up to "99+") without leaving the
-  // bounds. The resources badge hit this first; a channel with 10+ tasks would
-  // have hit it on the tasks trigger too.
   trigger: {
-    paddingTop: 9,
-    paddingRight: 12,
-    paddingBottom: 6,
-    paddingLeft: 6,
+    paddingVertical: 6,
+    paddingHorizontal: 4,
   },
+  // The box the badge is positioned against, sized EXPLICITLY — this is the fix
+  // for the two-digit count that kept rendering as "1".
+  //
+  // Yoga measures an absolutely-positioned child against its parent's CONTENT
+  // box. With the badge absolute inside the button itself, that box was just the
+  // icon — 20px — so a one-digit badge (17px minWidth) fitted and a two-digit one
+  // needed ~21px, got clamped to 20, and the text was squeezed out. It was never
+  // wrapping, which is why numberOfLines={1} did not help; and the earlier
+  // attempt to "reserve room" with paddingRight made the content box NARROWER,
+  // not wider.
+  //
+  // 30px is sized for the widest badge ("99+", ~27px). The icon sits at the
+  // bottom-left and the badge overlaps its top-right corner, as before.
+  iconBox: {
+    width: 30,
+    height: 26,
+    justifyContent: "flex-end",
+    alignItems: "flex-start",
+  },
+  // No fixed height, and no lineHeight override — matching DrawerContent's
+  // UnreadBadge, which renders two- and three-digit counts correctly because it
+  // lets its content size it.
   countBadge: {
     position: "absolute",
     top: 0,
     right: 0,
-    minWidth: 17,
-    height: 17,
-    paddingHorizontal: 4,
+    minWidth: 18,
+    paddingHorizontal: 5,
+    paddingVertical: 1,
     borderRadius: 9,
     backgroundColor: colors.primary,
     alignItems: "center",
@@ -232,7 +246,6 @@ const styles = StyleSheet.create({
   },
   countText: {
     fontSize: 10,
-    lineHeight: 13,
     fontFamily: "InstrumentSans_600SemiBold",
     color: colors.primaryForeground,
   },

--- a/mobile-app/src/presentation/shared/components/BottomSheet.tsx
+++ b/mobile-app/src/presentation/shared/components/BottomSheet.tsx
@@ -1,0 +1,306 @@
+import { useEffect, useState } from "react"
+import {
+  View,
+  Text,
+  TouchableOpacity,
+  ScrollView,
+  Modal,
+  Pressable,
+  StyleSheet,
+  Keyboard,
+  KeyboardAvoidingView,
+  useWindowDimensions,
+} from "react-native"
+import type { ReactNode } from "react"
+import { useSafeAreaInsets } from "react-native-safe-area-context"
+import { Plus, X } from "lucide-react-native"
+import type { LucideIcon } from "lucide-react-native"
+import { colors } from "@/src/presentation/shared/colors"
+
+// The half-screen bottom sheet behind the channel header buttons, shared by the
+// Resources and Tasks sheets. Both had the trigger, badge, backdrop, grabber,
+// header and scroll styles character-for-character the same.
+//
+// The sheet is CONTROLLED — the caller owns `visible`. TasksSheet closes itself
+// before navigating to a task, so the open state has to be reachable from
+// outside; managing it in here would need a render prop to give it back.
+
+/** Tracks the keyboard only when the sheet asks for it — see BottomSheet. */
+function useKeyboardUp(enabled: boolean) {
+  const [up, setUp] = useState(false)
+  useEffect(() => {
+    if (!enabled) return
+    const show = Keyboard.addListener("keyboardDidShow", () => setUp(true))
+    const hide = Keyboard.addListener("keyboardDidHide", () => setUp(false))
+    return () => {
+      show.remove()
+      hide.remove()
+    }
+  }, [enabled])
+  return enabled && up
+}
+
+interface SheetTriggerProps {
+  icon: LucideIcon
+  /** Rendered as a badge; hidden at 0, capped at "99+". */
+  count: number
+  onPress: () => void
+}
+
+/** The header button that opens a sheet, with its count badge. */
+export function SheetTrigger({ icon: Icon, count, onPress }: SheetTriggerProps) {
+  return (
+    <TouchableOpacity
+      style={styles.trigger}
+      onPress={onPress}
+      hitSlop={{ top: 8, bottom: 8, left: 8, right: 8 }}
+      activeOpacity={0.7}
+    >
+      {/* 20px so the two triggers sitting next to each other match. */}
+      <Icon size={20} color={colors.primary} strokeWidth={2} />
+      {count > 0 ? (
+        <View style={styles.countBadge}>
+          {/* numberOfLines={1}: a constrained badge would otherwise WRAP a
+              two-digit count and show only the first digit, the 17px height
+              hiding the rest. */}
+          <Text style={styles.countText} numberOfLines={1}>
+            {count > 99 ? "99+" : count}
+          </Text>
+        </View>
+      ) : null}
+    </TouchableOpacity>
+  )
+}
+
+interface BottomSheetProps {
+  visible: boolean
+  onClose: () => void
+  title: string
+  /** Rendered between the title and the close button — usually a SheetActionButton. */
+  headerAction?: ReactNode
+  /**
+   * Wrap in a KeyboardAvoidingView and drop the nav-bar inset while the keyboard
+   * is up. Only for sheets containing a text input: the sheet is pinned to the
+   * bottom half of the screen, exactly where the keyboard opens, so an input
+   * would be covered without this. Sheets with no input opt out so their tree
+   * stays as it was.
+   */
+  keyboardAware?: boolean
+  children: ReactNode
+}
+
+export function BottomSheet({
+  visible,
+  onClose,
+  title,
+  headerAction,
+  keyboardAware = false,
+  children,
+}: BottomSheetProps) {
+  const insets = useSafeAreaInsets()
+  const { height } = useWindowDimensions()
+  const keyboardUp = useKeyboardUp(keyboardAware)
+
+  const body = (
+    <>
+      {/* Backdrop closes the sheet */}
+      <Pressable style={styles.backdrop} onPress={onClose} />
+
+      <View
+        style={[
+          styles.sheet,
+          // The height is fixed at half the screen, but a keyboard taller than
+          // that would leave no room for it — shrink instead of running off the
+          // bottom. Only matters when the keyboard can appear.
+          keyboardAware && styles.sheetShrink,
+          {
+            height: height * 0.5,
+            // The nav-bar inset must NOT be applied while the keyboard is up: the
+            // KeyboardAvoidingView already lifts the sheet clear, and the nav bar
+            // is behind the keyboard at that point, so adding its height pushes
+            // the sheet a nav-bar's worth too high.
+            paddingBottom: keyboardUp ? 0 : insets.bottom,
+          },
+        ]}
+      >
+        <View style={styles.grabber} />
+
+        <View style={styles.sheetHeader}>
+          <Text style={styles.sheetTitle}>{title}</Text>
+          {headerAction}
+          <TouchableOpacity
+            onPress={onClose}
+            hitSlop={{ top: 8, bottom: 8, left: 8, right: 8 }}
+            activeOpacity={0.6}
+          >
+            <X size={18} color={colors.mutedForeground} strokeWidth={2} />
+          </TouchableOpacity>
+        </View>
+
+        {children}
+      </View>
+    </>
+  )
+
+  return (
+    <Modal visible={visible} transparent animationType="slide" onRequestClose={onClose}>
+      {keyboardAware ? (
+        // "padding" on both platforms, NOT "height": under edge-to-edge the window
+        // does not resize for the keyboard, and "height" lifts by shrinking and
+        // does not fully unwind on dismiss. Same choice as the channel screen.
+        <KeyboardAvoidingView
+          style={styles.modalBody}
+          behavior="padding"
+          keyboardVerticalOffset={0}
+        >
+          {body}
+        </KeyboardAvoidingView>
+      ) : (
+        body
+      )}
+    </Modal>
+  )
+}
+
+/** The primary action in a sheet header — "Attach", "Add". */
+export function SheetActionButton({
+  label,
+  onPress,
+}: {
+  label: string
+  onPress: () => void
+}) {
+  return (
+    <TouchableOpacity style={styles.actionButton} onPress={onPress} activeOpacity={0.7}>
+      <Plus size={14} color={colors.primaryForeground} strokeWidth={2.5} />
+      <Text style={styles.actionButtonText}>{label}</Text>
+    </TouchableOpacity>
+  )
+}
+
+/** The scrolling body of a sheet. */
+export function SheetScroll({
+  children,
+  persistTaps = false,
+}: {
+  children: ReactNode
+  /** Keep taps working while the keyboard is up — sheets with an input want this. */
+  persistTaps?: boolean
+}) {
+  return (
+    <ScrollView
+      style={styles.scroll}
+      contentContainerStyle={styles.scrollContent}
+      showsVerticalScrollIndicator
+      keyboardShouldPersistTaps={persistTaps ? "handled" : "never"}
+    >
+      {children}
+    </ScrollView>
+  )
+}
+
+/** The centred "nothing here yet" line inside a SheetScroll. */
+export function SheetEmpty({ children }: { children: ReactNode }) {
+  return <Text style={styles.empty}>{children}</Text>
+}
+
+const styles = StyleSheet.create({
+  // The badge sits INSIDE the trigger's box. It used to be pinned outside it
+  // (top: -2, right: -4); Android clips a child that overflows its parent, so once
+  // the count went two-digit the badge grew wider, ran past the edge and lost its
+  // right half — "18" rendered as "1". The padding here is what reserves that
+  // room, so the badge has somewhere to grow (up to "99+") without leaving the
+  // bounds. The resources badge hit this first; a channel with 10+ tasks would
+  // have hit it on the tasks trigger too.
+  trigger: {
+    paddingTop: 9,
+    paddingRight: 12,
+    paddingBottom: 6,
+    paddingLeft: 6,
+  },
+  countBadge: {
+    position: "absolute",
+    top: 0,
+    right: 0,
+    minWidth: 17,
+    height: 17,
+    paddingHorizontal: 4,
+    borderRadius: 9,
+    backgroundColor: colors.primary,
+    alignItems: "center",
+    justifyContent: "center",
+  },
+  countText: {
+    fontSize: 10,
+    lineHeight: 13,
+    fontFamily: "InstrumentSans_600SemiBold",
+    color: colors.primaryForeground,
+  },
+  modalBody: {
+    flex: 1,
+  },
+  backdrop: {
+    flex: 1,
+    backgroundColor: colors.scrim,
+  },
+  sheet: {
+    backgroundColor: colors.background,
+    borderTopLeftRadius: 20,
+    borderTopRightRadius: 20,
+    paddingHorizontal: 16,
+  },
+  sheetShrink: {
+    flexShrink: 1,
+  },
+  grabber: {
+    alignSelf: "center",
+    width: 36,
+    height: 4,
+    borderRadius: 2,
+    backgroundColor: colors.cardBorder,
+    marginTop: 8,
+    marginBottom: 8,
+  },
+  sheetHeader: {
+    flexDirection: "row",
+    alignItems: "center",
+    gap: 10,
+    paddingBottom: 10,
+    borderBottomWidth: 1,
+    borderBottomColor: colors.cardBorder,
+  },
+  sheetTitle: {
+    flex: 1,
+    fontSize: 16,
+    fontFamily: "InstrumentSans_600SemiBold",
+    color: colors.foreground,
+  },
+  actionButton: {
+    flexDirection: "row",
+    alignItems: "center",
+    gap: 4,
+    backgroundColor: colors.primary,
+    paddingHorizontal: 10,
+    paddingVertical: 6,
+    borderRadius: 8,
+  },
+  actionButtonText: {
+    fontSize: 12,
+    fontFamily: "InstrumentSans_600SemiBold",
+    color: colors.primaryForeground,
+  },
+  scroll: {
+    flex: 1,
+  },
+  scrollContent: {
+    paddingVertical: 10,
+    gap: 8,
+  },
+  empty: {
+    fontSize: 13,
+    fontFamily: "InstrumentSans_400Regular",
+    color: colors.mutedForeground,
+    textAlign: "center",
+    paddingVertical: 24,
+  },
+})

--- a/mobile-app/src/presentation/shared/components/CardList.tsx
+++ b/mobile-app/src/presentation/shared/components/CardList.tsx
@@ -1,0 +1,45 @@
+import { View, FlatList, StyleSheet } from "react-native"
+import type { ReactElement } from "react"
+import { useSafeAreaInsets } from "react-native-safe-area-context"
+
+interface CardListProps<T> {
+  data: T[]
+  keyExtractor: (item: T) => string
+  renderItem: (item: T) => ReactElement
+}
+
+/**
+ * The card list shared by the Inbox and My Tasks screens: 16px padding, 8px
+ * between cards, and a bottom pad that clears the home indicator.
+ *
+ * The safe-area inset lives here rather than at each call site because forgetting
+ * it puts the last card under the system gesture bar — the kind of thing that is
+ * invisible on a simulator and obvious on a device.
+ *
+ * Scoped to these two screens: the other list screens use a 12px gap and their
+ * own padding — see ScreenStates for the same note.
+ */
+export function CardList<T>({ data, keyExtractor, renderItem }: CardListProps<T>) {
+  const insets = useSafeAreaInsets()
+
+  return (
+    <FlatList
+      data={data}
+      keyExtractor={keyExtractor}
+      contentContainerStyle={[styles.listContent, { paddingBottom: insets.bottom + 24 }]}
+      ItemSeparatorComponent={() => <View style={styles.gap} />}
+      renderItem={({ item }) => renderItem(item)}
+      showsVerticalScrollIndicator={false}
+    />
+  )
+}
+
+const styles = StyleSheet.create({
+  listContent: {
+    paddingHorizontal: 16,
+    paddingVertical: 16,
+  },
+  gap: {
+    height: 8,
+  },
+})

--- a/mobile-app/src/presentation/shared/components/ScreenStates.tsx
+++ b/mobile-app/src/presentation/shared/components/ScreenStates.tsx
@@ -1,0 +1,59 @@
+import { View, Text, ActivityIndicator, StyleSheet } from "react-native"
+import type { LucideIcon } from "lucide-react-native"
+import { colors } from "@/src/presentation/shared/colors"
+
+/**
+ * The centred loading / empty states shared by the Inbox and My Tasks screens.
+ *
+ * Scoped to those two deliberately. The projects list and the build-unit index
+ * have their own visually similar states with genuinely DIFFERENT values (16px
+ * semibold empty text vs 12px regular, a 12px row gap vs 8, different `centered`
+ * padding), so folding them in here would restyle them rather than dedupe them.
+ * If those screens are ever aligned on purpose, they can adopt this then.
+ */
+export function LoadingState() {
+  return (
+    <View style={styles.centered}>
+      <ActivityIndicator size="large" color={colors.primary} />
+    </View>
+  )
+}
+
+interface EmptyStateProps {
+  /** Omitted by the "no project selected" states, which are message-only. */
+  icon?: LucideIcon
+  title?: string
+  message: string
+}
+
+export function EmptyState({ icon: Icon, title, message }: EmptyStateProps) {
+  return (
+    <View style={styles.centered}>
+      {Icon ? <Icon size={40} color={colors.cardBorder} strokeWidth={1.5} /> : null}
+      {title ? <Text style={styles.emptyTitle}>{title}</Text> : null}
+      <Text style={styles.emptyText}>{message}</Text>
+    </View>
+  )
+}
+
+const styles = StyleSheet.create({
+  centered: {
+    flex: 1,
+    alignItems: "center",
+    justifyContent: "center",
+    paddingHorizontal: 24,
+    gap: 6,
+  },
+  emptyTitle: {
+    fontSize: 14,
+    fontFamily: "InstrumentSans_600SemiBold",
+    color: colors.mutedForeground,
+    marginTop: 6,
+  },
+  emptyText: {
+    fontSize: 12,
+    fontFamily: "InstrumentSans_400Regular",
+    color: colors.mutedForeground,
+    textAlign: "center",
+  },
+})

--- a/mobile-app/src/presentation/shared/hooks/useSeen.ts
+++ b/mobile-app/src/presentation/shared/hooks/useSeen.ts
@@ -1,6 +1,6 @@
 import { useCallback, useMemo } from "react"
 import { useLiveQuery } from "@tanstack/react-db"
-import { seenStateCollection } from "@/src/application/collections/admin"
+import { seenStateCollection } from "@/src/application/collections/communication"
 import { markSeenAction } from "@/src/application/actions/seen"
 import { useSession } from "@/src/infrastructure/auth/client"
 

--- a/mobile-app/src/presentation/tasks/components/AssigneePickerModal.tsx
+++ b/mobile-app/src/presentation/tasks/components/AssigneePickerModal.tsx
@@ -1,0 +1,121 @@
+import {
+  Modal,
+  View,
+  Text,
+  TouchableOpacity,
+  ScrollView,
+  Pressable,
+  StyleSheet,
+} from "react-native"
+import { CheckCircle2, X } from "lucide-react-native"
+import { colors } from "@/src/presentation/shared/colors"
+
+interface AssigneePickerModalProps {
+  visible: boolean
+  onClose: () => void
+  /** Channel roster — who this task can be assigned to. */
+  memberIds: string[]
+  assigneeId: string | null
+  usersMap: Record<string, string>
+  /** null clears the assignee. */
+  onAssign: (userId: string | null) => void
+}
+
+/**
+ * Picks a task's assignee from the channel roster.
+ *
+ * Not shared/CenteredModal: this one dismisses on an outside tap, which that
+ * component deliberately does not do.
+ */
+export function AssigneePickerModal({
+  visible,
+  onClose,
+  memberIds,
+  assigneeId,
+  usersMap,
+  onAssign,
+}: AssigneePickerModalProps) {
+  return (
+    <Modal visible={visible} transparent animationType="fade" onRequestClose={onClose}>
+      <Pressable style={styles.backdrop} onPress={onClose} />
+      <View style={styles.sheet}>
+        <View style={styles.sheetHeader}>
+          <Text style={styles.sheetTitle}>Assign To</Text>
+          <TouchableOpacity
+            onPress={onClose}
+            hitSlop={{ top: 8, bottom: 8, left: 8, right: 8 }}
+            activeOpacity={0.6}
+          >
+            <X size={18} color={colors.mutedForeground} strokeWidth={2} />
+          </TouchableOpacity>
+        </View>
+        <ScrollView style={styles.sheetScroll}>
+          <TouchableOpacity
+            style={styles.memberRow}
+            onPress={() => onAssign(null)}
+            activeOpacity={0.7}
+          >
+            <Text style={styles.memberName}>Unassigned</Text>
+          </TouchableOpacity>
+          {memberIds.map((id) => (
+            <TouchableOpacity
+              key={id}
+              style={styles.memberRow}
+              onPress={() => onAssign(id)}
+              activeOpacity={0.7}
+            >
+              <Text style={styles.memberName}>{usersMap[id] ?? "Unknown"}</Text>
+              {assigneeId === id && (
+                <CheckCircle2 size={16} color={colors.primary} strokeWidth={2} />
+              )}
+            </TouchableOpacity>
+          ))}
+        </ScrollView>
+      </View>
+    </Modal>
+  )
+}
+
+const styles = StyleSheet.create({
+  backdrop: {
+    flex: 1,
+    backgroundColor: colors.scrim,
+  },
+  sheet: {
+    position: "absolute",
+    left: 24,
+    right: 24,
+    top: "30%",
+    maxHeight: "45%",
+    backgroundColor: colors.background,
+    borderRadius: 12,
+    padding: 16,
+  },
+  sheetHeader: {
+    flexDirection: "row",
+    alignItems: "center",
+    justifyContent: "space-between",
+    paddingBottom: 10,
+    borderBottomWidth: 1,
+    borderBottomColor: colors.cardBorder,
+  },
+  sheetTitle: {
+    fontSize: 15,
+    fontFamily: "InstrumentSans_600SemiBold",
+    color: colors.foreground,
+  },
+  sheetScroll: {
+    marginTop: 6,
+  },
+  memberRow: {
+    flexDirection: "row",
+    alignItems: "center",
+    justifyContent: "space-between",
+    paddingVertical: 10,
+  },
+  memberName: {
+    fontSize: 14,
+    fontFamily: "InstrumentSans_500Medium",
+    color: colors.foreground,
+  },
+})

--- a/mobile-app/src/presentation/tasks/components/ChannelTaskRow.tsx
+++ b/mobile-app/src/presentation/tasks/components/ChannelTaskRow.tsx
@@ -1,0 +1,114 @@
+import { View, Text, TouchableOpacity, StyleSheet } from "react-native"
+import { CheckCircle2, Circle } from "lucide-react-native"
+import { formatDateTime } from "@/src/presentation/shared/lib/datetime"
+import { colors } from "@/src/presentation/shared/colors"
+import type { Task } from "@buildinlime/domain-types"
+
+interface ChannelTaskRowProps {
+  task: Task
+  /** Arrived since you last opened this channel — see useSeen. */
+  unread: boolean
+  assigneeName?: string
+  onPress: () => void
+}
+
+/**
+ * One task in the channel's Tasks sheet.
+ *
+ * Not MyTaskRow: that one is the cross-project My Tasks list and carries a
+ * breadcrumb to locate the task. Here the channel is already the context, so the
+ * row spends its space on the unread state instead.
+ */
+export function ChannelTaskRow({
+  task,
+  unread,
+  assigneeName,
+  onPress,
+}: ChannelTaskRowProps) {
+  return (
+    <TouchableOpacity
+      style={[styles.row, unread && styles.rowUnread]}
+      onPress={onPress}
+      activeOpacity={0.75}
+    >
+      {task.completed ? (
+        <CheckCircle2 size={18} color="#166534" strokeWidth={2} />
+      ) : (
+        <Circle
+          size={18}
+          color={unread ? colors.primary : colors.mutedForeground}
+          strokeWidth={2}
+          {...(unread ? { fill: colors.primary } : {})}
+        />
+      )}
+
+      <View style={styles.rowBody}>
+        <Text
+          style={[
+            styles.taskName,
+            unread && styles.taskNameUnread,
+            task.completed && styles.taskNameCompleted,
+          ]}
+          numberOfLines={2}
+        >
+          {task.name}
+        </Text>
+        {task.description ? (
+          <Text style={styles.taskDescription} numberOfLines={2}>
+            {task.description}
+          </Text>
+        ) : null}
+        <Text style={styles.taskMeta} numberOfLines={1}>
+          {assigneeName ? `${assigneeName} · ` : "Unassigned · "}
+          {formatDateTime(task.opened_at)}
+        </Text>
+      </View>
+    </TouchableOpacity>
+  )
+}
+
+const styles = StyleSheet.create({
+  row: {
+    flexDirection: "row",
+    alignItems: "flex-start",
+    gap: 10,
+    paddingHorizontal: 10,
+    paddingVertical: 10,
+    backgroundColor: colors.background,
+    borderWidth: 1,
+    borderColor: colors.cardBorder,
+    borderRadius: 10,
+  },
+  rowUnread: {
+    backgroundColor: colors.cardSurface,
+    borderColor: colors.secondary,
+  },
+  rowBody: {
+    flex: 1,
+    gap: 2,
+  },
+  taskName: {
+    fontSize: 13,
+    fontFamily: "InstrumentSans_500Medium",
+    color: colors.foreground,
+    lineHeight: 18,
+  },
+  taskNameUnread: {
+    fontFamily: "InstrumentSans_600SemiBold",
+  },
+  taskNameCompleted: {
+    color: colors.mutedForeground,
+    textDecorationLine: "line-through",
+  },
+  taskDescription: {
+    fontSize: 12,
+    fontFamily: "InstrumentSans_400Regular",
+    color: colors.mutedForeground,
+  },
+  taskMeta: {
+    fontSize: 11,
+    fontFamily: "InstrumentSans_400Regular",
+    color: colors.mutedForeground,
+    marginTop: 2,
+  },
+})

--- a/mobile-app/src/presentation/tasks/components/MyTaskRow.tsx
+++ b/mobile-app/src/presentation/tasks/components/MyTaskRow.tsx
@@ -1,0 +1,108 @@
+import { View, Text, TouchableOpacity, StyleSheet } from "react-native"
+import { CheckSquare, Square } from "lucide-react-native"
+import { Breadcrumb } from "@/src/presentation/shared/components/Breadcrumb"
+import { formatDateTime } from "@/src/presentation/shared/lib/datetime"
+import { useLookups } from "@/src/presentation/shared/hooks/useLookups"
+import { colors } from "@/src/presentation/shared/colors"
+import type { Task } from "@buildinlime/domain-types"
+
+interface MyTaskRowProps {
+  task: Task
+  /** Passed in rather than called here: one hook for the list, not one per row. */
+  lookups: ReturnType<typeof useLookups>
+  onPress: () => void
+}
+
+/** One assigned task in the My Tasks list, with the path that locates it. */
+export function MyTaskRow({ task, lookups, onPress }: MyTaskRowProps) {
+  const { getChannel, getBuildUnit, getProject } = lookups
+
+  const channel = getChannel(task.channel_id)
+  const buildUnit = getBuildUnit(task.buildunit_id)
+  const project = getProject(buildUnit?.project_id)
+
+  return (
+    <TouchableOpacity
+      style={[styles.row, task.completed && styles.rowCompleted]}
+      onPress={onPress}
+      activeOpacity={0.75}
+    >
+      <View style={styles.checkbox}>
+        {task.completed ? (
+          <CheckSquare size={16} color={colors.primary} strokeWidth={2} />
+        ) : (
+          <Square size={16} color={colors.primary} strokeWidth={2} />
+        )}
+      </View>
+      <View style={styles.rowBody}>
+        <Text
+          style={[styles.taskName, task.completed && styles.taskNameCompleted]}
+          numberOfLines={2}
+        >
+          {task.name}
+        </Text>
+        {task.description ? (
+          <Text style={styles.taskDescription} numberOfLines={1}>
+            {task.description}
+          </Text>
+        ) : null}
+        <Text style={styles.taskDate}>
+          {task.completed
+            ? `Completed ${formatDateTime(task.closed_at)}`
+            : `Opened ${formatDateTime(task.opened_at)}`}
+        </Text>
+        <Breadcrumb
+          projectName={project?.name}
+          buildUnitName={buildUnit?.name}
+          channelName={channel?.name}
+        />
+      </View>
+    </TouchableOpacity>
+  )
+}
+
+const styles = StyleSheet.create({
+  row: {
+    flexDirection: "row",
+    alignItems: "flex-start",
+    gap: 12,
+    paddingHorizontal: 14,
+    paddingVertical: 12,
+    backgroundColor: colors.cardSurface,
+    borderWidth: 1,
+    borderColor: colors.cardBorder,
+    borderRadius: 12,
+  },
+  rowCompleted: {
+    backgroundColor: colors.background,
+    opacity: 0.6,
+  },
+  checkbox: {
+    marginTop: 2,
+  },
+  rowBody: {
+    flex: 1,
+  },
+  taskName: {
+    fontSize: 13,
+    fontFamily: "InstrumentSans_600SemiBold",
+    color: colors.foreground,
+    lineHeight: 19,
+  },
+  taskNameCompleted: {
+    color: colors.mutedForeground,
+    textDecorationLine: "line-through",
+  },
+  taskDescription: {
+    fontSize: 12,
+    fontFamily: "InstrumentSans_400Regular",
+    color: colors.mutedForeground,
+    marginTop: 2,
+  },
+  taskDate: {
+    fontSize: 11,
+    fontFamily: "InstrumentSans_400Regular",
+    color: colors.mutedForeground,
+    marginTop: 3,
+  },
+})

--- a/mobile-app/src/presentation/tasks/components/TaskDetailsFields.tsx
+++ b/mobile-app/src/presentation/tasks/components/TaskDetailsFields.tsx
@@ -1,0 +1,98 @@
+import { View, Text, TouchableOpacity, StyleSheet } from "react-native"
+import { UserPlus } from "lucide-react-native"
+import { TaskField, FieldValue, FieldHint } from "./TaskField"
+import { PropertyPill } from "@/src/presentation/properties/components/PropertyPill"
+import { formatDateTime } from "@/src/presentation/shared/lib/datetime"
+import { colors } from "@/src/presentation/shared/colors"
+import type { Property } from "@buildinlime/domain-types"
+
+interface TaskDetailsFieldsProps {
+  creatorName: string
+  /** Passed through to formatDateTime, which takes either form. */
+  openedAt: Date | string
+  assigneeName?: string
+  /**
+   * Creator-only. The server enforces it (tasks.update returns FORBIDDEN
+   * otherwise) — hiding the button is courtesy, not the control.
+   */
+  canAssign: boolean
+  onAssignPress: () => void
+  properties: Property[]
+}
+
+/** The task's read-only detail blocks: who opened it, who owns it, its properties. */
+export function TaskDetailsFields({
+  creatorName,
+  openedAt,
+  assigneeName,
+  canAssign,
+  onAssignPress,
+  properties,
+}: TaskDetailsFieldsProps) {
+  return (
+    <>
+      <TaskField label="Created By">
+        <FieldValue>
+          {creatorName} · {formatDateTime(openedAt)}
+        </FieldValue>
+      </TaskField>
+
+      <TaskField label="Assigned To">
+        <View style={styles.assignRow}>
+          <FieldValue>{assigneeName ?? "Unassigned"}</FieldValue>
+          {canAssign && (
+            <TouchableOpacity
+              style={styles.assignBtn}
+              onPress={onAssignPress}
+              hitSlop={{ top: 8, bottom: 8, left: 8, right: 8 }}
+              activeOpacity={0.7}
+            >
+              <UserPlus size={14} color={colors.primary} strokeWidth={2} />
+              <Text style={styles.assignBtnText}>Assign</Text>
+            </TouchableOpacity>
+          )}
+        </View>
+        {!canAssign && <FieldHint>Only the task's creator can assign it.</FieldHint>}
+      </TaskField>
+
+      {properties.length > 0 && (
+        <TaskField label="Properties">
+          <View style={styles.pillRow}>
+            {properties.map((p) => (
+              <PropertyPill key={p.id} property={p} />
+            ))}
+          </View>
+        </TaskField>
+      )}
+    </>
+  )
+}
+
+const styles = StyleSheet.create({
+  assignRow: {
+    flexDirection: "row",
+    alignItems: "center",
+    justifyContent: "space-between",
+    gap: 10,
+  },
+  assignBtn: {
+    flexDirection: "row",
+    alignItems: "center",
+    gap: 4,
+    paddingHorizontal: 10,
+    paddingVertical: 6,
+    borderRadius: 8,
+    borderWidth: 1,
+    borderColor: colors.primary,
+  },
+  assignBtnText: {
+    fontSize: 12,
+    fontFamily: "InstrumentSans_600SemiBold",
+    color: colors.primary,
+  },
+  pillRow: {
+    flexDirection: "row",
+    flexWrap: "wrap",
+    gap: 6,
+  },
+})

--- a/mobile-app/src/presentation/tasks/components/TaskField.tsx
+++ b/mobile-app/src/presentation/tasks/components/TaskField.tsx
@@ -1,0 +1,57 @@
+import { View, Text, StyleSheet } from "react-native"
+import type { ReactNode } from "react"
+import { colors } from "@/src/presentation/shared/colors"
+
+interface TaskFieldProps {
+  label: string
+  children: ReactNode
+}
+
+/**
+ * One labelled block on the task screen — an uppercase caption over its content.
+ *
+ * Shared by TaskDetailsFields and TaskStatusHistory: both blocks had the caption
+ * and spacing styles character-for-character the same, so keeping one copy is
+ * what stops them drifting apart.
+ */
+export function TaskField({ label, children }: TaskFieldProps) {
+  return (
+    <View style={styles.field}>
+      <Text style={styles.fieldLabel}>{label}</Text>
+      {children}
+    </View>
+  )
+}
+
+/** The primary value line inside a TaskField. */
+export function FieldValue({ children }: { children: ReactNode }) {
+  return <Text style={styles.fieldValue}>{children}</Text>
+}
+
+/** The secondary line inside a TaskField — hints and empty states. */
+export function FieldHint({ children }: { children: ReactNode }) {
+  return <Text style={styles.fieldHint}>{children}</Text>
+}
+
+const styles = StyleSheet.create({
+  field: {
+    gap: 4,
+  },
+  fieldLabel: {
+    fontSize: 11,
+    fontFamily: "InstrumentSans_500Medium",
+    color: colors.mutedForeground,
+    textTransform: "uppercase",
+    letterSpacing: 0.5,
+  },
+  fieldValue: {
+    fontSize: 14,
+    fontFamily: "InstrumentSans_500Medium",
+    color: colors.foreground,
+  },
+  fieldHint: {
+    fontSize: 11,
+    fontFamily: "InstrumentSans_400Regular",
+    color: colors.mutedForeground,
+  },
+})

--- a/mobile-app/src/presentation/tasks/components/TaskScreenHeader.tsx
+++ b/mobile-app/src/presentation/tasks/components/TaskScreenHeader.tsx
@@ -1,0 +1,91 @@
+import { View, Text, TouchableOpacity, StyleSheet } from "react-native"
+import type { ReactNode } from "react"
+import { useSafeAreaInsets } from "react-native-safe-area-context"
+import { Trash2 } from "lucide-react-native"
+import { colors } from "@/src/presentation/shared/colors"
+
+interface TaskScreenHeaderProps {
+  title: string
+  onBack: () => void
+  /** Rendered to the left of the delete button — the task's attachments sheet. */
+  actions?: ReactNode
+  /** Omitted when the viewer may not delete, which hides the button entirely. */
+  onDelete?: () => void
+}
+
+/**
+ * The task screen's top bar: back arrow, task name, then the action slot and
+ * delete.
+ *
+ * Not shared/ScreenHeader — that one opens the drawer from a hamburger, and this
+ * screen is a pushed route that needs a back arrow.
+ */
+export function TaskScreenHeader({
+  title,
+  onBack,
+  actions,
+  onDelete,
+}: TaskScreenHeaderProps) {
+  const insets = useSafeAreaInsets()
+
+  return (
+    <View style={[styles.header, { paddingTop: insets.top + 8 }]}>
+      <TouchableOpacity
+        style={styles.backButton}
+        onPress={onBack}
+        hitSlop={{ top: 10, bottom: 10, left: 10, right: 10 }}
+        activeOpacity={0.6}
+      >
+        <Text style={styles.backArrow}>‹</Text>
+      </TouchableOpacity>
+      <Text style={styles.headerTitle} numberOfLines={1}>
+        {title}
+      </Text>
+      {actions}
+      {onDelete && (
+        <TouchableOpacity
+          onPress={onDelete}
+          hitSlop={{ top: 8, bottom: 8, left: 8, right: 8 }}
+          activeOpacity={0.6}
+          style={styles.headerAction}
+        >
+          <Trash2 size={18} color={colors.mutedForeground} strokeWidth={2} />
+        </TouchableOpacity>
+      )}
+    </View>
+  )
+}
+
+const styles = StyleSheet.create({
+  header: {
+    flexDirection: "row",
+    alignItems: "center",
+    // paddingTop applied inline from useSafeAreaInsets().top (real device inset).
+    paddingBottom: 16,
+    paddingHorizontal: 16,
+    backgroundColor: colors.background,
+    borderBottomWidth: 1,
+    borderBottomColor: colors.border,
+    gap: 8,
+  },
+  backButton: {
+    padding: 4,
+    marginRight: 4,
+  },
+  backArrow: {
+    fontSize: 32,
+    color: colors.primary,
+    fontFamily: "InstrumentSans_400Regular",
+    lineHeight: 32,
+  },
+  headerTitle: {
+    flex: 1,
+    fontSize: 18,
+    fontFamily: "InstrumentSans_600SemiBold",
+    color: colors.foreground,
+    lineHeight: 22,
+  },
+  headerAction: {
+    padding: 6,
+  },
+})

--- a/mobile-app/src/presentation/tasks/components/TaskStatusControl.tsx
+++ b/mobile-app/src/presentation/tasks/components/TaskStatusControl.tsx
@@ -1,0 +1,191 @@
+import { View, Text, TextInput, TouchableOpacity, StyleSheet } from "react-native"
+import { CheckCircle2, Circle } from "lucide-react-native"
+import { colors } from "@/src/presentation/shared/colors"
+
+interface TaskStatusControlProps {
+  completed: boolean
+  /** Whether the note step is expanded. */
+  noteOpen: boolean
+  onToggleNote: () => void
+  note: string
+  onNoteChange: (text: string) => void
+  submitting: boolean
+  onCancel: () => void
+  onConfirm: () => void
+}
+
+/**
+ * The status pill and its note step — the one interactive control on the task
+ * screen.
+ *
+ * Tapping the pill does NOT flip the status: it opens the note step, and the
+ * note is what commits the change. The note is REQUIRED, so Confirm stays
+ * disabled until it is non-empty.
+ */
+export function TaskStatusControl({
+  completed,
+  noteOpen,
+  onToggleNote,
+  note,
+  onNoteChange,
+  submitting,
+  onCancel,
+  onConfirm,
+}: TaskStatusControlProps) {
+  const canSubmit = !!note.trim() && !submitting
+
+  return (
+    <>
+      <TouchableOpacity
+        style={[styles.statusBtn, completed && styles.statusBtnDone]}
+        onPress={onToggleNote}
+        activeOpacity={0.75}
+      >
+        {completed ? (
+          <CheckCircle2 size={18} color="#166534" strokeWidth={2} />
+        ) : (
+          <Circle size={18} color={colors.primary} strokeWidth={2} />
+        )}
+        <Text style={[styles.statusText, completed && styles.statusTextDone]}>
+          {completed ? "Completed" : "Open"}
+        </Text>
+        <Text style={styles.statusHint}>
+          {completed ? "Tap to reopen" : "Tap to complete"}
+        </Text>
+      </TouchableOpacity>
+
+      {noteOpen && (
+        <View style={styles.noteSection}>
+          <Text style={styles.noteTitle}>
+            {completed ? "Why are you reopening this?" : "What was done?"}
+          </Text>
+          <Text style={styles.noteHint}>
+            Required. Posted to the channel so the team sees the reason.
+          </Text>
+          <TextInput
+            style={styles.noteInput}
+            value={note}
+            onChangeText={onNoteChange}
+            placeholder={
+              completed
+                ? "e.g. Rebar spacing is off, needs redoing"
+                : "e.g. Slab poured, cured 48h"
+            }
+            placeholderTextColor={colors.mutedForeground}
+            multiline
+            numberOfLines={3}
+            maxLength={400}
+            autoFocus
+            textAlignVertical="top"
+          />
+          <View style={styles.noteActions}>
+            <TouchableOpacity onPress={onCancel} activeOpacity={0.7}>
+              <Text style={styles.noteCancel}>Cancel</Text>
+            </TouchableOpacity>
+            <TouchableOpacity
+              style={[styles.noteSubmit, !canSubmit && styles.noteSubmitDisabled]}
+              onPress={onConfirm}
+              disabled={!canSubmit}
+              activeOpacity={0.8}
+            >
+              <Text style={styles.noteSubmitText}>
+                {completed ? "Reopen Task" : "Mark Completed"}
+              </Text>
+            </TouchableOpacity>
+          </View>
+        </View>
+      )}
+    </>
+  )
+}
+
+const styles = StyleSheet.create({
+  statusBtn: {
+    flexDirection: "row",
+    alignItems: "center",
+    gap: 8,
+    paddingHorizontal: 12,
+    paddingVertical: 12,
+    borderRadius: 10,
+    borderWidth: 1,
+    borderColor: colors.cardBorder,
+    backgroundColor: colors.cardSurface,
+  },
+  statusBtnDone: {
+    backgroundColor: "#16653411",
+    borderColor: "#16653455",
+  },
+  statusText: {
+    fontSize: 14,
+    fontFamily: "InstrumentSans_600SemiBold",
+    color: colors.foreground,
+  },
+  statusTextDone: {
+    color: "#166534",
+  },
+  statusHint: {
+    flex: 1,
+    textAlign: "right",
+    fontSize: 11,
+    fontFamily: "InstrumentSans_400Regular",
+    color: colors.mutedForeground,
+  },
+  noteSection: {
+    gap: 6,
+    marginTop: 10,
+    padding: 12,
+    backgroundColor: colors.cardSurface,
+    borderWidth: 1,
+    borderColor: colors.cardBorder,
+    borderRadius: 12,
+  },
+  noteTitle: {
+    fontSize: 14,
+    fontFamily: "InstrumentSans_600SemiBold",
+    color: colors.foreground,
+  },
+  noteHint: {
+    fontSize: 11,
+    fontFamily: "InstrumentSans_400Regular",
+    color: colors.mutedForeground,
+  },
+  noteInput: {
+    minHeight: 72,
+    marginTop: 4,
+    borderWidth: 1,
+    borderColor: colors.cardBorder,
+    borderRadius: 8,
+    backgroundColor: colors.background,
+    paddingHorizontal: 10,
+    paddingVertical: 8,
+    fontSize: 13,
+    fontFamily: "InstrumentSans_400Regular",
+    color: colors.foreground,
+  },
+  noteActions: {
+    flexDirection: "row",
+    alignItems: "center",
+    justifyContent: "flex-end",
+    gap: 14,
+    marginTop: 4,
+  },
+  noteCancel: {
+    fontSize: 13,
+    fontFamily: "InstrumentSans_500Medium",
+    color: colors.mutedForeground,
+  },
+  noteSubmit: {
+    backgroundColor: colors.primary,
+    paddingHorizontal: 12,
+    paddingVertical: 8,
+    borderRadius: 8,
+  },
+  noteSubmitDisabled: {
+    opacity: 0.4,
+  },
+  noteSubmitText: {
+    fontSize: 13,
+    fontFamily: "InstrumentSans_600SemiBold",
+    color: colors.primaryForeground,
+  },
+})

--- a/mobile-app/src/presentation/tasks/components/TaskStatusHistory.tsx
+++ b/mobile-app/src/presentation/tasks/components/TaskStatusHistory.tsx
@@ -1,0 +1,62 @@
+import { View, Text, StyleSheet } from "react-native"
+import { TaskField, FieldHint } from "./TaskField"
+import { formatDateTime } from "@/src/presentation/shared/lib/datetime"
+import { colors } from "@/src/presentation/shared/colors"
+import type { Message } from "@buildinlime/domain-types"
+
+interface TaskStatusHistoryProps {
+  /** The notes posted with each status change, newest first. */
+  history: Message[]
+  usersMap: Record<string, string>
+}
+
+/**
+ * The notes posted with each status change.
+ *
+ * The message text is shown verbatim: it is the same message the channel shows,
+ * and re-parsing our own wording back apart would be a data model made of prose.
+ */
+export function TaskStatusHistory({ history, usersMap }: TaskStatusHistoryProps) {
+  return (
+    <TaskField label="Status History">
+      {history.length === 0 ? (
+        <FieldHint>
+          No status changes yet. Notes appear here when the status is changed.
+        </FieldHint>
+      ) : (
+        history.map((m) => (
+          <View key={m.id} style={styles.historyRow}>
+            <Text style={styles.historyText}>{m.text}</Text>
+            <Text style={styles.historyMeta}>
+              {usersMap[m.createdby_id] ?? "Unknown"} · {formatDateTime(m.created_at)}
+            </Text>
+          </View>
+        ))
+      )}
+    </TaskField>
+  )
+}
+
+const styles = StyleSheet.create({
+  historyRow: {
+    gap: 3,
+    marginTop: 8,
+    paddingHorizontal: 10,
+    paddingVertical: 8,
+    backgroundColor: colors.cardSurface,
+    borderWidth: 1,
+    borderColor: colors.cardBorder,
+    borderRadius: 10,
+  },
+  historyText: {
+    fontSize: 13,
+    fontFamily: "InstrumentSans_400Regular",
+    color: colors.foreground,
+    lineHeight: 18,
+  },
+  historyMeta: {
+    fontSize: 11,
+    fontFamily: "InstrumentSans_400Regular",
+    color: colors.mutedForeground,
+  },
+})

--- a/mobile-app/src/presentation/tasks/components/TasksSheet.tsx
+++ b/mobile-app/src/presentation/tasks/components/TasksSheet.tsx
@@ -1,87 +1,26 @@
-import { useEffect, useState } from "react"
+import { useState } from "react"
 import { useRouter } from "expo-router"
-import {
-  View,
-  Text,
-  TextInput,
-  TouchableOpacity,
-  ScrollView,
-  Modal,
-  Pressable,
-  StyleSheet,
-  Alert,
-  Keyboard,
-  KeyboardAvoidingView,
-  useWindowDimensions,
-} from "react-native"
-import { useSafeAreaInsets } from "react-native-safe-area-context"
-import { ListTodo, Plus, X, CheckCircle2, Circle } from "lucide-react-native"
+import { View, Text, TextInput, TouchableOpacity, StyleSheet, Alert } from "react-native"
+import { ListTodo } from "lucide-react-native"
 import { useSession } from "@/src/infrastructure/auth/client"
 import { useChannelTasks } from "@/src/presentation/tasks/hooks/useChannelTasks"
 import { useSeen } from "@/src/presentation/shared/hooks/useSeen"
 import { useLookups } from "@/src/presentation/shared/hooks/useLookups"
 import { createTaskAction } from "@/src/application/actions/tasks"
-import { formatDateTime } from "@/src/presentation/shared/lib/datetime"
+import { ChannelTaskRow } from "@/src/presentation/tasks/components/ChannelTaskRow"
+import {
+  BottomSheet,
+  SheetTrigger,
+  SheetActionButton,
+  SheetScroll,
+  SheetEmpty,
+} from "@/src/presentation/shared/components/BottomSheet"
 import { colors } from "@/src/presentation/shared/colors"
-import type { Task } from "@buildinlime/domain-types"
 
 interface TasksSheetProps {
   channelId: string
   buildUnitId: string
   projectId: string
-}
-
-function TaskRow({
-  task,
-  unread,
-  assigneeName,
-  onPress,
-}: {
-  task: Task
-  unread: boolean
-  assigneeName?: string
-  onPress: () => void
-}) {
-  return (
-    <TouchableOpacity
-      style={[styles.row, unread && styles.rowUnread]}
-      onPress={onPress}
-      activeOpacity={0.75}
-    >
-      {task.completed ? (
-        <CheckCircle2 size={18} color="#166534" strokeWidth={2} />
-      ) : (
-        <Circle
-          size={18}
-          color={unread ? colors.primary : colors.mutedForeground}
-          strokeWidth={2}
-          {...(unread ? { fill: colors.primary } : {})}
-        />
-      )}
-
-      <View style={styles.rowBody}>
-        <Text
-          style={[
-            styles.taskName,
-            unread && styles.taskNameUnread,
-            task.completed && styles.taskNameCompleted,
-          ]}
-          numberOfLines={2}
-        >
-          {task.name}
-        </Text>
-        {task.description ? (
-          <Text style={styles.taskDescription} numberOfLines={2}>
-            {task.description}
-          </Text>
-        ) : null}
-        <Text style={styles.taskMeta} numberOfLines={1}>
-          {assigneeName ? `${assigneeName} · ` : "Unassigned · "}
-          {formatDateTime(task.opened_at)}
-        </Text>
-      </View>
-    </TouchableOpacity>
-  )
 }
 
 /**
@@ -100,24 +39,7 @@ export function TasksSheet({ channelId, buildUnitId, projectId }: TasksSheetProp
   const [description, setDescription] = useState("")
   const [submitting, setSubmitting] = useState(false)
 
-  const insets = useSafeAreaInsets()
-  const { height } = useWindowDimensions()
   const { data: session } = useSession()
-
-  // Same rule as MessageInput: the nav-bar inset must not be applied while the
-  // keyboard is up. The KeyboardAvoidingView already lifts the sheet clear of the
-  // keyboard, and the nav bar is behind the keyboard at that point — adding its
-  // height on top pushes the sheet a nav-bar's worth too high.
-  const [keyboardUp, setKeyboardUp] = useState(false)
-  useEffect(() => {
-    const show = Keyboard.addListener("keyboardDidShow", () => setKeyboardUp(true))
-    const hide = Keyboard.addListener("keyboardDidHide", () => setKeyboardUp(false))
-    return () => {
-      show.remove()
-      hide.remove()
-    }
-  }, [])
-
   const { tasks } = useChannelTasks(channelId)
   const { isTaskUnseen } = useSeen()
   const { getUserName } = useLookups()
@@ -174,229 +96,89 @@ export function TasksSheet({ channelId, buildUnitId, projectId }: TasksSheetProp
 
   return (
     <>
-      <TouchableOpacity
-        style={styles.trigger}
-        onPress={() => setOpen(true)}
-        hitSlop={{ top: 8, bottom: 8, left: 8, right: 8 }}
-        activeOpacity={0.7}
-      >
-        <ListTodo size={20} color={colors.primary} strokeWidth={2} />
-        {unopenedCount > 0 ? (
-          <View style={styles.countBadge}>
-            {/* numberOfLines={1}: a constrained badge would otherwise WRAP a
-                two-digit count and show only the first digit. */}
-            <Text style={styles.countText} numberOfLines={1}>
-              {unopenedCount > 99 ? "99+" : unopenedCount}
-            </Text>
-          </View>
-        ) : null}
-      </TouchableOpacity>
+      <SheetTrigger icon={ListTodo} count={unopenedCount} onPress={() => setOpen(true)} />
 
-      <Modal
+      <BottomSheet
         visible={open}
-        transparent
-        animationType="slide"
-        onRequestClose={() => setOpen(false)}
+        onClose={() => setOpen(false)}
+        title="Tasks"
+        headerAction={
+          <SheetActionButton label="Add" onPress={() => setAddOpen((v) => !v)} />
+        }
+        // The add form below holds a text input, and the sheet sits in the bottom
+        // half of the screen where the keyboard opens.
+        keyboardAware
       >
-        {/* The sheet is pinned to the bottom half of the screen — exactly where the
-            keyboard opens — so the add form is covered unless something lifts it.
-            "padding" on both platforms, NOT "height": under edge-to-edge the window
-            does not resize for the keyboard, and "height" lifts by shrinking and
-            does not fully unwind on dismiss. Same choice as the channel screen. */}
-        <KeyboardAvoidingView
-          style={styles.modalBody}
-          behavior="padding"
-          keyboardVerticalOffset={0}
-        >
-          <Pressable style={styles.backdrop} onPress={() => setOpen(false)} />
-
-          <View
-            style={[
-              styles.sheet,
-              { height: height * 0.5, paddingBottom: keyboardUp ? 0 : insets.bottom },
-            ]}
-          >
-            <View style={styles.grabber} />
-
-            <View style={styles.sheetHeader}>
-              <Text style={styles.sheetTitle}>Tasks</Text>
-              <TouchableOpacity
-                style={styles.addBtn}
-                onPress={() => setAddOpen((v) => !v)}
-                activeOpacity={0.7}
-              >
-                <Plus size={14} color={colors.primaryForeground} strokeWidth={2.5} />
-                <Text style={styles.addText}>Add</Text>
+        {addOpen && (
+          <View style={styles.addForm}>
+            <TextInput
+              style={styles.input}
+              value={name}
+              onChangeText={setName}
+              placeholder="Task name"
+              placeholderTextColor={colors.mutedForeground}
+              autoFocus
+            />
+            <TextInput
+              style={styles.input}
+              value={description}
+              onChangeText={setDescription}
+              placeholder="Description (optional)"
+              placeholderTextColor={colors.mutedForeground}
+            />
+            {nameTaken && (
+              <Text style={styles.nameTaken}>
+                A task with this name already exists in this channel.
+              </Text>
+            )}
+            <View style={styles.addActions}>
+              <TouchableOpacity onPress={resetForm} activeOpacity={0.7}>
+                <Text style={styles.cancelText}>Cancel</Text>
               </TouchableOpacity>
               <TouchableOpacity
-                onPress={() => setOpen(false)}
-                hitSlop={{ top: 8, bottom: 8, left: 8, right: 8 }}
-                activeOpacity={0.6}
+                style={[
+                  styles.submitBtn,
+                  (!name.trim() || nameTaken) && styles.submitBtnDisabled,
+                ]}
+                onPress={handleAdd}
+                disabled={!name.trim() || nameTaken || submitting}
+                activeOpacity={0.8}
               >
-                <X size={18} color={colors.mutedForeground} strokeWidth={2} />
+                <Text style={styles.submitText}>
+                  {submitting ? "Adding…" : "Add Task"}
+                </Text>
               </TouchableOpacity>
             </View>
-
-            {addOpen && (
-              <View style={styles.addForm}>
-                <TextInput
-                  style={styles.input}
-                  value={name}
-                  onChangeText={setName}
-                  placeholder="Task name"
-                  placeholderTextColor={colors.mutedForeground}
-                  autoFocus
-                />
-                <TextInput
-                  style={styles.input}
-                  value={description}
-                  onChangeText={setDescription}
-                  placeholder="Description (optional)"
-                  placeholderTextColor={colors.mutedForeground}
-                />
-                {nameTaken && (
-                  <Text style={styles.nameTaken}>
-                    A task with this name already exists in this channel.
-                  </Text>
-                )}
-                <View style={styles.addActions}>
-                  <TouchableOpacity onPress={resetForm} activeOpacity={0.7}>
-                    <Text style={styles.cancelText}>Cancel</Text>
-                  </TouchableOpacity>
-                  <TouchableOpacity
-                    style={[
-                      styles.submitBtn,
-                      (!name.trim() || nameTaken) && styles.submitBtnDisabled,
-                    ]}
-                    onPress={handleAdd}
-                    disabled={!name.trim() || nameTaken || submitting}
-                    activeOpacity={0.8}
-                  >
-                    <Text style={styles.submitText}>
-                      {submitting ? "Adding…" : "Add Task"}
-                    </Text>
-                  </TouchableOpacity>
-                </View>
-              </View>
-            )}
-
-            <ScrollView
-              style={styles.scroll}
-              contentContainerStyle={styles.scrollContent}
-              showsVerticalScrollIndicator
-              keyboardShouldPersistTaps="handled"
-            >
-              {sorted.map((task) => (
-                <TaskRow
-                  key={task.id}
-                  task={task}
-                  unread={isTaskUnseen(task)}
-                  assigneeName={
-                    task.assignee_id ? getUserName(task.assignee_id) : undefined
-                  }
-                  // The task screen marks it read on open — doing it here too would
-                  // be a second place to keep in step.
-                  onPress={() => {
-                    setOpen(false)
-                    router.push(
-                      `/(tabs)/project/${projectId}/${buildUnitId}/${channelId}/${task.id}` as any
-                    )
-                  }}
-                />
-              ))}
-              {sorted.length === 0 && (
-                <Text style={styles.empty}>No tasks yet. Tap Add to create one.</Text>
-              )}
-            </ScrollView>
           </View>
-        </KeyboardAvoidingView>
-      </Modal>
+        )}
+
+        <SheetScroll persistTaps>
+          {sorted.map((task) => (
+            <ChannelTaskRow
+              key={task.id}
+              task={task}
+              unread={isTaskUnseen(task)}
+              assigneeName={task.assignee_id ? getUserName(task.assignee_id) : undefined}
+              // The task screen marks it read on open — doing it here too would
+              // be a second place to keep in step.
+              onPress={() => {
+                setOpen(false)
+                router.push(
+                  `/(tabs)/project/${projectId}/${buildUnitId}/${channelId}/${task.id}` as any
+                )
+              }}
+            />
+          ))}
+          {sorted.length === 0 && (
+            <SheetEmpty>No tasks yet. Tap Add to create one.</SheetEmpty>
+          )}
+        </SheetScroll>
+      </BottomSheet>
     </>
   )
 }
 
 const styles = StyleSheet.create({
-  // The badge sits INSIDE the trigger's box — see the note in ResourcesSheet. It
-  // was pinned outside (top: -2, right: -4), where Android clips it: a two-digit
-  // count grows the badge past the edge and the last digit is lost. The resources
-  // badge hit this first, but a channel with 10+ tasks would have hit it here too.
-  trigger: {
-    paddingTop: 9,
-    paddingRight: 12,
-    paddingBottom: 6,
-    paddingLeft: 6,
-  },
-  countBadge: {
-    position: "absolute",
-    top: 0,
-    right: 0,
-    minWidth: 17,
-    height: 17,
-    paddingHorizontal: 4,
-    borderRadius: 9,
-    backgroundColor: colors.primary,
-    alignItems: "center",
-    justifyContent: "center",
-  },
-  countText: {
-    fontSize: 10,
-    lineHeight: 13,
-    fontFamily: "InstrumentSans_600SemiBold",
-    color: colors.primaryForeground,
-  },
-  modalBody: {
-    flex: 1,
-  },
-  backdrop: {
-    flex: 1,
-    backgroundColor: colors.scrim,
-  },
-  sheet: {
-    backgroundColor: colors.background,
-    borderTopLeftRadius: 20,
-    borderTopRightRadius: 20,
-    paddingHorizontal: 16,
-    // The height is fixed at half the screen, but a keyboard taller than that
-    // would leave no room for it — shrink instead of running off the bottom.
-    flexShrink: 1,
-  },
-  grabber: {
-    alignSelf: "center",
-    width: 36,
-    height: 4,
-    borderRadius: 2,
-    backgroundColor: colors.cardBorder,
-    marginTop: 8,
-    marginBottom: 8,
-  },
-  sheetHeader: {
-    flexDirection: "row",
-    alignItems: "center",
-    gap: 10,
-    paddingBottom: 10,
-    borderBottomWidth: 1,
-    borderBottomColor: colors.cardBorder,
-  },
-  sheetTitle: {
-    flex: 1,
-    fontSize: 16,
-    fontFamily: "InstrumentSans_600SemiBold",
-    color: colors.foreground,
-  },
-  addBtn: {
-    flexDirection: "row",
-    alignItems: "center",
-    gap: 4,
-    backgroundColor: colors.primary,
-    paddingHorizontal: 10,
-    paddingVertical: 6,
-    borderRadius: 8,
-  },
-  addText: {
-    fontSize: 12,
-    fontFamily: "InstrumentSans_600SemiBold",
-    color: colors.primaryForeground,
-  },
   addForm: {
     gap: 8,
     paddingVertical: 10,
@@ -443,62 +225,5 @@ const styles = StyleSheet.create({
     fontSize: 13,
     fontFamily: "InstrumentSans_600SemiBold",
     color: colors.primaryForeground,
-  },
-  scroll: {
-    flex: 1,
-  },
-  scrollContent: {
-    paddingVertical: 10,
-    gap: 8,
-  },
-  empty: {
-    fontSize: 13,
-    fontFamily: "InstrumentSans_400Regular",
-    color: colors.mutedForeground,
-    textAlign: "center",
-    paddingVertical: 24,
-  },
-  row: {
-    flexDirection: "row",
-    alignItems: "flex-start",
-    gap: 10,
-    paddingHorizontal: 10,
-    paddingVertical: 10,
-    backgroundColor: colors.background,
-    borderWidth: 1,
-    borderColor: colors.cardBorder,
-    borderRadius: 10,
-  },
-  rowUnread: {
-    backgroundColor: colors.cardSurface,
-    borderColor: colors.secondary,
-  },
-  rowBody: {
-    flex: 1,
-    gap: 2,
-  },
-  taskName: {
-    fontSize: 13,
-    fontFamily: "InstrumentSans_500Medium",
-    color: colors.foreground,
-    lineHeight: 18,
-  },
-  taskNameUnread: {
-    fontFamily: "InstrumentSans_600SemiBold",
-  },
-  taskNameCompleted: {
-    color: colors.mutedForeground,
-    textDecorationLine: "line-through",
-  },
-  taskDescription: {
-    fontSize: 12,
-    fontFamily: "InstrumentSans_400Regular",
-    color: colors.mutedForeground,
-  },
-  taskMeta: {
-    fontSize: 11,
-    fontFamily: "InstrumentSans_400Regular",
-    color: colors.mutedForeground,
-    marginTop: 2,
   },
 })

--- a/mobile-app/src/presentation/tasks/lib/status-note.ts
+++ b/mobile-app/src/presentation/tasks/lib/status-note.ts
@@ -1,0 +1,30 @@
+/**
+ * Composes the channel message that records a task status change.
+ *
+ * A status change is recorded as an ordinary channel message carrying the task's
+ * id — tasks have no notes table, so this is a record in the channel rather than
+ * a history on the task. Zero schema change, and the team sees the reason in
+ * context.
+ *
+ * messages.text is varchar(500). The note is the part worth keeping, so the task
+ * NAME is what gets truncated if the two together would overflow.
+ *
+ * `note` is expected already trimmed; the caller rejects an empty one.
+ */
+export function buildStatusNoteText({
+  taskName,
+  next,
+  note,
+}: {
+  taskName: string
+  next: "open" | "completed"
+  note: string
+}): string {
+  const label = next === "completed" ? `completed` : `reopened`
+  const prefix = `Task ${label}: `
+  const suffix = ` — ${note}`
+  const room = 500 - prefix.length - suffix.length
+  const name =
+    taskName.length > room && room > 1 ? `${taskName.slice(0, room - 1)}…` : taskName
+  return `${prefix}${name}${suffix}`.slice(0, 500)
+}

--- a/mobile-app/tests/collection-specs.test.ts
+++ b/mobile-app/tests/collection-specs.test.ts
@@ -1,0 +1,73 @@
+import { describe, it, expect } from "vitest"
+import {
+  usersSpec,
+  membershipsSpec,
+  channelMembersSpec,
+  projectsSpec,
+  buildUnitsSpec,
+  channelsSpec,
+  seenStateSpec,
+  inboxMentionsSpec,
+  myTasksSpec,
+  tasksSpec,
+  messagesSpec,
+  resourcesSpec,
+  propertiesSpec,
+} from "@buildinlime/sync-core"
+
+// The shared collection descriptors. These pin the two properties that are
+// load-bearing and silent when wrong.
+
+const ids = ["a", "b"]
+const all = [
+  usersSpec(),
+  membershipsSpec(),
+  channelMembersSpec(ids),
+  projectsSpec(ids),
+  buildUnitsSpec(ids),
+  channelsSpec(ids),
+  seenStateSpec(),
+  inboxMentionsSpec(ids),
+  myTasksSpec(ids),
+  tasksSpec(ids),
+  messagesSpec(ids),
+  resourcesSpec(ids),
+  propertiesSpec({
+    memberProjectIds: ids,
+    memberBuildunitIds: ids,
+    memberChannelIds: ids,
+  }),
+]
+
+describe("collection specs", () => {
+  it("gives every collection a unique id", () => {
+    // The id doubles as the collection's PERSISTENCE NAMESPACE. Two collections
+    // sharing one would interleave their rows and offsets in the same namespace,
+    // which surfaces as Electric reporting up-to-date while nothing renders —
+    // the same failure mode as a mismatched schemaVersion (see ./collections).
+    const seen = all.map((s) => s.id)
+    expect(new Set(seen).size).toBe(seen.length)
+  })
+
+  it("gives every collection a unique route", () => {
+    const paths = all.map((s) => s.path)
+    expect(new Set(paths).size).toBe(paths.length)
+  })
+
+  it("puts only the heavy screen-scoped collections on the idle-GC tier", () => {
+    // NEVER_GC is Infinity, which makes startGCTimer() skip scheduling. Getting
+    // this backwards is invisible until a badge goes stale (an always-mounted
+    // collection that GC'd) or a shape never closes (a heavy one that cannot).
+    const idle = all.filter((s) => Number.isFinite(s.gcTime)).map((s) => s.id).sort()
+    expect(idle).toEqual(["messages", "properties", "resources", "tasks"])
+  })
+
+  it("omits the params key entirely for the unscoped shapes", () => {
+    // These are scoped `user_id = me` server-side. Passing an empty id set would
+    // be read as "unscoped" anyway, but the routes distinguish a MISSING
+    // parameter from an empty one — see CollectionSpec.params.
+    for (const spec of [usersSpec(), membershipsSpec(), seenStateSpec()]) {
+      expect(spec.params).toBeUndefined()
+    }
+  })
+})

--- a/mobile-app/tests/status-note.test.ts
+++ b/mobile-app/tests/status-note.test.ts
@@ -1,0 +1,52 @@
+import { describe, it, expect } from "vitest"
+import { buildStatusNoteText } from "@/src/presentation/tasks/lib/status-note"
+
+// The task status note is posted as an ordinary channel message, and
+// messages.text is varchar(500) — so this composer has to fit an arbitrary task
+// name and an arbitrary note into that budget. Pure TypeScript, so it is tested
+// directly rather than through the screen.
+
+describe("buildStatusNoteText", () => {
+  it("labels completion and reopening differently", () => {
+    expect(
+      buildStatusNoteText({ taskName: "Pour slab", next: "completed", note: "cured 48h" })
+    ).toBe("Task completed: Pour slab — cured 48h")
+
+    expect(
+      buildStatusNoteText({ taskName: "Pour slab", next: "open", note: "rebar off" })
+    ).toBe("Task reopened: Pour slab — rebar off")
+  })
+
+  it("truncates the task NAME, never the note, and stays within 500 chars", () => {
+    const note = "n".repeat(200)
+    const text = buildStatusNoteText({
+      taskName: "x".repeat(600),
+      next: "completed",
+      note,
+    })
+
+    expect(text.length).toBeLessThanOrEqual(500)
+    // The note is the part worth keeping, so it survives intact...
+    expect(text.endsWith(` — ${note}`)).toBe(true)
+    // ...and the name is what gives way, marked with an ellipsis.
+    expect(text).toContain("…")
+  })
+
+  it("uses the full budget when the name is what overflows", () => {
+    const text = buildStatusNoteText({
+      taskName: "x".repeat(600),
+      next: "completed",
+      note: "n",
+    })
+    expect(text).toHaveLength(500)
+  })
+
+  it("leaves a name that already fits untouched", () => {
+    const text = buildStatusNoteText({
+      taskName: "Short name",
+      next: "completed",
+      note: "done",
+    })
+    expect(text).not.toContain("…")
+  })
+})

--- a/mobile-app/tests/upload-policy.test.ts
+++ b/mobile-app/tests/upload-policy.test.ts
@@ -1,0 +1,86 @@
+import { describe, it, expect, vi, afterEach } from "vitest"
+import {
+  nextRetryDelay,
+  shouldAutoRetry,
+  statusForFailure,
+  isRetryableStatus,
+  scheduleDecision,
+  MAX_AUTO_RETRIES,
+  MAX_BACKOFF_MS,
+} from "@buildinlime/sync-core"
+
+// The pending-upload policy shared by web's usePendingResources and mobile's
+// upload-manager. Pure functions, so they are tested here directly — mobile's
+// vitest is the plain-node runner the workspace already uses for sync-core
+// logic. The values below are the ones BOTH apps inlined before the extraction;
+// this file is what stops the two drifting apart again.
+
+afterEach(() => {
+  vi.useRealTimers()
+})
+
+describe("nextRetryDelay", () => {
+  it("doubles from 1s and caps at the ceiling", () => {
+    expect(nextRetryDelay(1)).toBe(1000)
+    expect(nextRetryDelay(2)).toBe(2000)
+    expect(nextRetryDelay(3)).toBe(4000)
+    expect(nextRetryDelay(4)).toBe(8000)
+    expect(nextRetryDelay(5)).toBe(16000)
+    // Attempt 6 would be 32s uncapped.
+    expect(nextRetryDelay(6)).toBe(MAX_BACKOFF_MS)
+    expect(nextRetryDelay(50)).toBe(MAX_BACKOFF_MS)
+  })
+})
+
+describe("shouldAutoRetry", () => {
+  it("retries while under the cap and online", () => {
+    expect(shouldAutoRetry(1, true)).toBe(true)
+    expect(shouldAutoRetry(MAX_AUTO_RETRIES, true)).toBe(true)
+    expect(shouldAutoRetry(MAX_AUTO_RETRIES + 1, true)).toBe(false)
+  })
+
+  it("never arms a timer while offline — reconnect is what wakes those", () => {
+    expect(shouldAutoRetry(1, false)).toBe(false)
+    expect(shouldAutoRetry(MAX_AUTO_RETRIES, false)).toBe(false)
+  })
+})
+
+describe("statusForFailure", () => {
+  it("distinguishes a real error from merely being offline", () => {
+    expect(statusForFailure(true)).toBe("error")
+    expect(statusForFailure(false)).toBe("awaiting_network")
+  })
+})
+
+describe("isRetryableStatus", () => {
+  it("covers exactly the two failure states", () => {
+    expect(isRetryableStatus("error")).toBe(true)
+    expect(isRetryableStatus("awaiting_network")).toBe(true)
+    expect(isRetryableStatus("uploading")).toBe(false)
+    expect(isRetryableStatus("scheduled")).toBe(false)
+    expect(isRetryableStatus("awaiting_schedule")).toBe(false)
+  })
+})
+
+describe("scheduleDecision", () => {
+  it("uploads now when there is no schedule", () => {
+    expect(scheduleDecision(null)).toEqual({ kind: "now" })
+  })
+
+  it("uploads now when the time has already passed", () => {
+    vi.useFakeTimers()
+    vi.setSystemTime(new Date("2026-07-18T12:00:00Z"))
+    expect(scheduleDecision(new Date("2026-07-18T11:59:59Z"))).toEqual({ kind: "now" })
+    // Exactly now counts as passed — a zero delay must not arm a timer.
+    expect(scheduleDecision(new Date("2026-07-18T12:00:00Z"))).toEqual({ kind: "now" })
+  })
+
+  it("waits the remaining time when the schedule is in the future", () => {
+    vi.useFakeTimers()
+    vi.setSystemTime(new Date("2026-07-18T12:00:00Z"))
+    expect(scheduleDecision(new Date("2026-07-18T12:00:30Z"))).toEqual({
+      kind: "later",
+      delayMs: 30_000,
+    })
+  })
+})

--- a/packages/sync-core/src/collection-specs.ts
+++ b/packages/sync-core/src/collection-specs.ts
@@ -1,0 +1,232 @@
+// The per-table collection DESCRIPTORS — one copy, shared by both apps.
+//
+// sync-core already owned the machinery that turns a spec into collection
+// options (makeCollectionOptionsBuilder in ./collections). What it did not own
+// was the specs themselves, so every table's id, route, shape parameters, row
+// schema, key function and GC tier existed twice — once per app — with nothing
+// keeping the two copies equal. They had already started to drift in their
+// comments.
+//
+// What stays at the CALL SITE, deliberately:
+//
+//   persistence  different engines (OPFS/wa-sqlite on web, expo-sqlite on
+//                mobile), and web resolves it asynchronously where mobile is
+//                synchronous.
+//   handlers     only one app writes through most of these. Web wires onInsert
+//                on projects/build-units/channels; mobile wires onUpdate on
+//                properties. Everything else takes no handler on purpose — a
+//                missing handler makes a stray collection.insert() fail loudly,
+//                which is the intended design (writes go through
+//                @tanstack/offline-transactions).
+//   onError      memberships overrides it with the app's own retry singleton.
+//
+// `teams` is not here: it exists on web only, so a shared descriptor would be a
+// second home for a single call site.
+
+import {
+  userRowSchema,
+  membershipRowSchema,
+  projectRowSchema,
+  buildUnitRowSchema,
+  channelRowSchema,
+  taskRowSchema,
+  messageRowSchema,
+  resourceRowSchema,
+  propertyRowSchema,
+  seenStateRowSchema,
+} from "@buildinlime/contracts"
+import { NEVER_GC, IDLE_GC_MS } from "./collections"
+import type { CollectionSpec } from "./collections"
+
+/** A descriptor minus the parts each app supplies for itself. */
+export type SharedCollectionSpec = Omit<CollectionSpec, "persistence" | "handlers">
+
+const byId = (item: { id: string }) => item.id
+
+// ---------------------------------------------------------------------------
+// Always-mounted spine (NEVER_GC)
+//
+// These are held for the whole session by an always-mounted subscriber — web's
+// Sidebar, mobile's DrawerContent — so GC would never fire for them anyway. A
+// non-finite gcTime makes startGCTimer() skip scheduling entirely.
+// ---------------------------------------------------------------------------
+
+export const usersSpec = (): SharedCollectionSpec => ({
+  id: `users`,
+  path: `/api/users`,
+  schema: userRowSchema,
+  getKey: byId,
+  gcTime: NEVER_GC,
+})
+
+/**
+ * The current user's SELF membership stream — scoped `user_id = me` server-side,
+ * so it takes no id parameters and never rebuilds on a scope change.
+ *
+ * Every other scoped shape derives its id sets from this one, which is why it
+ * loads first and why the call site passes an `onError` that RECORDS the failure
+ * before retrying: Electric marks a collection ready from its error path as well
+ * as on up-to-date, so "ready with zero rows" has to be distinguishable from a
+ * shape that failed. See makeShapeRetry.
+ */
+export const membershipsSpec = (): SharedCollectionSpec => ({
+  id: `memberships`,
+  path: `/api/memberships`,
+  schema: membershipRowSchema,
+  getKey: byId,
+  gcTime: NEVER_GC,
+})
+
+/**
+ * The channel ROSTER — who belongs to a channel, for assignee pickers.
+ *
+ * Note the parameter name: this route takes `channel_ids`, not the `member_ids`
+ * the other organization routes take. It is also NOT membershipsSpec: that one is
+ * scoped `user_id = me`, so filtering it by channel yields exactly one row (you).
+ */
+export const channelMembersSpec = (channelIds: string[]): SharedCollectionSpec => ({
+  id: `channel-members`,
+  path: `/api/channel-members`,
+  params: { channel_ids: channelIds },
+  schema: membershipRowSchema,
+  getKey: byId,
+  gcTime: NEVER_GC,
+})
+
+export const projectsSpec = (memberProjectIds: string[]): SharedCollectionSpec => ({
+  id: `projects`,
+  path: `/api/projects`,
+  params: { member_ids: memberProjectIds },
+  schema: projectRowSchema,
+  getKey: byId,
+  gcTime: NEVER_GC,
+})
+
+export const buildUnitsSpec = (memberBuildunitIds: string[]): SharedCollectionSpec => ({
+  id: `build-units`,
+  path: `/api/buildunits`,
+  params: { member_ids: memberBuildunitIds },
+  schema: buildUnitRowSchema,
+  getKey: byId,
+  gcTime: NEVER_GC,
+})
+
+export const channelsSpec = (memberChannelIds: string[]): SharedCollectionSpec => ({
+  id: `channels`,
+  path: `/api/channels`,
+  params: { member_ids: memberChannelIds },
+  schema: channelRowSchema,
+  getKey: byId,
+  gcTime: NEVER_GC,
+})
+
+/** One row per (user, scope, scope_id) — the composite key for seen state. */
+export const seenKey = (userId: string, scope: string, scopeId: string) =>
+  `${userId}:${scope}:${scopeId}`
+
+/**
+ * The current user's "last seen" markers — the timestamp successor to the reads
+ * collection. Scoped `user_id = me` server-side with no parameter able to widen
+ * it, so it takes no membership ids and never rebuilds on a scope change.
+ *
+ * NEVER_GC because the always-mounted unread badges subscribe to it.
+ */
+export const seenStateSpec = (): SharedCollectionSpec => ({
+  id: `seen-state`,
+  path: `/api/seen-state`,
+  schema: seenStateRowSchema,
+  getKey: (item: { user_id: string; scope: string; scope_id: string }) =>
+    seenKey(item.user_id, item.scope, item.scope_id),
+  gcTime: NEVER_GC,
+})
+
+/**
+ * Narrow badge slices. NEVER_GC for the same reason as the spine: the unread
+ * pills that read them are always mounted. They exist precisely SO the heavy
+ * messages/tasks collections below can idle — the badges read these instead.
+ */
+export const inboxMentionsSpec = (memberChannelIds: string[]): SharedCollectionSpec => ({
+  id: `inbox-mentions`,
+  path: `/api/inbox-mentions`,
+  params: { member_channel_ids: memberChannelIds },
+  schema: messageRowSchema,
+  getKey: byId,
+  gcTime: NEVER_GC,
+})
+
+export const myTasksSpec = (memberChannelIds: string[]): SharedCollectionSpec => ({
+  id: `my-tasks`,
+  path: `/api/my-tasks`,
+  params: { member_channel_ids: memberChannelIds },
+  schema: taskRowSchema,
+  getKey: byId,
+  gcTime: NEVER_GC,
+})
+
+// ---------------------------------------------------------------------------
+// Heavy, screen-scoped collections (IDLE_GC_MS)
+//
+// Nothing always-mounted holds these: the badges read the narrow slices above
+// and the unread logic reads seen_state, so their only subscribers are the
+// channel/task screens. They genuinely go idle on the project list, Inbox and
+// My-Tasks screens, and GC closing their long-poll is the point. Persisted, so
+// the next visit resurrects and RESUMES from the stored offset rather than
+// refetching — resurrection is driven by addSubscriber, so it needs a live
+// query (a bare .get() will not revive one). See the GC tier note in
+// ./collections.
+// ---------------------------------------------------------------------------
+
+export const tasksSpec = (memberChannelIds: string[]): SharedCollectionSpec => ({
+  id: `tasks`,
+  path: `/api/tasks`,
+  params: { member_channel_ids: memberChannelIds },
+  schema: taskRowSchema,
+  getKey: byId,
+  gcTime: IDLE_GC_MS,
+})
+
+export const messagesSpec = (memberChannelIds: string[]): SharedCollectionSpec => ({
+  id: `messages`,
+  path: `/api/messages`,
+  params: { member_channel_ids: memberChannelIds },
+  schema: messageRowSchema,
+  getKey: byId,
+  gcTime: IDLE_GC_MS,
+})
+
+/**
+ * Metadata only — file bytes and thumbnails load from the separate
+ * /api/resources/:id/file route, so GC'ing this never affects a rendered
+ * thumbnail.
+ */
+export const resourcesSpec = (memberChannelIds: string[]): SharedCollectionSpec => ({
+  id: `resources`,
+  path: `/api/resources`,
+  params: { member_channel_ids: memberChannelIds },
+  schema: resourceRowSchema,
+  getKey: byId,
+  gcTime: IDLE_GC_MS,
+})
+
+/**
+ * Scoped by entity_id (project/build-unit) AND by the denormalized channel_id
+ * (channel/task properties) — no task-id dependency, so it can be built in
+ * parallel with the other channel-scoped collections rather than waiting for
+ * tasks to land.
+ */
+export const propertiesSpec = (params: {
+  memberProjectIds: string[]
+  memberBuildunitIds: string[]
+  memberChannelIds: string[]
+}): SharedCollectionSpec => ({
+  id: `properties`,
+  path: `/api/properties`,
+  params: {
+    member_project_ids: params.memberProjectIds,
+    member_buildunit_ids: params.memberBuildunitIds,
+    member_channel_ids: params.memberChannelIds,
+  },
+  schema: propertyRowSchema,
+  getKey: byId,
+  gcTime: IDLE_GC_MS,
+})

--- a/packages/sync-core/src/index.ts
+++ b/packages/sync-core/src/index.ts
@@ -4,6 +4,7 @@
 export * from "./platform"
 export * from "./collections"
 export * from "./mutation-fns"
+export * from "./upload-policy"
 export * from "./actions/tasks"
 export * from "./actions/messages"
 export * from "./actions/properties"

--- a/packages/sync-core/src/index.ts
+++ b/packages/sync-core/src/index.ts
@@ -3,6 +3,7 @@
 // and mobile both bind to their own executor + collections. See ARCHITECTURE.md §10.
 export * from "./platform"
 export * from "./collections"
+export * from "./collection-specs"
 export * from "./mutation-fns"
 export * from "./upload-policy"
 export * from "./actions/tasks"

--- a/packages/sync-core/src/upload-policy.ts
+++ b/packages/sync-core/src/upload-policy.ts
@@ -1,0 +1,80 @@
+// Pending-upload POLICY — the rules both apps' upload paths obey, in one copy.
+//
+// Scope note, because it is easy to expect more from this file than it gives:
+// this is the policy layer ONLY. The two upload implementations around it
+// (web's usePendingResources hook, mobile's upload-manager service) are NOT
+// unified and deliberately so — they differ in ways that are design, not drift:
+//
+//   - lifetime      web is per-hook-instance state; mobile is a module singleton
+//                   that must outlive screen unmounts
+//   - data model    web carries a File + objectUrl (+ description, memberIds);
+//                   mobile carries a uri + mimeType for a file copied to disk
+//   - interruption  on restore web RESETS an interrupted `uploading` to
+//                   `awaiting_schedule` and waits for the user; mobile RESUMES
+//                   it (that is what its `inFlight` set exists to permit)
+//
+// What genuinely was duplicated is below: the status vocabulary, the backoff
+// numbers, and the three decisions. Those had drifted into two copies of the
+// same literals, which is precisely the kind of thing that silently stops
+// matching. Behaviour is unchanged on both sides — every function here returns
+// what the inlined code it replaced already returned.
+
+export type UploadStatus =
+  | "awaiting_schedule"
+  | "scheduled"
+  | "uploading"
+  | "awaiting_network"
+  | "error"
+
+/** Auto-retry attempts before an upload is left for the user to retry by hand. */
+export const MAX_AUTO_RETRIES = 5
+
+/** Backoff ceiling — reached at attempt 6, so in practice the last attempt. */
+export const MAX_BACKOFF_MS = 30_000
+
+/**
+ * Exponential backoff for a failed attempt: 1s, 2s, 4s, 8s, 16s, then capped.
+ * `attempt` is 1-based (the first retry is attempt 1).
+ */
+export function nextRetryDelay(attempt: number): number {
+  return Math.min(MAX_BACKOFF_MS, 1000 * 2 ** (attempt - 1))
+}
+
+/**
+ * Whether to arm a backoff timer after a failure.
+ *
+ * Offline never schedules one: the reconnect listener is what wakes those
+ * uploads, so a timer would fire pointlessly into an offline network.
+ */
+export function shouldAutoRetry(attempt: number, online: boolean): boolean {
+  return attempt <= MAX_AUTO_RETRIES && online
+}
+
+/**
+ * How a failure is shown. Offline is not really a failure — it gets the calmer
+ * "awaiting network" rather than a red error for something we will auto-retry.
+ */
+export function statusForFailure(online: boolean): UploadStatus {
+  return online ? "error" : "awaiting_network"
+}
+
+/** Statuses the reconnect listener and hydration should re-drive. */
+export function isRetryableStatus(status: UploadStatus): boolean {
+  return status === "error" || status === "awaiting_network"
+}
+
+export type ScheduleDecision =
+  | { kind: "now" }
+  | { kind: "later"; delayMs: number }
+
+/**
+ * Whether a scheduled upload fires now or waits.
+ *
+ * A null time means "no schedule — go now", and a time already past also goes
+ * now rather than arming a negative timeout.
+ */
+export function scheduleDecision(when: Date | null): ScheduleDecision {
+  if (!when) return { kind: "now" }
+  const delayMs = when.getTime() - Date.now()
+  return delayMs <= 0 ? { kind: "now" } : { kind: "later", delayMs }
+}

--- a/web-app/code/src/application/collections/admin.ts
+++ b/web-app/code/src/application/collections/admin.ts
@@ -1,23 +1,20 @@
-import { userRowSchema, teamRowSchema } from "@buildinlime/contracts"
+import { teamRowSchema } from "@buildinlime/contracts"
+import { usersSpec } from "@buildinlime/sync-core"
 import { getPersistence } from "../../infrastructure/persistence/browser-persistence"
 import { defineCollection, NEVER_GC } from "./_shared"
 
-// Row schemas come from @buildinlime/contracts — one copy, shared with mobile and
-// asserted against the drizzle tables server-side. See ARCHITECTURE.md §10.
+// The descriptors live once in @buildinlime/sync-core — see collection-specs.ts.
+// This file supplies only web's persistence handle.
+//
+// `teams` keeps its spec here: it is web-only, so a shared descriptor would be a
+// second home for a single call site.
 
 // usersCollection is wrapped with SQLite persistence (OPFS) so the user list
 // hydrates instantly from local cache on reload, even with the server offline.
 function _makeUsersCollection(
   persistence: Awaited<ReturnType<typeof getPersistence>>["persistence"],
 ) {
-  return defineCollection({
-    id: `users`,
-    path: `/api/users`,
-    schema: userRowSchema,
-    getKey: (item: { id: string }) => item.id,
-    gcTime: NEVER_GC,
-    persistence,
-  })
+  return defineCollection({ ...usersSpec(), persistence })
 }
 
 // Deferred export — initialized by initializeUsersCollection() in

--- a/web-app/code/src/application/collections/communication.ts
+++ b/web-app/code/src/application/collections/communication.ts
@@ -1,15 +1,28 @@
 import {
-  taskRowSchema,
-  messageRowSchema,
-  resourceRowSchema,
-  propertyRowSchema,
-  seenStateRowSchema,
-} from "@buildinlime/contracts"
+  tasksSpec,
+  messagesSpec,
+  resourcesSpec,
+  propertiesSpec,
+  seenStateSpec,
+  inboxMentionsSpec,
+  myTasksSpec,
+  seenKey,
+} from "@buildinlime/sync-core"
 import { getPersistence } from "../../infrastructure/persistence/browser-persistence"
-import { defineCollection, NEVER_GC, IDLE_GC_MS } from "./_shared"
+import { defineCollection } from "./_shared"
 
-// Row schemas come from @buildinlime/contracts — one copy, shared with mobile and
-// asserted against the drizzle tables server-side. See ARCHITECTURE.md §10.
+// The descriptors (id, route, shape params, row schema, key, GC tier) live once
+// in @buildinlime/sync-core — see collection-specs.ts, which also carries the
+// reasoning for each GC tier. This file supplies only web's persistence handle;
+// none of these collections take handlers (writes go through
+// @tanstack/offline-transactions — see application/actions/*).
+
+/**
+ * The seen_state collection's key. Re-exported because the optimistic upsert in
+ * actions/seen.ts must look up an existing row before deciding insert-vs-update,
+ * and a key built differently there would silently miss.
+ */
+export { seenKey }
 
 // ---------------------------------------------------------------------------
 // Factory functions — collections are created AFTER memberships load so that
@@ -20,50 +33,14 @@ function _makeTasksCollection(
   persistence: Awaited<ReturnType<typeof getPersistence>>["persistence"],
   memberChannelIds: string[],
 ) {
-  return defineCollection({
-    id: `tasks`,
-    path: `/api/tasks`,
-    params: { member_channel_ids: memberChannelIds },
-    schema: taskRowSchema,
-    getKey: (item: { id: string }) => item.id,
-    // Idle-GC: the always-mounted Sidebar "My Tasks" badge reads the
-    // user-scoped myTasksCollection slice, and useSeen reads only seen_state
-    // — so nothing always-mounted holds this full collection. Its only
-    // subscribers are the channel/task views, so it idles (and closes its
-    // shape stream) on the project list, Inbox and My-Tasks screens,
-    // resurrecting + resuming from OPFS on the next visit.
-    gcTime: IDLE_GC_MS,
-    persistence,
-    // No handlers — task writes go through @tanstack/offline-transactions (see
-    // application/actions/tasks.ts). Direct collection.insert/update/delete calls
-    // outside an offline transaction fail with "no handler", which is the intended
-    // loud failure mode.
-  })
+  return defineCollection({ ...tasksSpec(memberChannelIds), persistence })
 }
 
 function _makeResourcesCollection(
   persistence: Awaited<ReturnType<typeof getPersistence>>["persistence"],
   memberChannelIds: string[],
 ) {
-  return defineCollection({
-    id: `resources`,
-    path: `/api/resources`,
-    params: { member_channel_ids: memberChannelIds },
-    schema: resourceRowSchema,
-    getKey: (item: { id: string }) => item.id,
-    // Idle-GC (not NEVER_GC): resources is subscribed ONLY by the channel
-    // Resources view and the message/task attachment sections — nothing
-    // always-mounted holds it (the Sidebar and badges never touch it). The
-    // shape carries metadata only; file bytes/thumbnails load from the
-    // separate /api/resources/:id/file route, so GC'ing this collection
-    // never affects a rendered thumbnail. Persisted, so the next Resources
-    // visit resurrects it and resumes from the OPFS offset rather than
-    // refetching. See IDLE_GC_MS.
-    gcTime: IDLE_GC_MS,
-    persistence,
-    // No handlers — resource deletes go through @tanstack/offline-transactions
-    // (see application/actions/resources.ts).
-  })
+  return defineCollection({ ...resourcesSpec(memberChannelIds), persistence })
 }
 
 function _makePropertiesCollection(
@@ -74,130 +51,34 @@ function _makePropertiesCollection(
     memberChannelIds: string[]
   },
 ) {
-  return defineCollection({
-    id: `properties`,
-    path: `/api/properties`,
-    params: {
-      member_project_ids: params.memberProjectIds,
-      member_buildunit_ids: params.memberBuildunitIds,
-      member_channel_ids: params.memberChannelIds,
-    },
-    schema: propertyRowSchema,
-    getKey: (item: { id: string }) => item.id,
-    // Idle-GC (not NEVER_GC): properties is subscribed ONLY by the channel /
-    // build-unit / task routes — nothing always-mounted holds it (verified:
-    // the Sidebar and unread badges never touch it). So it idles on the
-    // project list, Inbox and My-Tasks screens, and GC closes its shape
-    // stream there. Persisted, so the next channel/task visit resurrects it
-    // and resumes from the OPFS offset rather than refetching. See IDLE_GC_MS.
-    gcTime: IDLE_GC_MS,
-    persistence,
-    // No handlers — property writes go through @tanstack/offline-transactions
-    // (see application/actions/properties.ts: create / update / delete).
-  })
+  return defineCollection({ ...propertiesSpec(params), persistence })
 }
 
 function _makeMessagesCollection(
   persistence: Awaited<ReturnType<typeof getPersistence>>["persistence"],
   memberChannelIds: string[],
 ) {
-  return defineCollection({
-    id: `messages`,
-    path: `/api/messages`,
-    params: { member_channel_ids: memberChannelIds },
-    schema: messageRowSchema,
-    getKey: (item: { id: string }) => item.id,
-    // Idle-GC: with the Sidebar's per-channel unread pills removed, the
-    // always-mounted inbox badge reading the inbox-mentions slice, and
-    // useSeen reading only seen_state, nothing always-mounted holds this full
-    // collection. It idles (and closes its shape stream) on the project list
-    // / My-Tasks / Inbox screens, and resurrects + resumes from OPFS when a
-    // channel or the Inbox view opens.
-    gcTime: IDLE_GC_MS,
-    persistence,
-    // No handlers — message writes go through @tanstack/offline-transactions
-    // (see application/actions/messages.ts). Delete is not currently used by UI;
-    // add a mutationFn + action when needed.
-  })
+  return defineCollection({ ...messagesSpec(memberChannelIds), persistence })
 }
 
-/**
- * The seen_state collection's key. Exported because the optimistic upsert in
- * actions/seen.ts must look up an existing row before deciding insert-vs-update,
- * and a key built differently there would silently miss.
- */
-export const seenKey = (userId: string, scope: string, scopeId: string) =>
-  `${userId}:${scope}:${scopeId}`
-
-/**
- * The current user's "last seen" markers — the timestamp successor to the reads
- * collection (web has cut over; the reads TABLE stays for mobile). Shape scoped
- * `user_id = me` server-side (see routes/api/seen-state.ts) — no id set to pass,
- * so it needs no membership params and never rebuilds on scope change.
- *
- * Key is composite: one row per (user, scope, scope_id). NEVER_GC because the
- * always-mounted inbox / my-tasks badges subscribe to it, so it never idles.
- */
 function _makeSeenStateCollection(
   persistence: Awaited<ReturnType<typeof getPersistence>>["persistence"],
 ) {
-  return defineCollection({
-    id: `seen-state`,
-    path: `/api/seen-state`,
-    schema: seenStateRowSchema,
-    getKey: (item: { user_id: string; scope: string; scope_id: string }) =>
-      seenKey(item.user_id, item.scope, item.scope_id),
-    gcTime: NEVER_GC,
-    persistence,
-    // No handlers — seen markers are written through @tanstack/offline-transactions
-    // (see application/actions/seen.ts).
-  })
+  return defineCollection({ ...seenStateSpec(), persistence })
 }
-
-// ---------------------------------------------------------------------------
-// Badge slices — user-scoped subsets that exist so the ALWAYS-MOUNTED Sidebar
-// inbox / my-tasks badges don't have to hold the full channel-scoped messages /
-// tasks collections open for the whole session just to count the few rows that
-// concern the current user. The server does the mention / assignee filter (see
-// routes/api/inbox-mentions.ts and api/my-tasks.ts); the badge subscribes to
-// these tiny shapes, and the full collections are freed to garbage-collect.
-//
-// gcTime: NEVER_GC — these ARE the always-mounted subscription, so they never
-// idle; a finite gcTime would be moot. Persisted like the rest, so the badge count
-// paints from OPFS on reload before Electric reconnects. Channel-scoped, so they
-// rebuild with the other channel-scoped collections on a membership resync (see
-// initializeCommunicationCollections callers). Read-only: no mutation handlers —
-// messages/tasks are written via their full collections.
-// ---------------------------------------------------------------------------
 
 function _makeInboxMentionsCollection(
   persistence: Awaited<ReturnType<typeof getPersistence>>["persistence"],
   memberChannelIds: string[],
 ) {
-  return defineCollection({
-    id: `inbox-mentions`,
-    path: `/api/inbox-mentions`,
-    params: { member_channel_ids: memberChannelIds },
-    schema: messageRowSchema,
-    getKey: (item: { id: string }) => item.id,
-    gcTime: NEVER_GC,
-    persistence,
-  })
+  return defineCollection({ ...inboxMentionsSpec(memberChannelIds), persistence })
 }
 
 function _makeMyTasksCollection(
   persistence: Awaited<ReturnType<typeof getPersistence>>["persistence"],
   memberChannelIds: string[],
 ) {
-  return defineCollection({
-    id: `my-tasks`,
-    path: `/api/my-tasks`,
-    params: { member_channel_ids: memberChannelIds },
-    schema: taskRowSchema,
-    getKey: (item: { id: string }) => item.id,
-    gcTime: NEVER_GC,
-    persistence,
-  })
+  return defineCollection({ ...myTasksSpec(memberChannelIds), persistence })
 }
 
 // ---------------------------------------------------------------------------

--- a/web-app/code/src/application/collections/organization.ts
+++ b/web-app/code/src/application/collections/organization.ts
@@ -1,25 +1,24 @@
 import {
-  projectRowSchema,
-  buildUnitRowSchema,
-  channelRowSchema,
-  membershipRowSchema,
-} from "@buildinlime/contracts"
+  projectsSpec,
+  buildUnitsSpec,
+  channelsSpec,
+  channelMembersSpec,
+  membershipsSpec,
+} from "@buildinlime/sync-core"
 import { trpc } from "%/infrastructure/trpc/lib/trpc-client"
 import { getPersistence } from "../../infrastructure/persistence/browser-persistence"
-import { defineCollection, retryOnMembershipsError, NEVER_GC } from "./_shared"
+import { defineCollection, retryOnMembershipsError } from "./_shared"
 
-// Row schemas come from @buildinlime/contracts — one copy, shared with mobile and
-// asserted against the drizzle tables server-side. See ARCHITECTURE.md §10.
+// The descriptors (id, route, shape params, row schema, key, GC tier) live once
+// in @buildinlime/sync-core — see collection-specs.ts. This file supplies what is
+// web's own: the persistence handle, the memberships onError, and the tRPC write
+// handlers below (mobile is read-only for these tables).
 
 function _makeMembershipsCollection(
   persistence: Awaited<ReturnType<typeof getPersistence>>["persistence"],
 ) {
   return defineCollection({
-    id: `memberships`,
-    path: `/api/memberships`,
-    schema: membershipRowSchema,
-    getKey: (item: { id: string }) => item.id,
-    gcTime: NEVER_GC,
+    ...membershipsSpec(),
     persistence,
     // Reports the error before retrying, so the bootstrap can tell a clean empty
     // sync apart from a shape that failed and was marked ready anyway — see
@@ -54,17 +53,7 @@ function _makeChannelMembersCollection(
   persistence: Awaited<ReturnType<typeof getPersistence>>["persistence"],
   channelIds: string[],
 ) {
-  return defineCollection({
-    id: `channel-members`,
-    path: `/api/channel-members`,
-    // Note the param name: this route takes `channel_ids`, not the `member_ids` the
-    // projects/buildunits/channels routes take.
-    params: { channel_ids: channelIds },
-    schema: membershipRowSchema,
-    getKey: (item: { id: string }) => item.id,
-    gcTime: NEVER_GC,
-    persistence,
-  })
+  return defineCollection({ ...channelMembersSpec(channelIds), persistence })
 }
 
 // Deferred export — initialized by initializeChannelMembersCollection().
@@ -89,12 +78,7 @@ function _makeProjectsCollection(
   memberProjectIds: string[],
 ) {
   return defineCollection({
-    id: `projects`,
-    path: `/api/projects`,
-    params: { member_ids: memberProjectIds },
-    schema: projectRowSchema,
-    getKey: (item: { id: string }) => item.id,
-    gcTime: NEVER_GC,
+    ...projectsSpec(memberProjectIds),
     persistence,
     handlers: {
       onInsert: async ({ transaction }: { transaction: { mutations: { modified: { id: string; name: string; description?: string | null; owner_id: string } }[] } }) => {
@@ -150,12 +134,7 @@ function _makeBuildUnitsCollection(
   memberBuildunitIds: string[],
 ) {
   return defineCollection({
-    id: `build-units`,
-    path: `/api/buildunits`,
-    params: { member_ids: memberBuildunitIds },
-    schema: buildUnitRowSchema,
-    getKey: (item: { id: string }) => item.id,
-    gcTime: NEVER_GC,
+    ...buildUnitsSpec(memberBuildunitIds),
     persistence,
     handlers: {
       onInsert: async ({ transaction }: { transaction: { mutations: { modified: { id: string; name: string; description?: string | null; project_id: string; owner_id: string } }[] } }) => {
@@ -219,12 +198,7 @@ function _makeChannelsCollection(
   memberChannelIds: string[],
 ) {
   return defineCollection({
-    id: `channels`,
-    path: `/api/channels`,
-    params: { member_ids: memberChannelIds },
-    schema: channelRowSchema,
-    getKey: (item: { id: string }) => item.id,
-    gcTime: NEVER_GC,
+    ...channelsSpec(memberChannelIds),
     persistence,
     handlers: {
       onInsert: async ({ transaction }: { transaction: { mutations: { modified: { id: string; name: never; description?: string | null; buildunit_id: string; owner_id: string } }[] } }) => {

--- a/web-app/code/src/application/hooks/pending-resources-db.ts
+++ b/web-app/code/src/application/hooks/pending-resources-db.ts
@@ -1,3 +1,5 @@
+import type { UploadStatus } from "@buildinlime/sync-core"
+
 const DB_NAME = `buildinlime-pending`
 const STORE = `pending`
 const VERSION = 1
@@ -8,7 +10,10 @@ export interface StoredResource {
   name: string
   description: string
   file: File
-  status: `awaiting_schedule` | `scheduled` | `uploading` | `error`
+  // Was a hand-written union here that omitted `awaiting_network`, while
+  // doUpload persists exactly that value on an offline failure — so the stored
+  // shape had a status the type said was impossible. Shared with mobile now.
+  status: UploadStatus
   scheduledAt: Date | null
   channelId: string | null
   taskId: string | null

--- a/web-app/code/src/application/hooks/pending-resources-db.ts
+++ b/web-app/code/src/application/hooks/pending-resources-db.ts
@@ -21,9 +21,11 @@ export interface StoredResource {
   buildunitId: string
   projectId: string
   createdbyId: string
-  memberIds: string[]
   errorMessage?: string
 }
+// Rows written before memberIds was dropped still carry the key in IndexedDB.
+// That is harmless — it is read back as an untyped extra property and never
+// sent — so no migration is needed.
 
 let dbPromise: Promise<IDBDatabase> | null = null
 

--- a/web-app/code/src/application/hooks/use-pending-resources.ts
+++ b/web-app/code/src/application/hooks/use-pending-resources.ts
@@ -1,12 +1,18 @@
 import { useState, useRef, useCallback, useEffect } from "react"
+import {
+  nextRetryDelay,
+  shouldAutoRetry,
+  statusForFailure,
+  isRetryableStatus,
+  scheduleDecision,
+} from "@buildinlime/sync-core"
+import type { UploadStatus } from "@buildinlime/sync-core"
 import { dbGetAll, dbPut, dbDelete, type StoredResource } from "./pending-resources-db"
 
-export type UploadStatus =
-  | "awaiting_schedule"
-  | "scheduled"
-  | "uploading"
-  | "awaiting_network"
-  | "error"
+// Retry/backoff numbers and the status vocabulary are shared with mobile — see
+// @buildinlime/sync-core's upload-policy. Re-exported because the schedule
+// popover imports the type from here.
+export type { UploadStatus }
 
 export interface PendingResource {
   id: string
@@ -68,7 +74,7 @@ export function usePendingResources(filterChannelId: string | null, filterTaskId
   useEffect(() => {
     const onOnline = () => {
       pendingRef.current.forEach((r) => {
-        if (r.status === "error" || r.status === "awaiting_network") {
+        if (isRetryableStatus(r.status)) {
           retryAttempts.current.set(r.id, 0)
           const t = retryTimers.current.get(r.id)
           if (t) {
@@ -104,22 +110,19 @@ export function usePendingResources(filterChannelId: string | null, filterTaskId
         // Errored / waiting-for-network uploads from a previous session: retry
         // once on mount if we think we're online; otherwise the `online`
         // listener will pick them up when connectivity returns.
-        if (
-          (r.status === "error" || r.status === "awaiting_network") &&
-          navigator.onLine
-        ) {
+        if (isRetryableStatus(r.status) && navigator.onLine) {
           doUploadRef.current(r.id)
         }
         // Re-schedule timers for items that were waiting for a future time
         if (r.status === "scheduled" && r.scheduledAt) {
-          const delay = r.scheduledAt.getTime() - Date.now()
-          if (delay <= 0) {
+          const decision = scheduleDecision(r.scheduledAt)
+          if (decision.kind === "now") {
             doUploadRef.current(r.id)
           } else {
             const timer = setTimeout(() => {
               timers.current.delete(r.id)
               doUploadRef.current(r.id)
-            }, delay)
+            }, decision.delayMs)
             timers.current.set(r.id, timer)
           }
         }
@@ -184,7 +187,7 @@ export function usePendingResources(filterChannelId: string | null, filterTaskId
       // While offline this isn't really a failure — surface it as a calmer
       // "waiting for network" state so the user doesn't see a red error for
       // an upload we're going to retry as soon as connectivity returns.
-      const nextStatus: UploadStatus = navigator.onLine ? "error" : "awaiting_network"
+      const nextStatus = statusForFailure(navigator.onLine)
       setPendingSync((prev) =>
         prev.map((r) =>
           r.id === id ? { ...r, status: nextStatus, errorMessage: message } : r
@@ -197,9 +200,8 @@ export function usePendingResources(filterChannelId: string | null, filterTaskId
       // the parent message/task hasn't replayed from the outbox yet).
       const attempt = (retryAttempts.current.get(id) ?? 0) + 1
       retryAttempts.current.set(id, attempt)
-      const MAX_AUTO_RETRIES = 5
-      if (attempt <= MAX_AUTO_RETRIES && navigator.onLine) {
-        const delay = Math.min(30000, 1000 * 2 ** (attempt - 1))
+      if (shouldAutoRetry(attempt, navigator.onLine)) {
+        const delay = nextRetryDelay(attempt)
         const timer = setTimeout(() => {
           retryTimers.current.delete(id)
           doUploadRef.current(id)
@@ -249,15 +251,11 @@ export function usePendingResources(filterChannelId: string | null, filterTaskId
       const existing = timers.current.get(id)
       if (existing) clearTimeout(existing)
 
-      if (!scheduledAt) {
-        // Upload immediately
-        doUpload(id)
-        return
-      }
-
-      const delay = scheduledAt.getTime() - Date.now()
-      if (delay <= 0) {
-        // Scheduled time already passed — upload now
+      // Null time, or a time already past, uploads now rather than arming a
+      // negative timeout. The `!scheduledAt` arm is redundant with
+      // scheduleDecision(null) but is what narrows the type below.
+      const decision = scheduleDecision(scheduledAt)
+      if (!scheduledAt || decision.kind === "now") {
         doUpload(id)
         return
       }
@@ -276,7 +274,7 @@ export function usePendingResources(filterChannelId: string | null, filterTaskId
       const timer = setTimeout(() => {
         timers.current.delete(id)
         doUpload(id)
-      }, delay)
+      }, decision.delayMs)
 
       timers.current.set(id, timer)
     },

--- a/web-app/code/src/application/hooks/use-pending-resources.ts
+++ b/web-app/code/src/application/hooks/use-pending-resources.ts
@@ -28,7 +28,6 @@ export interface PendingResource {
   buildunitId: string
   projectId: string
   createdbyId: string
-  memberIds: string[]
   errorMessage?: string
 }
 
@@ -41,7 +40,6 @@ export interface AddPendingOptions {
   buildunitId: string
   projectId: string
   createdbyId: string
-  memberIds: string[]
 }
 
 export function usePendingResources(filterChannelId: string | null, filterTaskId?: string | null) {
@@ -160,7 +158,9 @@ export function usePendingResources(filterChannelId: string | null, filterTaskId
     if (resource.messageId) formData.append("messageId", resource.messageId)
     formData.append("buildunitId", resource.buildunitId)
     formData.append("projectId", resource.projectId)
-    formData.append("memberIds", JSON.stringify(resource.memberIds))
+    // No memberIds: the upload handler never read it, and resources no longer
+    // carry a member_ids column at all — access is resolved through the
+    // channel's memberships instead (see fileStorage.ts serveResourceFile).
 
     try {
       const res = await fetch("/api/resources/upload", {
@@ -233,7 +233,6 @@ export function usePendingResources(filterChannelId: string | null, filterTaskId
       buildunitId: opts.buildunitId,
       projectId: opts.projectId,
       createdbyId: opts.createdbyId,
-      memberIds: opts.memberIds,
     }
     // Update ref synchronously so doUpload can find the resource even when
     // scheduleUpload is called immediately after addPending in the same loop

--- a/web-app/code/src/presentation/components/buildInlime/communication/CommentsSection.tsx
+++ b/web-app/code/src/presentation/components/buildInlime/communication/CommentsSection.tsx
@@ -85,7 +85,6 @@ export function CommentsSection({
         buildunitId,
         projectId,
         createdbyId: currentUserId,
-        memberIds,
       })
       scheduleUpload(id, null) // null = upload immediately
     }

--- a/web-app/code/src/presentation/components/buildInlime/communication/ResourcesSection.tsx
+++ b/web-app/code/src/presentation/components/buildInlime/communication/ResourcesSection.tsx
@@ -14,7 +14,6 @@ export interface ResourcesSectionProps {
   buildunitId: string
   projectId: string
   createdbyId: string
-  memberIds: string[]
 }
 
 export function ResourcesSection({
@@ -23,7 +22,6 @@ export function ResourcesSection({
   buildunitId,
   projectId,
   createdbyId,
-  memberIds,
 }: ResourcesSectionProps) {
   const [formOpen, setFormOpen] = useState(false)
 
@@ -83,7 +81,6 @@ export function ResourcesSection({
       buildunitId,
       projectId,
       createdbyId,
-      memberIds,
     })
     setFormOpen(false)
   }

--- a/web-app/code/src/presentation/pages/TaskPage.tsx
+++ b/web-app/code/src/presentation/pages/TaskPage.tsx
@@ -160,7 +160,6 @@ export function TaskPage({
               buildunitId={buildUnitId}
               projectId={projectId}
               createdbyId={currentUserId}
-              memberIds={channelMemberIds.length > 0 ? channelMemberIds : [currentUserId]}
             />
           </div>
 


### PR DESCRIPTION
Continues the modularization started in #38, which covered the web presentation layer. This pass covers the mobile presentation layer and the two shared-package opportunities it surfaced.

## Mobile presentation

The feature modules under `src/presentation/` already existed, but the routes bypassed them — defining row components, live queries and large stylesheets inline.

| | before | after |
|---|---|---|
| `[taskId].tsx` | 712 | 304 |
| `ResourcesSheet.tsx` | 576 | 226 |
| `TasksSheet.tsx` | 504 | 229 |
| `inbox.tsx` | 282 | 110 |
| `my-tasks.tsx` | 259 | 110 |
| channel `index.tsx` | 179 | 140 |

New shared components: `BottomSheet` (+ `SheetTrigger`/`SheetActionButton`/`SheetScroll`/`SheetEmpty`), `BackHeader`, `CardList`, `ScreenStates`. Rows moved to the modules that own them (`MentionRow`, `MyTaskRow`, `ChannelTaskRow`, `ResourceRows`, and the task-screen panels).

## Shared packages

**Upload policy** (`sync-core/upload-policy.ts`) — both apps had their own copy of the same `UploadStatus` union, the same 1s/2s/4s/8s/16s-capped-at-30s backoff, the same 5-attempt cap and the same online/offline failure split. Identical, with nothing keeping them so.

This also fixed a real bug: web's `StoredResource.status` listed four statuses while `doUpload` persists `awaiting_network` on an offline failure, so IndexedDB held a status the type called impossible.

Scope is the **policy only**. The two implementations around it are deliberately *not* unified — they differ by design, not drift: web is per-hook-instance state, mobile a singleton that outlives screen unmounts; web carries a `File` + objectUrl, mobile a uri to a file copied on disk; and on restore web *resets* an interrupted upload while mobile *resumes* it. The module header records this so it isn't re-litigated.

**Collection descriptors** (`sync-core/collection-specs.ts`) — sync-core already owned the machinery that turns a spec into collection options, but not the specs. 13 of 14 collections now share their descriptor; collection files drop 1164 → 865. `persistence`, `onError` and the write handlers stay per-app, which `CollectionSpec` already modelled.

Prerequisite commit: mobile kept `memberships` and `seen_state` in `collections/admin.ts` while web had them in organization/communication. Aligned to match the DB schema (`membershipTable` is in `organization-tables.ts`, `seenStateTable` in `communication-tables.ts`) — web was already right.

## Fixes

- **Two-digit sheet badge** rendered as its first digit only. Yoga measures an absolutely-positioned child against its parent's *content box*, which was just the 20px icon, so a two-digit badge got clamped. Two earlier attempts missed because they treated it as wrapping (`numberOfLines={1}`) and as clipping (`paddingRight` to "reserve room", which made the box *narrower*).
- **Dead `memberIds` upload field** — resources no longer have a `member_ids` column at all; access resolves through channel memberships. Removed the field and the plumbing that existed only to feed it. `CommentsSection` keeps its prop (it filters the mention list).
- **Build unit icon** — mobile used `Boxes`, web's *project* icon; now `Package`, matching web's five build-unit sites.
- **Project-switch comments** — switching was replaced by sign-out, but seven comments still named it as the trigger for code that actually runs on membership *resync*. Comment-only.

## Verification

Typecheck is not clean in this repo, so every change was **baseline-diffed** rather than read as pass/fail: web holds at 191, mobile at 85, sync-core clean, with identical error sets modulo line numbers. Lint unchanged on both sides. Tests 6 → 22.

Where a change could compile perfectly and still be wrong, equivalence was checked mechanically against `HEAD` rather than by eye:

- all 13 collection descriptors — path, schema, gcTime, param keys, key shape
- all 10 shared sheet-chrome styles, both action buttons, the sheet/flexShrink composition, and all 17 row styles
- all 5 `BackHeader` styles, against *both* originals

The existing 6 upload-manager tests — including the exponential-backoff and offline-then-reconnect specs — pass untouched, which is the strongest signal here since they exercise exactly the policy that moved.

## Not verified

**None of this has been exercised on a device yet.** The presentation commits in particular are verified statically only — the stylesheet partitions are reasoned, not observed. Worth driving before merge:

- two-digit counts on both sheet triggers (this is the *third* attempt at that fix)
- a full login → pick project → sign out → log back in cycle — covers the collection bootstrap and descriptor swap, which no test reaches
- the TasksSheet keyboard path (`keyboardAware`)
- uploading an attachment to a task and to a message on web — the path the `memberIds` change touched

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KwsbT7JvrDmJFNyYf6DTgo
