### PR TITLE
fix(web): repair the router Links that never navigated (typecheck 124 → 117)

### DIFF
--- a/.github/quality-baseline.json
+++ b/.github/quality-baseline.json
@@ -1,6 +1,6 @@
 {
   "_comment": "Ratchet baselines: max tolerated typecheck/lint ERROR counts per workspace. CI fails if a count EXCEEDS its baseline (a regression). When you fix errors and a count drops, lower the matching number here so the ratchet keeps the gain. The packages/* entries are 0 — born clean, so for them this is a hard gate. See agentGuides/testingAndCiSetup.md and .github/scripts/ratchet.sh.",
-  "buildinlime": { "typecheck": 124, "lint": 186 },
+  "buildinlime": { "typecheck": 117, "lint": 186 },
   "buildinlimemobile": { "typecheck": 33, "lint": 1 },
   "@buildinlime/contracts": { "typecheck": 0 },
   "@buildinlime/sync-core": { "typecheck": 0 },

--- a/web-app/code/src/presentation/components/buildInlime/Header.tsx
+++ b/web-app/code/src/presentation/components/buildInlime/Header.tsx
@@ -13,12 +13,20 @@ export function Header() {
 
       {/* CTA Buttons */}
       <div className="flex items-center gap-[16px]">
-        <Link to="/login" className={HEADER_LINK_CLASS} style={HEADER_LINK_STYLE}>
+        {/* /login's validateSearch returns both fields, so Link requires both —
+            it defaults them at runtime, and the validated URL carries them
+            either way, so stating them here changes nothing but the types. */}
+        <Link
+          to="/login"
+          search={{ returnTo: "/", mode: "login" }}
+          className={HEADER_LINK_CLASS}
+          style={HEADER_LINK_STYLE}
+        >
           Login
         </Link>
         <Link
           to="/login"
-          search={{ mode: "signup" }}
+          search={{ returnTo: "/", mode: "signup" }}
           className="bg-primary hover:bg-primary-hover text-white px-[24px] py-[12px] rounded-[10px] font-['Instrument_Sans',sans-serif] font-medium text-[16px] transition-colors"
           style={HEADER_LINK_STYLE}
         >

--- a/web-app/code/src/presentation/components/buildInlime/organization/ChannelCard.tsx
+++ b/web-app/code/src/presentation/components/buildInlime/organization/ChannelCard.tsx
@@ -7,7 +7,20 @@ interface ChannelCardProps {
   icon: LucideIcon;
   title: string;
   description: string;
-  to?: string;
+  /**
+   * Route params for the channel this card opens. Absent for a pending (ghost)
+   * channel, which has no route to point at yet.
+   *
+   * These are the router's own params rather than a pre-built URL string: the
+   * card used to take `to: string` and render `<Link href={to}>`, which is not a
+   * prop TanStack's Link accepts — it computes `href` from `to`/`params` and
+   * overwrites whatever was passed, so the interpolated URL was discarded.
+   */
+  linkParams?: {
+    projectId: string;
+    buildUnitName: string;
+    channelName: string;
+  };
   onClick?: () => void;
   isPending?: boolean;
   properties?: Property[];
@@ -17,7 +30,7 @@ export function ChannelCard({
   icon: Icon,
   title,
   description,
-  to,
+  linkParams,
   onClick,
   isPending,
   properties,
@@ -56,10 +69,11 @@ export function ChannelCard({
     </>
   );
 
-  if (to && !isPending) {
+  if (linkParams && !isPending) {
     return (
       <Link
-        href={to}
+        to="/projects/$projectId/$buildUnitName/$channelName"
+        params={linkParams}
         className="bg-card-surface border border-card-border rounded-lg p-4 hover:bg-icon-chip transition-colors cursor-pointer block"
       >
         {content}

--- a/web-app/code/src/presentation/components/buildInlime/organization/ChannelsSection.tsx
+++ b/web-app/code/src/presentation/components/buildInlime/organization/ChannelsSection.tsx
@@ -10,7 +10,8 @@ export interface Channel {
   title: string;
   description: string;
   isPending?: boolean;
-  to?: string;
+  /** Route params for the channel page; absent while the channel is pending. */
+  linkParams?: { projectId: string; buildUnitName: string; channelName: string };
   onClick?: () => void;
   properties?: Property[];
 }
@@ -47,7 +48,7 @@ export function ChannelsSection({ channels, buildUnitId, pendingIds, addPending,
             icon={channel.icon}
             title={channel.title}
             description={channel.description}
-            to={channel.to}
+            linkParams={channel.linkParams}
             onClick={channel.onClick}
             isPending={pendingIds.has(channel.id)}
             properties={channel.properties}

--- a/web-app/code/src/presentation/components/buildInlime/task/TaskPageHeader.tsx
+++ b/web-app/code/src/presentation/components/buildInlime/task/TaskPageHeader.tsx
@@ -41,14 +41,16 @@ export function TaskPageHeader({
           </Link>
           <ChevronRight className="w-4 h-4" />
           <Link
-            href={`/projects/${projectId}/${buildUnitName}`}
+            to="/projects/$projectId/$buildUnitName"
+            params={{ projectId, buildUnitName }}
             className="hover:text-foreground transition-colors"
           >
             {buildUnitName}
           </Link>
           <ChevronRight className="w-4 h-4" />
           <Link
-            href={`/projects/${projectId}/${buildUnitName}/${channelName}`}
+            to="/projects/$projectId/$buildUnitName/$channelName"
+            params={{ projectId, buildUnitName, channelName }}
             className="hover:text-foreground transition-colors"
           >
             {channelName}

--- a/web-app/code/src/presentation/hooks/use-build-unit-channels.ts
+++ b/web-app/code/src/presentation/hooks/use-build-unit-channels.ts
@@ -69,7 +69,7 @@ export function useBuildUnitChannels(buildUnitId: string, projectId: string, bui
       title: name,
       description: channel.description ?? '',
       icon: CHANNEL_ICONS[name] ?? ClipboardCheck,
-      to: `/projects/${projectId}/${buildUnitName}/${name}`,
+      linkParams: { projectId, buildUnitName, channelName: name },
       properties: channelPropsByEntity.get(channel.id as string) ?? [],
     }
   })
@@ -83,7 +83,7 @@ export function useBuildUnitChannels(buildUnitId: string, projectId: string, bui
       title: p.name as typeof CHANNEL_NAMES[number],
       description: p.description ?? '',
       icon: CHANNEL_ICONS[p.name as typeof CHANNEL_NAMES[number]] ?? ClipboardCheck,
-      to: undefined,
+      linkParams: undefined,
       properties: [],
     }))
 

--- a/web-app/code/src/presentation/hooks/use-project-build-units.ts
+++ b/web-app/code/src/presentation/hooks/use-project-build-units.ts
@@ -93,10 +93,12 @@ export function useProjectBuildUnits(projectId: string) {
   const buildUnits = [...dbBuildUnits, ...ghostRows]
 
   const onBuildUnitClick = (buildUnit: { id: string; name: string; desc: string }) => {
+    // No `state` payload: nothing in the app reads router/history state, and
+    // these three keys were never consumed anywhere. The destination re-derives
+    // what it needs from the URL params and its own live queries.
     navigate({
       to: "/projects/$projectId/$buildUnitName",
       params: { projectId, buildUnitName: buildUnit.name },
-      state: { buildUnitId: buildUnit.id, unitDescription: buildUnit.desc, projectName },
     })
   }
 

--- a/web-app/code/src/presentation/routes/_authenticated/projects/index.tsx
+++ b/web-app/code/src/presentation/routes/_authenticated/projects/index.tsx
@@ -39,7 +39,8 @@ function ProjectsRoute() {
   })
 
   const onProjectClick = (project: { id: string; name: string }) => {
-    navigate({ to: '/projects/$projectId', params: { projectId: project.id }, state: { projectName: project.name } })
+    // `state: { projectName }` removed — never read; see use-project-build-units.
+    navigate({ to: '/projects/$projectId', params: { projectId: project.id } })
   }
 
 return (


### PR DESCRIPTION
Phase 2 of the typecheck burn-down, following #41. **124 → 117.**

Intended for #41, but that merged while this was being written, so it lands as its own PR.

## Triage was the point, and most of the batch was deliberately skipped

Phase 2's scope was the 15 files carrying only one or two errors. They split cleanly in two:

- **Symptoms of the untyped-row root cause** — anything whose message contains `unknown`, `{}` or `$synced`. **Left alone on purpose.** Fixing these now means casts that the Phase 3 repair deletes again, so they are churn with a review cost and no lasting gain.
- **Router/Link typing** — genuinely independent of rows. That is what this PR fixes, and it turned out not to be cosmetic.

## `<Link href={...}>` never navigated

`href` is not a prop TanStack's `Link` accepts. It computes `href` from `to`/`params` and assigns it **after** spreading user props (`@tanstack/react-router/dist/esm/link.js:355`), so a passed `href` is overwritten. With `to` undefined, `buildLocation` falls back to the **current** location — the interpolated destination was simply discarded.

Affected: the build-unit and channel breadcrumbs on the task page, and every channel card on a build-unit page.

The clearest evidence these were mistakes rather than an intentional pattern: `TaskPageHeader`'s **first** breadcrumb already uses `to` + `params` correctly. The two directly beneath it did not.

| Fixed | Change |
| --- | --- |
| `TaskPageHeader` | Two breadcrumbs → `to` + `params`, matching the first one in the same file |
| `ChannelCard` | Took `to?: string` and built `<Link href={to}>`. Now takes the route's own params (`linkParams`), threaded through `ChannelsSection` from `use-build-unit-channels`, which had been interpolating the URL by hand. A pending ghost channel passes none, as before. |

## Two more from the same triage group

- **`Header`** — `/login`'s `validateSearch` returns both `returnTo` and `mode`, so `Link` requires both. It defaults them at runtime and the validated URL carries them regardless, so this is a types-only change.
- **Dead `state` payloads** — `navigate({ state: {...} })` in `use-project-build-units` and `projects/index`. Nothing in the app reads router or history state *anywhere*; these were write-only. Deleted, rather than augmenting `HistoryState` to legitimise data with no consumer.

## Verification

- **117** typecheck errors; baseline lowered to 117 in the same commit
- 77 tests pass, lint flat at 186, `pnpm build` succeeds, ratchet green on all seven pairs
- The one apparent "new" error in `use-build-unit-channels` is the message-text trap: the same pre-existing untyped-row error, re-worded because the object literal now carries `linkParams` instead of `to`. Its count is unchanged at 1.

**Not verified in a browser.** The claim that these links were dead comes from reading TanStack's `Link` source, not from clicking them — reaching those screens needs an authenticated session. The `to` + `params` form is correct either way, but that distinction between observed and inferred is worth keeping. Clicking a channel card and a task breadcrumb would settle it.

## Next

Phase 3 is the root cause: `CollectionSpec.schema` is `unknown` and `defineCollection` ends in `createCollection(... as any)`, so every collection's rows are untyped. It is not a subtraction — three attempts while sizing it produced 236, 302 and 258 errors against a 137 baseline, because downstream code is written against untyped rows. ARCHITECTURE §12.8 records the approach: explicit type arguments, one collection plus its consumers per commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01P4q8GDpkCCCuaqgdeoThDU
