### PR TITLE
fix(web): burn down the post-typing errors (typecheck 37 → 14, lint 195 → 180)

### DIFF
--- a/.github/quality-baseline.json
+++ b/.github/quality-baseline.json
@@ -1,6 +1,6 @@
 {
   "_comment": "Ratchet baselines: max tolerated typecheck/lint ERROR counts per workspace. CI fails if a count EXCEEDS its baseline (a regression). When you fix errors and a count drops, lower the matching number here so the ratchet keeps the gain. The packages/* entries are 0 — born clean, so for them this is a hard gate. See agentGuides/testingAndCiSetup.md and .github/scripts/ratchet.sh.",
-  "buildinlime": { "typecheck": 37, "lint": 195 },
+  "buildinlime": { "typecheck": 14, "lint": 180 },
   "buildinlimemobile": { "typecheck": 33, "lint": 1 },
   "@buildinlime/contracts": { "typecheck": 0 },
   "@buildinlime/sync-core": { "typecheck": 0 },

--- a/web-app/code/src/infrastructure/trpc/routers/users.ts
+++ b/web-app/code/src/infrastructure/trpc/routers/users.ts
@@ -37,7 +37,7 @@ export const usersRouter = router({
           updatedAt: now,
         })
         .returning({ id: users.id })
-      return { userId: created!.id }
+      return { userId: created.id }
     }),
 
   create: authedProcedure.input(z.any()).mutation(async () => {

--- a/web-app/code/src/presentation/components/buildInlime/admin/BuildUnitsNav.tsx
+++ b/web-app/code/src/presentation/components/buildInlime/admin/BuildUnitsNav.tsx
@@ -80,7 +80,7 @@ export function BuildUnitsNav({
                           return (
                             <Link
                               key={ch.id}
-                              to="/projects/$projectId/$buildUnitName/$channelName/"
+                              to="/projects/$projectId/$buildUnitName/$channelName"
                               params={{ projectId, buildUnitName: bu.name, channelName }}
                               className="flex items-center gap-1.5 px-2 py-1.5 text-sm text-muted-foreground hover:text-foreground hover:bg-icon-chip rounded transition-colors"
                             >

--- a/web-app/code/src/presentation/components/buildInlime/admin/SidebarProjects.tsx
+++ b/web-app/code/src/presentation/components/buildInlime/admin/SidebarProjects.tsx
@@ -1,5 +1,3 @@
-import { useState } from "react";
-import { ChevronDown, ChevronRight } from "lucide-react";
 import { UserInfo } from "./UserInfo";
 import { InboxNav } from "./InboxNav";
 import { MyTasksNav } from "./MyTasksNav";
@@ -11,7 +9,10 @@ export interface SidebarProjectsProps {
   buildUnitsNavActive?: boolean;
 }
 
-export function SidebarProjects({ buildUnitsNavTo, buildUnitsNavActive }: SidebarProjectsProps) {
+// NOTE: nothing renders this today — it is only re-exported from the barrel.
+// Props are declared but unused; kept rather than deleted because removing a UI
+// component is a product call, not a typecheck one.
+export function SidebarProjects(_props: SidebarProjectsProps) {
   return (
     <aside className="w-60 bg-card-surface border-r border-card-border flex flex-col">
       {/* User info */}

--- a/web-app/code/src/presentation/components/buildInlime/communication/ActivityPanel.tsx
+++ b/web-app/code/src/presentation/components/buildInlime/communication/ActivityPanel.tsx
@@ -8,7 +8,7 @@ export interface ActivityItem {
   date: string;
 }
 
-interface ActivityPanelProps {
+export interface ActivityPanelProps {
   activities: ActivityItem[];
   onSeeAll?: () => void;
 }

--- a/web-app/code/src/presentation/components/buildInlime/communication/AddTaskButton.tsx
+++ b/web-app/code/src/presentation/components/buildInlime/communication/AddTaskButton.tsx
@@ -1,6 +1,6 @@
 import { CalendarClock, UserPlus } from "lucide-react";
 
-interface AddTaskButtonProps {
+export interface AddTaskButtonProps {
   onClick?: () => void;
   onAddPeople?: () => void;
 }

--- a/web-app/code/src/presentation/components/buildInlime/communication/ResourcesSection.tsx
+++ b/web-app/code/src/presentation/components/buildInlime/communication/ResourcesSection.tsx
@@ -135,7 +135,7 @@ export function ResourcesSection({
             <SyncedResourceRow
               key={r.id}
               resource={r}
-              canDelete={canDelete(r.createdby_id as string)}
+              canDelete={canDelete(r.createdby_id)}
               onDelete={(id) => deleteResourceAction({ id })}
             />
           ))}

--- a/web-app/code/src/presentation/components/buildInlime/communication/TaskStatusSection.tsx
+++ b/web-app/code/src/presentation/components/buildInlime/communication/TaskStatusSection.tsx
@@ -183,15 +183,15 @@ export function TaskStatusSection({
           ) : (
             history.map((m) => (
               <div
-                key={m.id as string}
+                key={m.id}
                 className="border border-gray-200 rounded px-3 py-2"
               >
                 {/* Shown verbatim: it is the same message the channel shows, and
                     re-parsing our own wording back apart would be a data model
                     made of prose. */}
-                <p className="text-sm text-foreground">{m.text as string}</p>
+                <p className="text-sm text-foreground">{m.text}</p>
                 <p className="text-xs text-muted-foreground mt-0.5">
-                  {authorName(m.createdby_id as string)} ·{" "}
+                  {authorName(m.createdby_id)} ·{" "}
                   {formatDateTime(m.created_at as string)}
                 </p>
               </div>

--- a/web-app/code/src/presentation/components/buildInlime/index.tsx
+++ b/web-app/code/src/presentation/components/buildInlime/index.tsx
@@ -59,7 +59,8 @@ export { Header } from "./Header";
 export { Hero } from "./Hero";
 export { LoginCard } from "./LoginCard";
 export { LoginDecorativeImage } from "./LoginDecorativeImage";
-export { LoginForm, type LoginFormProps } from "./LoginForm";
+// LoginForm takes no props — it reads its mode from the route search.
+export { LoginForm } from "./LoginForm";
 export { LoginHeader } from "./LoginHeader";
 export { LoginTerms } from "./LoginTerms";
 export { NavButton } from "./NavButton";

--- a/web-app/code/src/presentation/components/buildInlime/organization/ChannelHeader.tsx
+++ b/web-app/code/src/presentation/components/buildInlime/organization/ChannelHeader.tsx
@@ -1,6 +1,6 @@
 import type { LucideIcon } from "lucide-react";
 
-interface ChannelHeaderProps {
+export interface ChannelHeaderProps {
   icon: LucideIcon;
   title: string;
   description: string;

--- a/web-app/code/src/presentation/components/buildInlime/organization/ChannelsSection.tsx
+++ b/web-app/code/src/presentation/components/buildInlime/organization/ChannelsSection.tsx
@@ -16,7 +16,7 @@ export interface Channel {
   properties?: Property[];
 }
 
-interface ChannelsSectionProps {
+export interface ChannelsSectionProps {
   channels: Channel[];
   buildUnitId: string;
   pendingIds: Set<string>;

--- a/web-app/code/src/presentation/components/buildInlime/organization/ProjectHeader.tsx
+++ b/web-app/code/src/presentation/components/buildInlime/organization/ProjectHeader.tsx
@@ -1,7 +1,7 @@
 import { Boxes } from "lucide-react";
 import type { LucideIcon } from "lucide-react";
 
-interface ProjectHeaderProps {
+export interface ProjectHeaderProps {
   title: string;
   description: string;
   icon?: LucideIcon;

--- a/web-app/code/src/presentation/hooks/use-build-unit-channels.ts
+++ b/web-app/code/src/presentation/hooks/use-build-unit-channels.ts
@@ -2,7 +2,7 @@ import { useEffect, useCallback, useRef } from 'react'
 import { useLiveQuery, eq, inArray } from "@tanstack/react-db"
 import { ClipboardCheck } from 'lucide-react'
 import { channelsCollection, propertiesCollection } from '%/infrastructure/database/tanstack-db-electric/admincollections'
-import { CHANNEL_NAMES } from '%/domain/shared/types'
+import type { CHANNEL_NAMES } from '%/domain/shared/types'
 import { CHANNEL_ICONS } from '%/presentation/lib/channelIcons'
 import { unwrapJsonb, mapPropertyRow } from '%/presentation/lib/utils'
 import { usePendingItems } from './use-pending-items'
@@ -63,14 +63,16 @@ export function useBuildUnitChannels(buildUnitId: string, projectId: string, bui
   }
 
   const dbChannelList: Channel[] = (dbChannels ?? []).map((channel) => {
-    const name = unwrapJsonb(channel.name as unknown as string) as typeof CHANNEL_NAMES[number]
+    // Type argument rather than a trailing cast: CHANNEL_ICONS is keyed by the
+    // channel-name union, so `string` cannot index it.
+    const name = unwrapJsonb<typeof CHANNEL_NAMES[number]>(channel.name)
     return {
       id: channel.id,
       title: name,
       description: channel.description ?? '',
       icon: CHANNEL_ICONS[name] ?? ClipboardCheck,
       linkParams: { projectId, buildUnitName, channelName: name },
-      properties: channelPropsByEntity.get(channel.id as string) ?? [],
+      properties: channelPropsByEntity.get(channel.id) ?? [],
     }
   })
 

--- a/web-app/code/src/presentation/hooks/use-channel-route.ts
+++ b/web-app/code/src/presentation/hooks/use-channel-route.ts
@@ -19,10 +19,10 @@ export function useChannelRoute(buildUnitId: string, channelId: string) {
   const mapProperties = (rawList: typeof dbChannelProperties): Property[] =>
     (rawList ?? []).map((p) => ({
       ...p,
-      type: unwrapJsonb(p.type) as Property['type'],
-      entity: unwrapJsonb(p.entity) as Property['entity'],
-      status_value: unwrapJsonb(p.status_value) as Property['status_value'],
-      priority_value: unwrapJsonb(p.priority_value) as Property['priority_value'],
+      type: unwrapJsonb(p.type),
+      entity: unwrapJsonb(p.entity),
+      status_value: unwrapJsonb(p.status_value),
+      priority_value: unwrapJsonb(p.priority_value),
     }))
 
   return {

--- a/web-app/code/src/presentation/hooks/use-inbox-page.ts
+++ b/web-app/code/src/presentation/hooks/use-inbox-page.ts
@@ -45,12 +45,15 @@ export function useInboxPage() {
     const buildUnit = getBuildUnit(msg.buildunit_id)
     const channel = getChannel(msg.channel_id)
     if (!buildUnit || !channel) return
+    // Bound before the call: inferring through the params union picks `undefined`
+    // for the generic rather than its `string` default.
+    const channelName = unwrapJsonb(channel.name)
     navigate({
-      to: "/projects/$projectId/$buildUnitName/$channelName/",
+      to: "/projects/$projectId/$buildUnitName/$channelName",
       params: {
         projectId: msg.project_id,
         buildUnitName: buildUnit.name,
-        channelName: unwrapJsonb(channel.name),
+        channelName,
       },
       // Carry the message id so the channel can scroll to it. Without this the
       // Inbox only ever landed you at the top of the channel, leaving you to

--- a/web-app/code/src/presentation/hooks/use-project-build-units.ts
+++ b/web-app/code/src/presentation/hooks/use-project-build-units.ts
@@ -61,10 +61,10 @@ export function useProjectBuildUnits(projectId: string) {
   const dbBuildUnits = (buildUnitsFromDB ?? []).map((bu) => ({
     id: bu.id,
     name: bu.name,
-    description: bu.descritption,
-    properties: propertiesByEntity.get(bu.id as string) ?? [],
-    health: (bu.health ?? "On track") as "On track" | "At risk" | "Off track",
-    priority: (bu.priority ?? "Low") as "High" | "Mid" | "Low",
+    description: bu.description,
+    properties: propertiesByEntity.get(bu.id) ?? [],
+    health: (bu.health ?? "On track"),
+    priority: (bu.priority ?? "Low"),
     waitingOnTask: {
       name: bu.task_name ?? "—",
       assignee: bu.task_assignee ?? "—",
@@ -92,7 +92,10 @@ export function useProjectBuildUnits(projectId: string) {
 
   const buildUnits = [...dbBuildUnits, ...ghostRows]
 
-  const onBuildUnitClick = (buildUnit: { id: string; name: string; desc: string }) => {
+  // Takes only what it reads. It previously declared `desc`, a field the build
+  // unit rows do not have (they carry `description`), so no caller's object was
+  // ever assignable — invisible while the rows were untyped.
+  const onBuildUnitClick = (buildUnit: { name: string }) => {
     // No `state` payload: nothing in the app reads router/history state, and
     // these three keys were never consumed anywhere. The destination re-derives
     // what it needs from the URL params and its own live queries.

--- a/web-app/code/src/presentation/hooks/use-task-route.ts
+++ b/web-app/code/src/presentation/hooks/use-task-route.ts
@@ -57,11 +57,11 @@ export function useTaskRoute(channelId: string, taskName: string) {
 
   const properties: Property[] = (dbTaskProperties ?? []).map((p) => ({
     ...p,
-    type: unwrapJsonb(p.type) as Property['type'],
-    entity: unwrapJsonb(p.entity) as Property['entity'],
-    status_value: unwrapJsonb(p.status_value) as Property['status_value'],
-    priority_value: unwrapJsonb(p.priority_value) as Property['priority_value'],
-    task_status_value: unwrapJsonb(p.task_status_value) as Property['task_status_value'],
+    type: unwrapJsonb(p.type),
+    entity: unwrapJsonb(p.entity),
+    status_value: unwrapJsonb(p.status_value),
+    priority_value: unwrapJsonb(p.priority_value),
+    task_status_value: unwrapJsonb(p.task_status_value),
   }))
 
   return {
@@ -77,7 +77,7 @@ export function useTaskRoute(channelId: string, taskName: string) {
     currentAssigneeId,
     currentUserId,
     createdByName,
-    createdAt: task.opened_at as Date | string | undefined,
+    createdAt: task.opened_at,
     // Only the creator may assign — mirrored by a FORBIDDEN check in tasks.update.
     canAssign: !!createdById && createdById === currentUserId,
   }

--- a/web-app/code/src/presentation/lib/utils.ts
+++ b/web-app/code/src/presentation/lib/utils.ts
@@ -7,11 +7,26 @@ export function cn(...inputs: ClassValue[]) {
   return twMerge(clsx(inputs))
 }
 
-// Electric SQL returns jsonb columns as JSON-encoded strings (e.g. '"critical"').
-// This unwraps them to their actual value.
-export function unwrapJsonb(v: unknown): unknown {
-  return typeof v === 'string' && v.startsWith('"') ? JSON.parse(v) : v
-}
+// Re-exported, not redefined. This file used to carry its OWN copy returning
+// `unknown` — a third implementation alongside the one in @buildinlime/contracts
+// that sync-core re-exports — so every unwrapped jsonb value arrived untyped in
+// the presentation layer and had to be cast at each call site. The shared one is
+// generic (defaulting to string, which every jsonb column here holds).
+// One implementation, typed at the UI boundary.
+//
+// This file used to carry its OWN copy — a third alongside contracts' and the
+// sync-core re-export — which returned `unknown`, so every unwrapped jsonb value
+// arrived untyped and was cast at each call site.
+//
+// The generic lives HERE rather than on the shared function on purpose: that one
+// is passed to `z.preprocess(...)` inside the row schemas, and making it generic
+// changes what those schemas infer. Presentation gets the convenient type; the
+// schemas keep the function they were written against.
+import { unwrapJsonb as unwrapJsonbRaw } from '@buildinlime/contracts'
+
+/** Unwraps a jsonb column. Defaults to `string` — every jsonb column here is a
+ *  string enum. Pass an explicit type argument for anything else. */
+export const unwrapJsonb = <T = string>(v: unknown): T => unwrapJsonbRaw(v) as T
 
 // Turns a raw properties-collection row (jsonb columns still wrapped) into a
 // Property the pill/icon display can read. Shared by the hooks that surface

--- a/web-app/code/src/presentation/routes/_authenticated/projects/index.tsx
+++ b/web-app/code/src/presentation/routes/_authenticated/projects/index.tsx
@@ -1,11 +1,9 @@
 import { createFileRoute, useNavigate } from '@tanstack/react-router'
-import { Sidebar } from "../../../components/buildInlime";
-import { NewProjectButton } from "../../../components/buildInlime";
-//import { DisplayButton } from "../../../components/buildInlime";
-//import { FilterButton } from "../../../components/buildInlime";
+import { Sidebar, NewProjectButton , RoutePendingComponent  } from "../../../components/buildInlime";
+// import { DisplayButton } from "../../../components/buildInlime";
+// import { FilterButton } from "../../../components/buildInlime";
 import { ProjectsTable } from "../../../components/buildInlime";
 import { projectsCollection, usersCollection } from '%/infrastructure/database/tanstack-db-electric/admincollections'
-import { RoutePendingComponent } from "../../../components/buildInlime";
 
 import { useLiveQuery } from "@tanstack/react-db"
 
@@ -34,7 +32,7 @@ function ProjectsRoute() {
       id: p.id,
       name: p.name,
       createdBy: creator?.name || creator?.email || "Unknown",
-      createdAt: p.created_at ? new Date(p.created_at as string | Date).toLocaleDateString() : "—",
+      createdAt: p.created_at ? new Date(p.created_at).toLocaleDateString() : "—",
     }
   })
 


### PR DESCRIPTION
Phase 3b, following #43. **typecheck 37 → 14, lint 195 → 180.**

That puts the burn-down at **137 → 14 overall, a 90% reduction**, with tests up from 31 to 92 across the series.

## Two live bugs the typing exposed

This is the payoff from #43, and the argument for having done it:

- **`bu.descritption`** in `use-project-build-units` — a typo. **Build unit descriptions have been silently `undefined` on the projects page.** With rows untyped, any property name compiled.
- **`onBuildUnitClick(buildUnit: { id, name, desc })`** in the same file declared a `desc` field the rows do not have (they carry `description`), so no caller's object was ever assignable. It only ever reads `name`, so it now asks for exactly that.

Both trailing-slash route literals are also fixed — BuildUnitsNav's sidebar channel link and use-inbox-page's mention navigation pointed at `/projects/$projectId/$buildUnitName/$channelName/`, which is not in the generated route union. Whether TanStack normalises that at runtime depends on its `trailingSlash` default, which this router does not set; either way the declared literal is the correct one. Same bug class as #42, now cleared at the last two sites.

## A third copy of `unwrapJsonb`

`presentation/lib/utils.ts` carried its own implementation returning `unknown` — alongside the one in `@buildinlime/contracts` and sync-core's re-export. That is *why* unwrapped jsonb values arrived untyped in the UI and were cast at each call site. It now re-exports the shared implementation behind a generic defaulting to `string` (every jsonb column here holds a string enum).

**The generic deliberately lives at the UI boundary, not on the shared function.** Making the contracts one generic looked tidier and broke schema inference: it is passed to `z.preprocess(...)` inside the row schemas, and `channelRowSchema`'s `name` started inferring as `undefined`. Reverted — presentation gets the convenient type, the schemas keep the function they were written against.

## Lint went DOWN, which closes the loose end from #43

#43 had to raise the lint baseline 186 → 195, because typing rows makes `unknown`-coping code provably dead. Most of that turns out to be auto-fixable — `no-unnecessary-type-assertion` on casts that existed only to launder `unknown` — so this runs the fixer over the affected files:

| | lint errors |
| --- | ---: |
| before the burn-down | 186 |
| after #43 (rows typed) | 195 |
| **this PR** | **180** |

The fixer did strip one **load-bearing** cast — `CHANNEL_ICONS` is keyed by the channel-name union and `string` cannot index it — which typecheck caught immediately. It is now expressed as a type argument, a better form than the `as unknown as string … as typeof CHANNEL_NAMES[number]` it replaced.

## Smaller items

- Five props interfaces the barrel already advertised were declared but never exported; `LoginForm` has no props at all, so that re-export was dropped.
- `SidebarProjects` had unused imports, props and destructuring. **Nothing renders it** — it is only re-exported from the barrel. Cleaned and flagged rather than deleted, because removing a UI component is a product call, not a typecheck one.

## Verification

92 tests pass, `pnpm build` succeeds, ratchet green on all seven pairs, baselines lowered to **14 / 180**.

## What's left (14), and the decision it needs

These are not mechanical, which is why they stop here rather than getting cast away:

- **Domain-vs-wire types** — components declare domain types (`Task`, `Property`, `Message`) while receiving wire rows (`TaskRow`, `PropertyRow`, `MessageRow`). Either the components adopt the wire types, or there is an explicit mapping layer at the boundary. That is an architectural call worth making deliberately, and once made most of these collapse together.
- Three router-typing errors in `_authenticated.tsx` (redirect/navigate option shapes).
- The unreachable `status: 'loading'` recorded in §12.8: `useLiveQuery`'s `data` is a getter over `collection.entries()` and never undefined, so the loading state `use-build-unit-channels` returns is dead — while two routes still branch on it. A behavioural fix, not a typing one.

**Mobile still has the untyped collections** and its own 33 errors; the same #43 change applies there and has not been made.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01P4q8GDpkCCCuaqgdeoThDU
