### PR TITLE
fix(mobile): give every collection a real row type (typecheck 33 → 6)

### DIFF
--- a/.github/quality-baseline.json
+++ b/.github/quality-baseline.json
@@ -1,7 +1,7 @@
 {
   "_comment": "Ratchet baselines: max tolerated typecheck/lint ERROR counts per workspace. CI fails if a count EXCEEDS its baseline (a regression). When you fix errors and a count drops, lower the matching number here so the ratchet keeps the gain. The packages/* entries are 0 — born clean, so for them this is a hard gate. See agentGuides/testingAndCiSetup.md and .github/scripts/ratchet.sh.",
   "buildinlime": { "typecheck": 37, "lint": 195 },
-  "buildinlimemobile": { "typecheck": 33, "lint": 1 },
+  "buildinlimemobile": { "typecheck": 6, "lint": 1 },
   "@buildinlime/contracts": { "typecheck": 0 },
   "@buildinlime/sync-core": { "typecheck": 0 },
   "@buildinlime/domain-types": { "typecheck": 0 }

--- a/mobile-app/src/application/collections/_shared.ts
+++ b/mobile-app/src/application/collections/_shared.ts
@@ -3,6 +3,7 @@
 // the collection factory itself live once in @buildinlime/sync-core; this file
 // injects the mobile platform primitives and re-exports the result.
 import { createCollection } from "@tanstack/react-db"
+import type { Collection } from "@tanstack/react-db"
 import { electricCollectionOptions } from "@tanstack/electric-db-collection"
 import { persistedCollectionOptions } from "@tanstack/expo-db-sqlite-persistence"
 import { makeShapeRetry, makeCollectionOptionsBuilder } from "@buildinlime/sync-core"
@@ -77,9 +78,17 @@ const buildCollectionOptions = makeCollectionOptionsBuilder({
  * collection must share one, or the persistence adapter cache forks.
  *
  * The `as any` is the same one that used to sit at every collection site: the
- * builders' options types don't compose, and createCollection is what recovers a
- * properly typed Collection from it.
+ * builders' options types don't compose, so the row type has to be stated by the
+ * caller rather than inferred: sync-core types the injected tanstack builders as
+ * `(config: never) => object` on purpose (web and mobile inject different
+ * persistence packages), so buildCollectionOptions returns a bare `object` and
+ * there is nothing left to infer from. Note also that createCollection's FIRST
+ * type parameter is the schema, not the row — passing a row type there yields a
+ * garbage row type rather than an error. Mirrors web's _shared.ts.
+ *
+ * TRow must match the spec's schema; both come from @buildinlime/contracts, so
+ * they agree by construction, but the assertion does not verify it.
  */
-export const defineCollection = (spec: CollectionSpec) =>
+export const defineCollection = <TRow extends object>(spec: CollectionSpec) =>
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  createCollection(buildCollectionOptions(spec) as any)
+  createCollection(buildCollectionOptions(spec) as any) as unknown as Collection<TRow, string>

--- a/mobile-app/src/application/collections/admin.ts
+++ b/mobile-app/src/application/collections/admin.ts
@@ -1,3 +1,4 @@
+import type { UserRow } from "@buildinlime/contracts"
 import { usersSpec } from "@buildinlime/sync-core"
 import { getPersistence } from "../../infrastructure/persistence/expo-persistence"
 import { defineCollection, safeCleanup } from "./_shared"
@@ -16,7 +17,7 @@ import { defineCollection, safeCleanup } from "./_shared"
 function _makeUsersCollection(
   persistence: ReturnType<typeof getPersistence>["persistence"],
 ) {
-  return defineCollection({ ...usersSpec(), persistence })
+  return defineCollection<UserRow>({ ...usersSpec(), persistence })
 }
 
 // ---------------------------------------------------------------------------

--- a/mobile-app/src/application/collections/communication.ts
+++ b/mobile-app/src/application/collections/communication.ts
@@ -1,3 +1,4 @@
+import type { MessageRow, PropertyRow, ResourceRow, SeenStateRow, TaskRow } from "@buildinlime/contracts"
 import {
   tasksSpec,
   messagesSpec,
@@ -31,7 +32,7 @@ function _makeTasksCollection(
 ) {
   // No handlers — writes routed through @tanstack/offline-transactions
   // (see application/actions/tasks.ts).
-  return defineCollection({ ...tasksSpec(memberChannelIds), persistence })
+  return defineCollection<TaskRow>({ ...tasksSpec(memberChannelIds), persistence })
 }
 
 function _makeMessagesCollection(
@@ -44,7 +45,7 @@ function _makeMessagesCollection(
   // (the row survives so its replies keep a parent) — see deleteMessageAction. A
   // delete handler here would let messagesCollection.delete() drop the row
   // optimistically and orphan the thread. With none it fails loudly instead.
-  return defineCollection({ ...messagesSpec(memberChannelIds), persistence })
+  return defineCollection<MessageRow>({ ...messagesSpec(memberChannelIds), persistence })
 }
 
 function _makeResourcesCollection(
@@ -53,7 +54,7 @@ function _makeResourcesCollection(
 ) {
   // No handlers — onDelete routed through @tanstack/offline-transactions
   // (see application/actions/resources.ts → deleteResourceAction).
-  return defineCollection({ ...resourcesSpec(memberChannelIds), persistence })
+  return defineCollection<ResourceRow>({ ...resourcesSpec(memberChannelIds), persistence })
 }
 
 function _makePropertiesCollection(
@@ -64,7 +65,7 @@ function _makePropertiesCollection(
     memberChannelIds: string[]
   },
 ) {
-  return defineCollection({
+  return defineCollection<PropertyRow>({
     ...propertiesSpec(params),
     persistence,
     handlers: {
@@ -120,20 +121,20 @@ function _makeInboxMentionsCollection(
   persistence: ReturnType<typeof getPersistence>["persistence"],
   memberChannelIds: string[],
 ) {
-  return defineCollection({ ...inboxMentionsSpec(memberChannelIds), persistence })
+  return defineCollection<MessageRow>({ ...inboxMentionsSpec(memberChannelIds), persistence })
 }
 
 function _makeMyTasksCollection(
   persistence: ReturnType<typeof getPersistence>["persistence"],
   memberChannelIds: string[],
 ) {
-  return defineCollection({ ...myTasksSpec(memberChannelIds), persistence })
+  return defineCollection<TaskRow>({ ...myTasksSpec(memberChannelIds), persistence })
 }
 
 function _makeSeenStateCollection(
   persistence: ReturnType<typeof getPersistence>["persistence"],
 ) {
-  return defineCollection({ ...seenStateSpec(), persistence })
+  return defineCollection<SeenStateRow>({ ...seenStateSpec(), persistence })
 }
 
 // ---------------------------------------------------------------------------

--- a/mobile-app/src/application/collections/organization.ts
+++ b/mobile-app/src/application/collections/organization.ts
@@ -1,3 +1,4 @@
+import type { BuildUnitRow, ChannelRow, MembershipRow, ProjectRow } from "@buildinlime/contracts"
 import {
   projectsSpec,
   buildUnitsSpec,
@@ -26,21 +27,21 @@ function _makeProjectsCollection(
   persistence: ReturnType<typeof getPersistence>["persistence"],
   memberProjectIds: string[],
 ) {
-  return defineCollection({ ...projectsSpec(memberProjectIds), persistence })
+  return defineCollection<ProjectRow>({ ...projectsSpec(memberProjectIds), persistence })
 }
 
 function _makeBuildUnitsCollection(
   persistence: ReturnType<typeof getPersistence>["persistence"],
   memberBuildunitIds: string[],
 ) {
-  return defineCollection({ ...buildUnitsSpec(memberBuildunitIds), persistence })
+  return defineCollection<BuildUnitRow>({ ...buildUnitsSpec(memberBuildunitIds), persistence })
 }
 
 function _makeChannelsCollection(
   persistence: ReturnType<typeof getPersistence>["persistence"],
   memberChannelIds: string[],
 ) {
-  return defineCollection({ ...channelsSpec(memberChannelIds), persistence })
+  return defineCollection<ChannelRow>({ ...channelsSpec(memberChannelIds), persistence })
 }
 
 /**
@@ -54,13 +55,13 @@ function _makeChannelMembersCollection(
   persistence: ReturnType<typeof getPersistence>["persistence"],
   memberChannelIds: string[],
 ) {
-  return defineCollection({ ...channelMembersSpec(memberChannelIds), persistence })
+  return defineCollection<MembershipRow>({ ...channelMembersSpec(memberChannelIds), persistence })
 }
 
 function _makeMembershipsCollection(
   persistence: ReturnType<typeof getPersistence>["persistence"],
 ) {
-  return defineCollection({
+  return defineCollection<MembershipRow>({
     ...membershipsSpec(),
     persistence,
     // Reports the error before retrying, so the bootstrap can tell a clean empty

--- a/packages/contracts/src/index.ts
+++ b/packages/contracts/src/index.ts
@@ -10,6 +10,7 @@ export * from "./schemas/organization"
 export * from "./schemas/teams"
 export * from "./schemas/communication"
 export * from "./schemas/seen"
+export * from "./schemas/users"
 // Type-only ON PURPOSE: mobile imports from this root, Metro does not tree-shake,
 // and a VALUE export of the router would drag @trpc/server's runtime (which throws
 // in non-server environments) into the RN bundle. The contractRouter value is

--- a/packages/contracts/src/router.ts
+++ b/packages/contracts/src/router.ts
@@ -1,4 +1,4 @@
-import { router, procedure, stub } from "./trpc"
+import { router, procedure, stub, stubOf } from "./trpc"
 import { createTaskInput, updateTaskInput, deleteTaskInput } from "./schemas/tasks"
 import {
   createProjectInput,
@@ -21,6 +21,7 @@ import {
   deletePropertyInput,
 } from "./schemas/communication"
 import { markSeenInput } from "./schemas/seen"
+import { checkEmailInput } from "./schemas/users"
 
 // The wire contract, expressed as a tRPC router so its `typeof` is a real
 // AppRouter the client can type its calls against. Procedure NAMES and namespaces
@@ -28,8 +29,10 @@ import { markSeenInput } from "./schemas/seen"
 // INPUT SCHEMAS are shared with the server, so those cannot drift.
 //
 // This covers the surface the MOBILE client calls (ARCHITECTURE.md §10). The web
-// client uses the server's own AppRouter directly, so web-only procedures
-// (channels.addMember/removeMember, users.*) are intentionally not mirrored here.
+// client uses the server's own AppRouter directly, so genuinely web-only
+// procedures (channels.addMember/removeMember, the rest of users.*) are not
+// mirrored here. `users.checkEmail` IS mirrored: mobile's login screen calls it,
+// and while it was excluded as "web-only" that call was untyped.
 export const contractRouter = router({
   tasks: router({
     create: procedure.input(createTaskInput).mutation(stub),
@@ -67,6 +70,9 @@ export const contractRouter = router({
     create: procedure.input(createPropertyInput).mutation(stub),
     update: procedure.input(updatePropertyInput).mutation(stub),
     delete: procedure.input(deletePropertyInput).mutation(stub),
+  }),
+  users: router({
+    checkEmail: procedure.input(checkEmailInput).query(stubOf<{ exists: boolean }>()),
   }),
   seen: router({
     markSeen: procedure.input(markSeenInput).mutation(stub),

--- a/packages/contracts/src/schemas/users.ts
+++ b/packages/contracts/src/schemas/users.ts
@@ -1,0 +1,14 @@
+import { z } from "zod"
+
+/**
+ * `users.checkEmail` — the pre-sign-in lookup the mobile login screen makes to
+ * decide whether to offer sign-in or registration.
+ *
+ * Lives here rather than inline in the server router because mobile calls this
+ * procedure, so it belongs to the shared wire contract: the contract router
+ * mirrors it, and both sides validate against this one schema. It was previously
+ * declared inline on the server and omitted from the contract as "web-only",
+ * which left mobile's call untyped (`Property 'users' does not exist on type
+ * TRPCClient<...>`) — the exact drift the contract exists to prevent.
+ */
+export const checkEmailInput = z.object({ email: z.string().email() })

--- a/packages/contracts/src/trpc.ts
+++ b/packages/contracts/src/trpc.ts
@@ -21,3 +21,18 @@ export type MutationResult = { item: unknown; txid: number }
 export const stub = (): MutationResult => {
   throw new Error("contract router is type-only and must not be invoked")
 }
+
+/**
+ * Stub for a procedure whose OUTPUT the client actually reads.
+ *
+ * The default `stub` above is mutation-shaped, and outputs are deliberately not
+ * pinned — clients don't consume `item`. Queries are different: a client that
+ * destructures the result needs its shape, or the call types as a mutation
+ * result and the field it wants "does not exist". `users.checkEmail` is the
+ * case that surfaced this.
+ */
+export const stubOf =
+  <T,>(): (() => T) =>
+  () => {
+    throw new Error("contract router is type-only and must not be invoked")
+  }

--- a/web-app/code/src/infrastructure/trpc/routers/users.ts
+++ b/web-app/code/src/infrastructure/trpc/routers/users.ts
@@ -1,3 +1,4 @@
+import { checkEmailInput } from "@buildinlime/contracts"
 import { router, authedProcedure, procedure } from "../lib/trpc"
 import { z } from "zod"
 import { TRPCError } from "@trpc/server"
@@ -6,7 +7,7 @@ import { users } from "../../database/schema/auth-schema"
 
 export const usersRouter = router({
   checkEmail: procedure
-    .input(z.object({ email: z.string().email() }))
+    .input(checkEmailInput)
     .query(async ({ ctx, input }) => {
       const [user] = await ctx.db
         .select({ id: users.id })


### PR DESCRIPTION
The mobile half of #43. **typecheck 33 → 6.**

Branched from `main`, so it is independent of the open web PR #44 — the only shared file is `.github/quality-baseline.json`, where this touches the `buildinlimemobile` entry only.

## Same fix, ported

Mobile had the identical four-layer erasure, so `defineCollection` now takes the row type explicitly and asserts it on the result. Inference genuinely cannot reach it: sync-core types the injected tanstack builders as `(config: never) => object` precisely so the two apps can inject different persistence packages, which leaves `buildCollectionOptions` returning a bare `object`.

All thirteen collections typed. 21 of the 33 errors were the `unknown`/`{}` class.

The stale comment claiming *"createCollection is what recovers a properly typed Collection from it"* is corrected here too — its first type parameter is the **schema**, not the row, so passing a row type yields a garbage row type rather than an error. That is the trap that cost three bad measurements before #43.

## A real contract gap, closed

Typing the rows surfaced something better than a type error. Mobile's login calls `trpc.users.checkEmail`, but the contract router excluded `users.*` as "web-only" — its own comment said so. The call was untyped:

```
Property 'users' does not exist on type 'TRPCClient<...>'
```

That is exactly the drift §12.4 says the contract exists to prevent: a server contract change would have broken mobile's login silently at runtime rather than at build time.

`checkEmail` is now mirrored in the contract, its input schema lives in `@buildinlime/contracts`, and **the server validates against that same schema** instead of an inline copy — so the two cannot drift apart again.

That required one addition to the contract's stub vocabulary. The existing `stub` is mutation-shaped and outputs are deliberately unpinned (clients don't read `item`). A **query** whose result the client destructures is different — without an output type the call types as a mutation result and you get `Property 'exists' does not exist on type '{ txid: number; item?: unknown }'`. `stubOf<T>()` pins the output for those cases.

## Verification

| | |
| --- | --- |
| mobile typecheck | **33 → 6** |
| mobile lint | unchanged at 1 |
| mobile tests | 31 pass |
| contracts / sync-core / domain-types | still gate at **0** |
| web | unchanged at 37, 92 tests pass **including the contract-router parity spec** |
| build | `pnpm build` succeeds |
| ratchet | green on all seven pairs |

Because a large drop can mean `tsc` bailing out rather than progress, that was checked: **zero `TS1xxx`** parse errors and the remaining errors span six files. A type probe confirms `messagesCollection.toArray[0].text` is a real `string` while a bogus field still errors — the rows are genuinely typed, not `any`.

## Remaining (6)

Two expo-router `_layout` typings, two row-vs-prop mismatches on the project/build-unit screens, and one channel row-vs-prop.

That last group is **the same domain-vs-wire question left open on web in #44** — components declaring domain types (`Task`, `Channel`, `Property`) while receiving wire rows. Worth answering once for both apps rather than twice, which is why it stops here.

## Where the burn-down stands

| | typecheck |
| --- | --- |
| web (start) | 137 |
| web (after #44) | 14 |
| mobile (start) | 33 |
| mobile (this PR) | 6 |

**170 → 20 across both apps**, with the remaining 20 clustered on one architectural decision.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01P4q8GDpkCCCuaqgdeoThDU
