### PR TITLE
test(web): Playwright E2E (offline-sync + two-user-sync) + CI job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -95,9 +95,38 @@ jobs:
         run: pnpm test:integration
 
   # ---------------------------------------------------------------------------
-  # E2E (Playwright) — added in Phase 4. Needs compose (Postgres + Electric),
-  # a build, and the specs, so it is intentionally not wired yet.
+  # E2E (Playwright, web) — Phase 4. Brings up the dedicated ephemeral
+  # Postgres + Electric stack (docker-compose.e2e.yaml), then Playwright serves
+  # the app itself (vite dev) and runs the offline-sync + two-user-sync specs.
   # ---------------------------------------------------------------------------
+  e2e:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: pnpm/action-setup@v4
+        with:
+          version: ${{ env.PNPM_VERSION }}
+      - uses: actions/setup-node@v4
+        with:
+          node-version: ${{ env.NODE_VERSION }}
+          cache: pnpm
+      - run: pnpm install --frozen-lockfile
+      - name: Start e2e stack (Postgres + Electric)
+        run: docker compose -f web-app/code/docker-compose.e2e.yaml -p buildinlime-e2e up -d --wait
+      - name: Install Playwright browser
+        run: pnpm --filter buildinlime exec playwright install --with-deps chromium
+      - name: E2E tests (offline-sync + two-user-sync)
+        run: pnpm --filter buildinlime test:e2e
+      - name: Upload Playwright report
+        if: ${{ !cancelled() }}
+        uses: actions/upload-artifact@v4
+        with:
+          name: playwright-report
+          path: web-app/code/playwright-report/
+          retention-days: 7
+      - name: Tear down e2e stack
+        if: ${{ always() }}
+        run: docker compose -f web-app/code/docker-compose.e2e.yaml -p buildinlime-e2e down -v
 
   # ---------------------------------------------------------------------------
   # Quality ratchet — typecheck + lint are red at baseline, so this fails only

--- a/.gitignore
+++ b/.gitignore
@@ -73,3 +73,10 @@ ios/
 
 # purge-resources cron log
 logs/
+
+# Playwright (web E2E)
+web-app/code/test-results/
+web-app/code/playwright-report/
+web-app/code/blob-report/
+web-app/code/playwright/.cache/
+web-app/code/tests/e2e/.auth/

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "test": "pnpm test:unit && pnpm test:integration",
     "test:unit": "pnpm --filter buildinlime test:unit && pnpm --filter buildinlimemobile test",
     "test:integration": "pnpm --filter buildinlime test:integration",
-    "test:e2e": "echo '[test:e2e] Playwright arrives in Phase 4 — no specs yet' && exit 0",
+    "test:e2e": "pnpm --filter buildinlime test:e2e",
     "typecheck": "pnpm --filter buildinlime typecheck && pnpm --filter buildinlimemobile typecheck",
     "lint": "pnpm --filter buildinlime lint && pnpm --filter buildinlimemobile lint",
     "mobile:set-lan-ip": "pnpm --filter buildinlimemobile set-lan-ip",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -363,6 +363,9 @@ importers:
       '@dotenvx/dotenvx':
         specifier: ^1.51.2
         version: 1.57.1
+      '@playwright/test':
+        specifier: ^1.61.1
+        version: 1.61.1
       '@tanstack/devtools-vite':
         specifier: ^0.3.11
         version: 0.3.12(vite@7.3.1(@types/node@22.19.15)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3))
@@ -2436,6 +2439,11 @@ packages:
   '@pkgjs/parseargs@0.11.0':
     resolution: {integrity: sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg==}
     engines: {node: '>=14'}
+
+  '@playwright/test@1.61.1':
+    resolution: {integrity: sha512-8nKv6+0RJSL9FE4jYOEGXnPeM/Hg12qZpmqzZjRh3qM0Y7c3z1mrOTfFLids72RDQYVh9WpLEfR5WdpNX4fkig==}
+    engines: {node: '>=18'}
+    hasBin: true
 
   '@radix-ui/primitive@1.1.3':
     resolution: {integrity: sha512-JTF99U/6XIjCBo0wqkU5sK10glYe27MRRsfwoiq5zzOEZLHU3A3KCMa5X/azekYRCJ0HlwI0crAXS/5dEHTzDg==}
@@ -5481,6 +5489,11 @@ packages:
   fs.realpath@1.0.0:
     resolution: {integrity: sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==}
 
+  fsevents@2.3.2:
+    resolution: {integrity: sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==}
+    engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
+    os: [darwin]
+
   fsevents@2.3.3:
     resolution: {integrity: sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==}
     engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
@@ -6904,6 +6917,16 @@ packages:
   pkce-challenge@4.1.0:
     resolution: {integrity: sha512-ZBmhE1C9LcPoH9XZSdwiPtbPHZROwAnMy+kIFQVrnMCxY4Cudlz3gBOpzilgc0jOgRaiT3sIWfpMomW2ar2orQ==}
     engines: {node: '>=16.20.0'}
+
+  playwright-core@1.61.1:
+    resolution: {integrity: sha512-h7Qlt6m4REp25qvIdvbDtVmD4LqVXfpRxhORv9L0jzETM05p4fuPJ3dKyuSXQxDSbXnmS79HAgi9589lGSpLkg==}
+    engines: {node: '>=18'}
+    hasBin: true
+
+  playwright@1.61.1:
+    resolution: {integrity: sha512-DWnY5o3YbLWK4GovuAVwpqL+1VwGNdUGrRr++8j8PtQQzvAVZUIMjKQ90fY689sEJZJBbZVw1rXaOKSTitkzPQ==}
+    engines: {node: '>=18'}
+    hasBin: true
 
   plist@3.1.0:
     resolution: {integrity: sha512-uysumyrvkUX0rX/dEVqt8gC3sTBzd4zoWfLeS29nb53imdaXVvLINYXTI2GNqzaMuvacNx4uJQ8+b3zXR0pkgQ==}
@@ -10661,6 +10684,10 @@ snapshots:
   '@pkgjs/parseargs@0.11.0':
     optional: true
 
+  '@playwright/test@1.61.1':
+    dependencies:
+      playwright: 1.61.1
+
   '@radix-ui/primitive@1.1.3': {}
 
   '@radix-ui/react-alert-dialog@1.1.15(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)':
@@ -14306,6 +14333,9 @@ snapshots:
 
   fs.realpath@1.0.0: {}
 
+  fsevents@2.3.2:
+    optional: true
+
   fsevents@2.3.3:
     optional: true
 
@@ -15845,6 +15875,14 @@ snapshots:
   pirates@4.0.7: {}
 
   pkce-challenge@4.1.0: {}
+
+  playwright-core@1.61.1: {}
+
+  playwright@1.61.1:
+    dependencies:
+      playwright-core: 1.61.1
+    optionalDependencies:
+      fsevents: 2.3.2
 
   plist@3.1.0:
     dependencies:

--- a/web-app/code/docker-compose.e2e.yaml
+++ b/web-app/code/docker-compose.e2e.yaml
@@ -1,0 +1,44 @@
+name: buildinlime-e2e
+
+# Dedicated, EPHEMERAL stack for Playwright E2E — never touches the dev stack.
+# Distinct ports (54322 / 30001) and tmpfs storage so every run starts from a
+# clean database and leaves nothing behind. Bring up with:
+#   docker compose -f docker-compose.e2e.yaml -p buildinlime-e2e up -d --wait
+# (or `pnpm e2e:up`). Electric runs INSECURE — dev/test only, same as the dev
+# compose; see ARCHITECTURE.md §12.3.
+
+services:
+  postgres:
+    image: postgres:17-alpine
+    environment:
+      POSTGRES_DB: electric
+      POSTGRES_USER: postgres
+      POSTGRES_PASSWORD: password
+    ports:
+      - 54322:5432
+    # Ephemeral: the data dir lives in RAM, so each `up` is a fresh database and
+    # `down` reclaims everything. No named volume on purpose.
+    tmpfs:
+      - /var/lib/postgresql/data
+    command:
+      - -c
+      - listen_addresses=*
+      - -c
+      - wal_level=logical
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U postgres -d electric"]
+      interval: 3s
+      timeout: 3s
+      retries: 20
+
+  electric:
+    image: electricsql/electric:1.4.10
+    environment:
+      DATABASE_URL: postgresql://postgres:password@postgres:5432/electric?sslmode=disable
+      # Not suitable for production (ARCHITECTURE.md §12.3) — fine for E2E.
+      ELECTRIC_INSECURE: true
+    ports:
+      - 30001:3000
+    depends_on:
+      postgres:
+        condition: service_healthy

--- a/web-app/code/package.json
+++ b/web-app/code/package.json
@@ -18,6 +18,10 @@
     "test": "vitest run",
     "test:unit": "vitest run --project unit",
     "test:integration": "vitest run --project integration",
+    "test:e2e": "playwright test",
+    "test:e2e:ui": "playwright test --ui",
+    "e2e:up": "docker compose -f docker-compose.e2e.yaml -p buildinlime-e2e up -d --wait",
+    "e2e:down": "docker compose -f docker-compose.e2e.yaml -p buildinlime-e2e down -v",
     "typecheck": "tsc --noEmit",
     "lint": "eslint",
     "format": "prettier --check .",
@@ -79,6 +83,7 @@
   },
   "devDependencies": {
     "@dotenvx/dotenvx": "^1.51.2",
+    "@playwright/test": "^1.61.1",
     "@tanstack/devtools-vite": "^0.3.11",
     "@tanstack/eslint-config": "^0.3.0",
     "@testing-library/dom": "^10.4.0",

--- a/web-app/code/playwright.config.ts
+++ b/web-app/code/playwright.config.ts
@@ -1,0 +1,72 @@
+import { defineConfig, devices } from "@playwright/test"
+import path from "node:path"
+
+// -----------------------------------------------------------------------------
+// Web E2E (Phase 4 of agentGuides/testingAndCiSetup.md).
+//
+// The app is served in DEV mode (`vite dev`) rather than from a prod build: dev
+// is the only serving path proven to run the /api routes (tRPC, Electric shapes,
+// Better Auth) in this repo — there is no committed prod server preset yet
+// (ARCHITECTURE.md §11). The offline spec exercises the optimistic OUTBOX (client
+// JS), which behaves identically in dev; it only reloads AFTER reconnecting, so
+// the prod-only service worker is not needed.
+//
+// Served over plain http://localhost:3000 (NOT the Caddy HTTPS origin): Chromium
+// treats `localhost` as a secure context, so OPFS + crypto.subtle work, and with
+// NODE_ENV != production Better Auth's cookies are non-secure, so they ride over
+// http. The e2e Postgres+Electric stack must be up first (`pnpm e2e:up`).
+// -----------------------------------------------------------------------------
+
+const E2E_DB = "postgresql://postgres:password@localhost:54322/electric"
+// Must be identical in globalSetup (which signs the session cookie) and the app
+// (which verifies it). Kept here as the single source.
+const E2E_SECRET = "e2e-better-auth-secret-min-32-chars-0001"
+const BASE_URL = "http://localhost:3000"
+
+// globalSetup runs in THIS process; seed it the same DB + secret the app uses.
+process.env.DATABASE_URL ??= E2E_DB
+process.env.TEST_DATABASE_URL ??= E2E_DB
+process.env.BETTER_AUTH_SECRET ??= E2E_SECRET
+
+export default defineConfig({
+  testDir: "./tests/e2e",
+  globalSetup: "./tests/e2e/global-setup.ts",
+  // The specs share one seeded channel and drive optimistic/offline state, so
+  // run them serially rather than racing writes through one outbox.
+  fullyParallel: false,
+  workers: 1,
+  forbidOnly: !!process.env.CI,
+  retries: process.env.CI ? 2 : 0,
+  timeout: 120_000,
+  expect: { timeout: 30_000 },
+  reporter: process.env.CI
+    ? [["github"], ["html", { open: "never" }]]
+    : [["list"], ["html", { open: "never" }]],
+  use: {
+    baseURL: BASE_URL,
+    // Default context = user A. The two-user spec opens user B explicitly.
+    storageState: path.resolve(process.cwd(), "tests/e2e/.auth/userA.json"),
+    trace: "retain-on-failure",
+    ignoreHTTPSErrors: true,
+  },
+  projects: [{ name: "chromium", use: { ...devices["Desktop Chrome"] } }],
+  webServer: {
+    command: "pnpm dev",
+    url: BASE_URL,
+    reuseExistingServer: !process.env.CI,
+    timeout: 180_000,
+    stdout: "pipe",
+    stderr: "pipe",
+    env: {
+      DATABASE_URL: E2E_DB,
+      USE_ELECTRIC_URL: "true",
+      ELECTRIC_URL: "http://localhost:30001",
+      BETTER_AUTH_SECRET: E2E_SECRET,
+      BETTER_AUTH_URL: BASE_URL,
+      // Keep out of production so useSecureCookies stays false (server.ts) and
+      // the session cookie is accepted over http.
+      NODE_ENV: "development",
+      PORT: "3000",
+    },
+  },
+})

--- a/web-app/code/src/presentation/routes/_authenticated.tsx
+++ b/web-app/code/src/presentation/routes/_authenticated.tsx
@@ -192,9 +192,16 @@ async function initCollections(userId: string, sessionId: string): Promise<void>
   ])
 
   // 3. Start sync — OPFS hydrates from cache, Electric syncs in background.
-  //    (channelsCollection is intentionally started lazily by its route loaders.)
+  //    channelsCollection is part of the NEVER_GC spine, so start it here with
+  //    the other spine collections. It used to be left to a component subscriber
+  //    (the Sidebar) to start lazily, but nothing starts it on a cold deep-link
+  //    or reload straight to a channel URL — the channel route has no loader —
+  //    so the channel shape never synced and the page sat on "Channel not found"
+  //    for the whole session. Starting it at bootstrap makes deep-links
+  //    deterministic and matches projects/build_units/users/teams above.
   projectsCollection.startSyncImmediate()
   buildUnitsCollection.startSyncImmediate()
+  channelsCollection.startSyncImmediate()
   channelMembersCollection.startSyncImmediate()
   usersCollection.startSyncImmediate()
   teamsCollection.startSyncImmediate()

--- a/web-app/code/tests/e2e/README.md
+++ b/web-app/code/tests/e2e/README.md
@@ -1,0 +1,39 @@
+# Web E2E (Playwright)
+
+Phase 4 of `agentGuides/testingAndCiSetup.md`. Drives the real browser + Electric
++ Postgres round trip — the only tier that covers the optimistic-outbox write path
+(ARCHITECTURE.md §5) and cross-client sync (§4) end to end.
+
+## What it does
+
+- **`docker-compose.e2e.yaml`** — a dedicated, ephemeral Postgres + Electric stack
+  (ports **54322 / 30001**), isolated from the dev stack so a run never touches dev
+  data.
+- **`global-setup.ts`** — migrates + seeds the e2e DB (reusing the integration
+  harness) and writes an authenticated `storageState` per user. It bypasses the
+  email-OTP login: it inserts a `sessions` row and signs the `better-auth`
+  session cookie with `makeSignature` (better-auth's own primitive). No Resend.
+- **`offline-sync.spec.ts`** — post online → go offline → create a task + delete a
+  resource (optimistic) → reconnect → reload; assert everything drained and stuck.
+- **`two-user-sync.spec.ts`** — A posts, B receives via Electric.
+
+The app is served with `vite dev` on `http://localhost:3000` (not the prod build,
+not Caddy) — see the header comment in `playwright.config.ts` for why.
+
+## Run it locally
+
+```bash
+# from web-app/code
+pnpm e2e:up                 # bring up the ephemeral Postgres+Electric stack (--wait)
+pnpm exec playwright install chromium   # one-time: browser binary
+pnpm test:e2e               # run the specs (starts the app itself)
+pnpm test:e2e:ui            # or: interactive UI mode for debugging
+pnpm e2e:down               # tear the stack down (removes volumes)
+```
+
+The HTML report lands in `playwright-report/`; traces are retained on failure.
+
+## In CI
+
+The `e2e` job in `.github/workflows/ci.yml` brings the stack up with
+`docker compose … up -d --wait`, installs the browser, and runs `pnpm test:e2e`.

--- a/web-app/code/tests/e2e/global-setup.ts
+++ b/web-app/code/tests/e2e/global-setup.ts
@@ -1,0 +1,153 @@
+import { mkdirSync, writeFileSync } from "node:fs"
+import path from "node:path"
+import { randomUUID } from "node:crypto"
+import { makeSignature } from "better-auth/crypto"
+import { sessions } from "%/infrastructure/database/schema/auth-schema"
+
+// -----------------------------------------------------------------------------
+// Playwright globalSetup — migrates + seeds the E2E database and writes an
+// authenticated storageState per user, BYPASSING the email-OTP login entirely.
+//
+// Auth without OTP: we insert a real `sessions` row and hand the browser a
+// signed session cookie built with Better Auth's own public signing primitive
+// (`makeSignature` from better-auth/crypto — exactly what the server uses to
+// verify it). With only the session_token cookie present, getSession falls back
+// to a DB lookup by token, which finds our row. No Resend, no verifications
+// table, no prod-code changes.
+//
+// It reuses the integration harness (migrate/reset/factories) so seeding stays
+// single-sourced. The e2e DB is pointed at via env set in playwright.config.ts.
+// -----------------------------------------------------------------------------
+
+const AUTH_DIR = path.resolve(process.cwd(), "tests/e2e/.auth")
+// cookiePrefix is "better-auth" and useSecureCookies is false in dev, so the
+// session cookie is the un-prefixed name.
+const COOKIE_NAME = "better-auth.session_token"
+
+// Fixed, URL-friendly names so specs can build the channel deep-link.
+export const BUILD_UNIT_NAME = "AlphaUnit"
+export const CHANNEL_NAME = "Finance" // must be one of CHANNEL_NAMES
+export const RESOURCE_NAME = "e2e-doc.pdf"
+
+export default async function globalSetup(): Promise<void> {
+  // Ensure the integration harness modules (which read TEST_DATABASE_URL) point
+  // at the e2e DB even if the config default did not set it.
+  process.env.TEST_DATABASE_URL ??= process.env.DATABASE_URL
+
+  // Dynamic imports: these modules read env at load, so import them only after
+  // the env above is in place.
+  const { default: migrate } = await import("../integration/setup/global")
+  const { db, resetDb, closeDb } = await import("../integration/setup/db")
+  const {
+    createUser,
+    createProject,
+    createBuildUnit,
+    createChannel,
+    createMembership,
+    createResource,
+  } = await import("../integration/factories")
+
+  await migrate()
+  await resetDb()
+
+  const userA = await createUser({ name: "E2E Alice" })
+  const userB = await createUser({ name: "E2E Bob" })
+  const project = await createProject({ ownerId: userA.id, name: "E2E Project" })
+  const buildUnit = await createBuildUnit({
+    projectId: project.id,
+    ownerId: userA.id,
+    name: BUILD_UNIT_NAME,
+  })
+  const channel = await createChannel({
+    buildUnitId: buildUnit.id,
+    ownerId: userA.id,
+    name: CHANNEL_NAME,
+  })
+  // Both users need a membership row: the client derives its channel-scoped shape
+  // set from `memberships` (deriveMembershipSets), regardless of role.
+  await createMembership({
+    userId: userA.id,
+    channelId: channel.id,
+    buildUnitId: buildUnit.id,
+    projectId: project.id,
+    role: "owner",
+  })
+  await createMembership({
+    userId: userB.id,
+    channelId: channel.id,
+    buildUnitId: buildUnit.id,
+    projectId: project.id,
+    role: "co-owner",
+  })
+  // A channel-level resource for the offline delete test (uploader = A → A may
+  // delete it).
+  await createResource({
+    channelId: channel.id,
+    buildUnitId: buildUnit.id,
+    projectId: project.id,
+    createdById: userA.id,
+    name: RESOURCE_NAME,
+  })
+
+  const secret = process.env.BETTER_AUTH_SECRET
+  if (!secret) throw new Error("BETTER_AUTH_SECRET must be set for e2e")
+
+  mkdirSync(AUTH_DIR, { recursive: true })
+
+  async function writeAuthState(userId: string, file: string): Promise<void> {
+    const token = `${randomUUID()}${randomUUID()}`.replace(/-/g, "")
+    const expiresAt = new Date(Date.now() + 2 * 24 * 60 * 60 * 1000)
+    await db.insert(sessions).values({
+      id: randomUUID(),
+      token,
+      userId,
+      expiresAt,
+      createdAt: new Date(),
+      updatedAt: new Date(),
+      ipAddress: null,
+      userAgent: null,
+    })
+    const signed = `${token}.${await makeSignature(token, secret!)}`
+    writeFileSync(
+      file,
+      JSON.stringify({
+        cookies: [
+          {
+            name: COOKIE_NAME,
+            value: signed,
+            domain: "localhost",
+            path: "/",
+            httpOnly: true,
+            secure: false,
+            sameSite: "Lax",
+            expires: Math.floor(expiresAt.getTime() / 1000),
+          },
+        ],
+        origins: [],
+      }),
+    )
+  }
+
+  const userAState = path.join(AUTH_DIR, "userA.json")
+  const userBState = path.join(AUTH_DIR, "userB.json")
+  await writeAuthState(userA.id, userAState)
+  await writeAuthState(userB.id, userBState)
+
+  writeFileSync(
+    path.join(AUTH_DIR, "seed.json"),
+    JSON.stringify(
+      {
+        projectId: project.id,
+        buildUnitName: BUILD_UNIT_NAME,
+        channelName: CHANNEL_NAME,
+        resourceName: RESOURCE_NAME,
+        userA: { id: userA.id, statePath: userAState },
+        userB: { id: userB.id, statePath: userBState },
+      },
+      null,
+      2,
+    ),
+  )
+
+  await closeDb()
+}

--- a/web-app/code/tests/e2e/helpers.ts
+++ b/web-app/code/tests/e2e/helpers.ts
@@ -1,0 +1,24 @@
+import { readFileSync } from "node:fs"
+import path from "node:path"
+
+// The shape global-setup writes to tests/e2e/.auth/seed.json.
+export interface Seed {
+  projectId: string
+  buildUnitName: string
+  channelName: string
+  resourceName: string
+  userA: { id: string; statePath: string }
+  userB: { id: string; statePath: string }
+}
+
+export function readSeed(): Seed {
+  const file = path.resolve(process.cwd(), "tests/e2e/.auth/seed.json")
+  return JSON.parse(readFileSync(file, "utf8")) as Seed
+}
+
+/** The channel deep-link: /projects/:id/:buildUnitName/:channelName. */
+export function channelUrl(s: Seed): string {
+  return `/projects/${s.projectId}/${encodeURIComponent(
+    s.buildUnitName,
+  )}/${encodeURIComponent(s.channelName)}`
+}

--- a/web-app/code/tests/e2e/offline-sync.spec.ts
+++ b/web-app/code/tests/e2e/offline-sync.spec.ts
@@ -1,0 +1,53 @@
+import { test, expect } from "@playwright/test"
+import { readSeed, channelUrl } from "./helpers"
+
+// The differentiating end-to-end path (ARCHITECTURE.md §5): optimistic writes
+// applied to the local store while OFFLINE, drained through the durable outbox on
+// reconnect, and surviving a reload. Uses the default (user A) storageState.
+
+const s = readSeed()
+const url = channelUrl(s)
+
+test("optimistic writes go through the offline outbox and survive reload", async ({
+  page,
+  context,
+}) => {
+  await page.goto(url)
+
+  const composer = page.getByPlaceholder("Write a comment…")
+  await expect(composer).toBeVisible()
+
+  // 1. Post a message while ONLINE (baseline).
+  const onlineMsg = `online message ${Date.now()}`
+  await composer.click()
+  await composer.fill(onlineMsg)
+  await composer.press("Control+Enter")
+  await expect(page.getByText(onlineMsg)).toBeVisible()
+
+  // 2. Go offline.
+  await context.setOffline(true)
+
+  // 3. Create a task offline — appears optimistically in the Tasks panel.
+  const taskName = `Offline Task ${Date.now()}`
+  await page.getByRole("button", { name: "Add Task" }).first().click()
+  const taskInput = page.getByPlaceholder("Enter task name")
+  await taskInput.fill(taskName)
+  await taskInput.press("Enter")
+  await expect(page.getByText(taskName)).toBeVisible()
+
+  // 4. Delete the seeded resource offline — vanishes optimistically.
+  page.once("dialog", (d) => d.accept())
+  await page.getByTitle("Delete for everyone").first().click()
+  await expect(page.getByText(s.resourceName)).toHaveCount(0)
+
+  // 5. Reconnect — the outbox drains FIFO to the server.
+  await context.setOffline(false)
+
+  // 6. Reload — the offline mutations persisted (local + server) and the online
+  //    message is still there; the deleted resource stays gone.
+  await page.reload()
+  await expect(page.getByPlaceholder("Write a comment…")).toBeVisible()
+  await expect(page.getByText(taskName)).toBeVisible()
+  await expect(page.getByText(onlineMsg)).toBeVisible()
+  await expect(page.getByText(s.resourceName)).toHaveCount(0)
+})

--- a/web-app/code/tests/e2e/two-user-sync.spec.ts
+++ b/web-app/code/tests/e2e/two-user-sync.spec.ts
@@ -1,0 +1,47 @@
+import { test, expect } from "@playwright/test"
+import { readSeed, channelUrl } from "./helpers"
+
+// Cross-client sync (ARCHITECTURE.md §3, §4): a write by user A reaches user B
+// through Electric, not through B refetching. Two isolated browser contexts, each
+// authenticated as a different seeded member of the same channel.
+
+const s = readSeed()
+const url = channelUrl(s)
+
+test("a message user A posts reaches user B via Electric", async ({ browser }) => {
+  const ctxA = await browser.newContext({ storageState: s.userA.statePath })
+  const ctxB = await browser.newContext({ storageState: s.userB.statePath })
+  try {
+    const pageA = await ctxA.newPage()
+    const pageB = await ctxB.newPage()
+
+    await pageA.goto(url)
+    await pageB.goto(url)
+
+    const composerA = pageA.getByPlaceholder("Write a comment…")
+    await expect(composerA).toBeVisible()
+    await expect(pageB.getByPlaceholder("Write a comment…")).toBeVisible()
+
+    const msg = `cross-client message ${Date.now()}`
+    await composerA.click()
+    await composerA.fill(msg)
+    await composerA.press("Control+Enter")
+
+    // A sees it optimistically immediately.
+    await expect(pageA.getByText(msg)).toBeVisible()
+
+    // Reload A to drain its outbox to the server. In headless the offline
+    // executor's leader election / online detection does not fire on a plain
+    // enqueue-while-online, so the durable outbox flushes on the next executor
+    // init (page load) instead — the same path the offline-sync spec exercises.
+    // This is a test-env quirk, not the behaviour under test: what we assert is
+    // the Electric fan-out to B.
+    await pageA.reload()
+
+    // B receives it over the Electric sync stream (long-poll — allow generous time).
+    await expect(pageB.getByText(msg)).toBeVisible({ timeout: 45_000 })
+  } finally {
+    await ctxA.close()
+    await ctxB.close()
+  }
+})


### PR DESCRIPTION
## What & why

Closes **Phase 4** of `web-app/code/agentGuides/testingAndCiSetup.md` — the last remaining CI gap. Adds the only test tier that drives the real browser + Electric + Postgres round trip, covering the optimistic-outbox **write path** (ARCHITECTURE.md §5) and **cross-client sync** (§4) end to end. Unit/integration already cover the pure logic; nothing exercised the full system.

## What's in it

- **`docker-compose.e2e.yaml`** — dedicated, ephemeral Postgres + Electric stack (ports `54322`/`30001`, tmpfs), isolated from the dev stack so a run never touches dev data.
- **`playwright.config.ts`** — serves the app via `vite dev` on `http://localhost:3000`. `localhost` is a secure context (OPFS/`crypto.subtle` work) and `NODE_ENV!=production` keeps the session cookie non-secure over http. This is the only serving path that runs `/api` in the repo today (no prod server preset yet — §11).
- **`tests/e2e/global-setup.ts`** — migrates + seeds via the integration harness, then mints an authenticated `storageState` per user by inserting a `sessions` row and signing the `better-auth` cookie with `makeSignature`. **No OTP, no Resend, no production auth changes.**
- **Specs** — `offline-sync` (post online → offline → create task + delete resource optimistically → reconnect → reload, all survives) and `two-user-sync` (A posts, B receives via Electric).
- **CI** — new `e2e` job: compose up `--wait` → install chromium → `test:e2e` → upload `playwright-report` → teardown. Plus `test:e2e` / `e2e:up` / `e2e:down` scripts and `.gitignore` entries.

## Latent bug fixed along the way

`channelsCollection` was the one NEVER_GC spine collection **not** started at bootstrap — a comment claimed route loaders start it, but none do (only the resync path). So a cold deep-link or reload straight to a channel URL never synced the channel shape and sat on **"Channel not found" for the whole session**. Now started at bootstrap with the other spine collections (`_authenticated.tsx`). One line, real UX fix.

## Notes for reviewers

- The `two-user-sync` spec reloads user A after posting to drain the outbox: in headless the offline executor's leader election doesn't fire on plain enqueue-while-online, so the durable outbox flushes on the next executor init (same path `offline-sync` exercises). Documented inline; the assertion under test is the Electric fan-out to B.
- CD remains out of scope, still blocked on object storage (§12.1) and Electric security (§12.3).

## Verification (local)

| Tier | Result |
|---|---|
| **e2e** | **2 passed** |
| unit | 31 passed |
| integration | 13 passed |
| typecheck (hard gate) | 0 (web + mobile) |
| lint | 147 (= baseline) |
| quality ratchet | ✅ all at baseline |

🤖 Generated with [Claude Code](https://claude.com/claude-code)