### PR TITLE
fix(docker): pin DNS to IPv4 so the prerender server is reachable

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -49,7 +49,23 @@ COPY web-app/code/ web-app/code/
 #                     (vite.config.ts:64).
 #   STORAGE_DRIVER  — deliberately UNSET so the prerender builds no GCS client;
 #                     storage/index.ts is lazy for exactly this reason.
+#   NODE_OPTIONS    — pin DNS to IPv4, to stop an address-family mismatch during
+#                     prerender. TanStack's prerender starts a Vite preview server
+#                     and fetches `/` from it. Node resolves `localhost` verbatim,
+#                     and in this image that binds the server to ::1 — while the
+#                     failure in CI showed the client hitting 127.0.0.1 and finding
+#                     nothing ("Prerendered 0 pages", then TypeError: fetch failed,
+#                     ECONNREFUSED 127.0.0.1). Server and client on different
+#                     families.
+#
+#                     Caveat: this was NOT reproduced locally. A container with
+#                     IPv6 fully disabled binds 127.0.0.1 and works, so "the runner
+#                     has no IPv6" does not explain it on its own — it would need
+#                     IPv6 present but unroutable. ipv4first forces both sides onto
+#                     IPv4 either way. If the prerender fails in CI again, this is
+#                     the first assumption to re-test, not to trust.
 RUN DISABLE_CADDY=1 \
+    NODE_OPTIONS=--dns-result-order=ipv4first \
     DATABASE_URL=postgresql://postgres:password@localhost:5432/electric \
     BETTER_AUTH_SECRET=build-only-secret-000000000000000000000000 \
     BETTER_AUTH_URL=http://localhost:3000 \


### PR DESCRIPTION
Unblocks the deploy job, which failed on its first run (#53 merge, run 29717792076).

### What failed
Step 6 of 9, **Build and push images** — before the VM was touched. Steps 7–9 skipped,
production unaffected and verified healthy throughout (`200 / 401 / 404`).

`vite build` died in the prerender. TanStack starts a Vite preview server and fetches
`/` from it; the fetch got `ECONNREFUSED 127.0.0.1:42347` in ~10ms — nothing listening.

```
[prerender] Prerendered 0 pages:
TypeError: fetch failed
  [cause]: Error: connect ECONNREFUSED 127.0.0.1:42347
```

### What it isn't
- **Not a stale layer.** `docker build --no-cache` reproduces a *successful* build locally.
- **Not the runner.** The `build` job runs the same command on the same runner and passes.
  It only fails inside Docker.

### The mechanism
In `node:22-slim`, `localhost` resolves `::1` first (verbatim order) and Node binds the
preview server to IPv6 loopback — while CI's client went to `127.0.0.1`. Server and
client on different address families.

### Honest caveat — read before trusting this
**This was not reproduced.** A container with IPv6 *fully disabled* binds `127.0.0.1`
and works, so "the runner has no IPv6" does not explain it alone — that would require
IPv6 present but unroutable, which I could not reproduce locally.

`--dns-result-order=ipv4first` forces both sides onto IPv4 regardless of which one was
choosing wrong. It is well-motivated but unproven against the real failure, and **this
merge is the test.** The same caveat is in the Dockerfile comment so the next person
re-tests it rather than trusting it.

### Verification
- `docker build --no-cache --target build` still prerenders 1 page — no regression
- Bind/connect behaviour confirmed directly in `node:22-slim`, with and without the flag

### Risk
Build-stage only. If the fix is wrong the deploy fails at the same step and never
reaches the VM, exactly as it did the first time.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018FABgoZdEdqks8pRnFLMqM