### PR TITLE
fix(deploy): actAs permission + smoke test hit HTTP instead of HTTPS

### DIFF
--- a/deploy/deploy.sh
+++ b/deploy/deploy.sh
@@ -59,10 +59,22 @@ step "5/5 restart"
 "${COMPOSE[@]}" ps --format 'table {{.Service}}\t{{.Status}}'
 
 step "smoke test"
+# Hit the PUBLIC HTTPS URL, not http://localhost.
+#
+# Caddy 308-redirects HTTP to HTTPS, so `curl http://localhost/...` returns 308
+# forever and never 200. The first real run of this script rolled back a
+# perfectly healthy deploy because of exactly that: the image was fine,
+# migrations applied, containers came up — and the check was wrong.
+#
+# The public URL is also the more honest test: it exercises DNS, the certificate,
+# Caddy's routing and the app, which is what "deployed" actually means. It
+# hairpins back to this VM, which is verified to work from here.
+BASE="https://$(grep -oP '(?<=^PUBLIC_DOMAIN=).*' compose.env)"
 ok=true
+last=000
 for i in $(seq 1 20); do
-  code=$(curl -s -o /dev/null -w '%{http_code}' --max-time 10 http://localhost/api/auth/get-session || echo 000)
-  [[ "$code" == "200" ]] && break
+  last=$(curl -s -o /dev/null -w '%{http_code}' --max-time 10 "$BASE/api/auth/get-session" || echo 000)
+  [[ "$last" == "200" ]] && break
   [[ $i -eq 20 ]] && ok=false
   sleep 3
 done
@@ -70,12 +82,20 @@ done
 if $ok; then
   # /api/users must be 401, not 500 — proves the auth gate is intact and the
   # route manifest (scripts/generate-api-routes.mjs) loaded.
-  users=$(curl -s -o /dev/null -w '%{http_code}' --max-time 10 http://localhost/api/users || echo 000)
-  probe=$(curl -s -o /dev/null -w '%{http_code}' --max-time 10 http://localhost/api/.env || echo 000)
+  users=$(curl -s -o /dev/null -w '%{http_code}' --max-time 10 "$BASE/api/users" || echo 000)
+  probe=$(curl -s -o /dev/null -w '%{http_code}' --max-time 10 "$BASE/api/.env" || echo 000)
+  echo "  ${BASE}"
   echo "  /api/auth/get-session : 200"
   echo "  /api/users            : ${users} (expect 401)"
   echo "  /api/.env             : ${probe} (expect 404)"
   [[ "$users" == "401" && "$probe" == "404" ]] || ok=false
+else
+  # Print the evidence. Previously this branch printed NOTHING, so the first
+  # failure gave no clue why — the diagnosis had to be redone by hand on the VM.
+  echo "  ${BASE}/api/auth/get-session never returned 200 in 60s"
+  echo "  last status: ${last}"
+  echo "  --- app logs ---"
+  "${COMPOSE[@]}" logs app --tail 20 2>&1 | sed 's/^/  /'
 fi
 
 if ! $ok; then

--- a/deploy/setup-cicd.sh
+++ b/deploy/setup-cicd.sh
@@ -60,6 +60,26 @@ for role in roles/artifactregistry.writer roles/iap.tunnelResourceAccessor \
     --member "serviceAccount:${SA_EMAIL}" --role "$role" --condition=None
 done
 
+step "Let the deployer act as the VM's service account"
+# ---------------------------------------------------------------------------
+# `gcloud compute ssh/scp` against an instance that HAS a service account
+# attached requires iam.serviceAccounts.actAs on THAT account — the four project
+# roles above are not enough. Without this the deploy job fails at the config
+# sync step with:
+#
+#   PERMISSION_DENIED: User does not have iam.serviceAccounts.actAs permission
+#   on the instance's service account
+#
+# Bound on the VM's service account as a RESOURCE, not project-wide: granting
+# roles/iam.serviceAccountUser at project level would let the deployer
+# impersonate every service account in the project, including any added later.
+# ---------------------------------------------------------------------------
+VM_SA="${VM_SA:-buildinlime-vm@${PROJECT}.iam.gserviceaccount.com}"
+mk "serviceAccountUser on ${VM_SA}"
+run gcloud iam service-accounts add-iam-policy-binding "$VM_SA" \
+  --project "$PROJECT" --role roles/iam.serviceAccountUser \
+  --member "serviceAccount:${SA_EMAIL}"
+
 step "Workload Identity Pool"
 if have gcloud iam workload-identity-pools describe "$POOL" --project "$PROJECT" --location global; then
   skip "$POOL"


### PR DESCRIPTION
Two fixes from the deploy job's second and third runs. Production was never broken —
it is serving throughout, on the rolled-back image `ed06a5d`.

### 1. `actAs` on the VM's service account (run 29718992846, step 7)

```
PERMISSION_DENIED: User does not have iam.serviceAccounts.actAs permission
on the instance's service account
```

`gcloud compute ssh/scp` against an instance that has a service account attached
requires `actAs` on **that account**. The four project roles `setup-cicd.sh` already
granted are all necessary but none covers this, and nothing surfaces the gap until a
real SSH is attempted.

Bound on the VM's service account **as a resource, not project-wide** —
`roles/iam.serviceAccountUser` at project level would let the deployer impersonate
every service account in the project, including future ones. Already applied live;
the script change makes a rebuild reproducible.

### 2. The smoke test rolled back a healthy deploy (same run, step 8)

This is the one worth reading. The deploy **worked**: image pulled, migrations applied,
ownership sweep a no-op, all containers up. Then:

```
curl http://localhost/api/auth/get-session   -> 308   (Caddy redirects HTTP->HTTPS)
curl https://app.buildinlime.com/...         -> 200
```

`curl` was not following redirects, so the loop saw `308` twenty times, declared
failure, and rolled back a deploy that was completely fine.

Now hits the public HTTPS URL derived from `PUBLIC_DOMAIN`. That is also the more
honest check — it exercises DNS, the certificate, Caddy's routing and the app, which
is what "deployed" actually means. Verified from the VM: `200 / 401 / 404`.

**Also: the failure branch printed nothing.** No status code, no logs. The whole
diagnosis had to be redone by hand on the VM. It now prints the last status and the
app's last 20 log lines.

### Rollback safety
`git diff ed06a5d..c7d9fc9 -- '*drizzle*' '*migrations*'` is **empty** — no schema
change, so running the previous image against the current schema is safe. Had there
been one, the rollback would have left a mismatch, which is the documented limitation
in `deploy.sh` and `deploymentPlan.md` §9.

### What this means for the next run
Image `c7d9fc9` is already built, pushed, and verified working — run directly on the
VM it serves `200`. The next deploy should get through end to end.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018FABgoZdEdqks8pRnFLMqM