### PR TITLE
feat(web): marketing pages, landing refresh, and coming-soon pricing

### DIFF
--- a/web-app/code/src/presentation/components/buildInlime/ArticleList.tsx
+++ b/web-app/code/src/presentation/components/buildInlime/ArticleList.tsx
@@ -1,0 +1,70 @@
+/**
+ * The full, unabridged list of articles — what /blog and /documentation show.
+ *
+ * ResourceSection's history list is the abridged cousin of this: it drops the
+ * newest entry into a featured card and caps its height. Here every article is
+ * printed in full, on the page itself rather than inside a box, so the page
+ * scrolls as an article does.
+ */
+
+import { CategoryChip } from "./CategoryChip";
+import type { Article } from "../../content/articles";
+
+export type ArticleListProps = {
+  articles: Article[];
+};
+
+export function ArticleList({ articles }: ArticleListProps) {
+  return (
+    <div className="w-full px-[120px] pb-[40px]">
+      <div className="max-w-[788px] mx-auto flex flex-col">
+        {articles.map((article) => (
+          <article
+            key={article.title}
+            className="flex flex-col gap-[12px] py-[40px] border-b border-border first:pt-0 last:border-b-0"
+          >
+            <h2
+              className="font-['Instrument_Sans',sans-serif] font-semibold text-[22px] leading-[31px] text-black"
+              style={{ fontVariationSettings: "'wdth' 100" }}
+            >
+              {article.title}
+            </h2>
+
+            <div className="flex items-center gap-[12px]">
+              <span
+                className="font-['Instrument_Sans',sans-serif] text-[13px] leading-[18px] text-muted-foreground"
+                style={{ fontVariationSettings: "'wdth' 100" }}
+              >
+                <time dateTime={article.date}>{article.displayDate}</time>
+                {" · by "}
+                {article.author}
+              </span>
+              <CategoryChip category={article.category} />
+            </div>
+
+            <p
+              className="font-['Instrument_Sans',sans-serif] font-medium text-[17px] leading-[26px] text-black"
+              style={{ fontVariationSettings: "'wdth' 100" }}
+            >
+              {article.excerpt}
+            </p>
+
+            <div className="flex flex-col gap-[16px]">
+              {article.body.map((paragraph) => (
+                <p
+                  key={paragraph.slice(0, 48)}
+                  className="font-['Instrument_Sans',sans-serif] text-[15px] leading-[24px] text-black"
+                  style={{ fontVariationSettings: "'wdth' 100" }}
+                >
+                  {paragraph}
+                </p>
+              ))}
+            </div>
+          </article>
+        ))}
+      </div>
+    </div>
+  );
+}
+
+export default ArticleList;

--- a/web-app/code/src/presentation/components/buildInlime/BottomSection.tsx
+++ b/web-app/code/src/presentation/components/buildInlime/BottomSection.tsx
@@ -3,10 +3,10 @@ export function BottomSection() {
     <div className="p-3 border-t border-card-border">
       <div className="bg-icon-chip border border-card-border rounded-lg p-3">
         <p className="text-xs text-foreground font-medium mb-2">
-          What&apos;s new
+          Coming Soon
         </p>
         <p className="text-xs text-muted-foreground">
-          Announce filtes and share issues in private teams
+          AI enabled documentation and Ledger
         </p>
       </div>
     </div>

--- a/web-app/code/src/presentation/components/buildInlime/CategoryChip.tsx
+++ b/web-app/code/src/presentation/components/buildInlime/CategoryChip.tsx
@@ -1,0 +1,13 @@
+/** The category pill worn by every article, in both the list and the section. */
+export function CategoryChip({ category }: { category: string }) {
+  return (
+    <span
+      className="inline-flex items-center bg-card-surface text-primary rounded-full px-[12px] py-[4px] font-['Instrument_Sans',sans-serif] text-[13px] leading-[18px]"
+      style={{ fontVariationSettings: "'wdth' 100" }}
+    >
+      {category}
+    </span>
+  );
+}
+
+export default CategoryChip;

--- a/web-app/code/src/presentation/components/buildInlime/FeatureSection.tsx
+++ b/web-app/code/src/presentation/components/buildInlime/FeatureSection.tsx
@@ -1,0 +1,79 @@
+/**
+ * One feature group — Structure, Tasks, Offline — on the /features page.
+ *
+ * Two columns of cards under a section heading. Each card wears the platform it
+ * runs on, because web and mobile are not at parity and the page would mislead
+ * without it.
+ */
+
+import { PLATFORM_LABELS } from "../../content/features";
+import type { FeatureGroup } from "../../content/features";
+
+function PlatformChip({ label }: { label: string }) {
+  return (
+    <span
+      className="inline-flex items-center shrink-0 bg-card-surface text-primary rounded-full px-[12px] py-[4px] font-['Instrument_Sans',sans-serif] text-[13px] leading-[18px]"
+      style={{ fontVariationSettings: "'wdth' 100" }}
+    >
+      {label}
+    </span>
+  );
+}
+
+export function FeatureSection({ group }: { group: FeatureGroup }) {
+  return (
+    <section className="w-full px-[120px] py-[28px]">
+      <div className="max-w-[1270px] mx-auto flex flex-col gap-[20px]">
+        {/* Section heading */}
+        <div className="flex flex-col gap-[8px]">
+          <h2 className="font-['Inria_Sans',sans-serif] font-bold text-[22px] leading-[31px] text-foreground">
+            {group.title}
+          </h2>
+          <p
+            className="font-['Instrument_Sans',sans-serif] text-[15px] leading-[22px] text-muted-foreground max-w-[788px]"
+            style={{ fontVariationSettings: "'wdth' 100" }}
+          >
+            {group.description}
+          </p>
+        </div>
+
+        <ul className="grid grid-cols-2 gap-[20px]">
+          {group.features.map((feature) => (
+            <li
+              key={feature.name}
+              className="bg-white border border-border rounded-[10px] p-[24px] flex flex-col gap-[10px]"
+            >
+              <div className="flex items-start justify-between gap-[12px]">
+                <h3
+                  className="font-['Instrument_Sans',sans-serif] font-semibold text-[16px] leading-[24px] text-black"
+                  style={{ fontVariationSettings: "'wdth' 100" }}
+                >
+                  {feature.name}
+                </h3>
+                <PlatformChip label={PLATFORM_LABELS[feature.platform]} />
+              </div>
+
+              <p
+                className="font-['Instrument_Sans',sans-serif] text-[15px] leading-[22px] text-black"
+                style={{ fontVariationSettings: "'wdth' 100" }}
+              >
+                {feature.description}
+              </p>
+
+              {feature.note && (
+                <p
+                  className="font-['Instrument_Sans',sans-serif] text-[13px] leading-[18px] text-muted-foreground mt-auto pt-[4px]"
+                  style={{ fontVariationSettings: "'wdth' 100" }}
+                >
+                  {feature.note}
+                </p>
+              )}
+            </li>
+          ))}
+        </ul>
+      </div>
+    </section>
+  );
+}
+
+export default FeatureSection;

--- a/web-app/code/src/presentation/components/buildInlime/FeaturesCarousel.tsx
+++ b/web-app/code/src/presentation/components/buildInlime/FeaturesCarousel.tsx
@@ -5,17 +5,17 @@ const slides = [
   {
     heading: "Organization based on BuildUnits",
     description:
-      "Organize your project with BuildUnits which directly correspond to the units of construction",
+      "Organize your project into BuildUnits which directly correspond to the units of construction",
   },
   {
     heading: "Real-time Collaboration",
     description:
-      "Connect clients, architects, and site-supervisors in one unified platform for seamless communication",
+      "Organize communication among clients, architects and site-supervisors across different aspects of the construction project",
   },
   {
-    heading: "Document Tracking",
+    heading: "Documentation and Tracking",
     description:
-      "Out-of-the-box project documentation and tracking for all your construction needs",
+      "Out-of-the-box documentation, ledger keeping and tracking at different levels of granularity",
   },
 ];
 

--- a/web-app/code/src/presentation/components/buildInlime/Footer.tsx
+++ b/web-app/code/src/presentation/components/buildInlime/Footer.tsx
@@ -75,13 +75,13 @@ export function Footer({ compact = false }: { compact?: boolean } = {}) {
               </Link>
             </li>
             <li>
-              <a
-                href="#pricing"
+              <Link
+                to="/pricing"
                 className="font-['Instrument_Sans',sans-serif] text-[14px] leading-[20px] text-black hover:text-primary transition-colors"
                 style={{ fontVariationSettings: "'wdth' 100" }}
               >
                 Pricing
-              </a>
+              </Link>
             </li>
             <li>
               <a
@@ -158,12 +158,12 @@ function Copyright() {
       {new Date().getFullYear()}
       {" "}
       <a
-        href="https://buildinlime.com"
+        href="https://barefootprogrammers.in"
         className="hover:text-primary transition-colors"
         target="_blank"
         rel="noreferrer"
       >
-        buildinlime.com
+        barefootprogrammers.in
       </a>
       {". All rights reserved."}
     </p>

--- a/web-app/code/src/presentation/components/buildInlime/Footer.tsx
+++ b/web-app/code/src/presentation/components/buildInlime/Footer.tsx
@@ -1,18 +1,30 @@
 import { Link } from "@tanstack/react-router";
 import imgBrickPattern from "../../assets/brick-logo-brown.png";
 
-export function Footer() {
+/**
+ * `compact` drops the three link columns, leaving just the copyright — used on
+ * the reading pages (/resources, /blog, /documentation), where a full sitemap
+ * under the content is more furniture than the page needs.
+ */
+export function Footer({ compact = false }: { compact?: boolean } = {}) {
+  if (compact) {
+    return <CompactFooter />;
+  }
+
   return (
     <footer className="w-full px-[120px] py-[56px] border-t border-border mt-auto">
-      <div className="max-w-[1268px] mx-auto flex items-start gap-[109px]">
-        {/* Logo — links to the home page */}
-        <Link to="/" className="shrink-0 hover:opacity-80 transition-opacity">
-          <img
-            src={imgBrickPattern}
-            alt="BuildInLime"
-            className="w-[54px] h-[34px] object-cover"
-          />
-        </Link>
+      <div className="max-w-[1268px] mx-auto flex items-start gap-[60px]">
+        {/* Logo — links to the home page, with the copyright sitting under it */}
+        <div className="flex flex-col gap-[16px] shrink-0 w-[220px]">
+          <Link to="/" className="hover:opacity-80 transition-opacity w-fit">
+            <img
+              src={imgBrickPattern}
+              alt="BuildInLime"
+              className="w-[54px] h-[34px] object-cover"
+            />
+          </Link>
+          <Copyright />
+        </div>
 
         {/* Resources */}
         <div className="flex flex-col gap-[16px] w-[284.15px]">
@@ -24,22 +36,22 @@ export function Footer() {
           </h3>
           <ul className="flex flex-col gap-[8px]">
             <li>
-              <a
-                href="#blog"
+              <Link
+                to="/blog"
                 className="font-['Instrument_Sans',sans-serif] text-[14px] leading-[20px] text-black hover:text-primary transition-colors"
                 style={{ fontVariationSettings: "'wdth' 100" }}
               >
                 Blog
-              </a>
+              </Link>
             </li>
             <li>
-              <a
-                href="#documentation"
+              <Link
+                to="/documentation"
                 className="font-['Instrument_Sans',sans-serif] text-[14px] leading-[20px] text-black hover:text-primary transition-colors"
                 style={{ fontVariationSettings: "'wdth' 100" }}
               >
                 Documentation
-              </a>
+              </Link>
             </li>
           </ul>
         </div>
@@ -54,13 +66,13 @@ export function Footer() {
           </h3>
           <ul className="flex flex-col gap-[8px]">
             <li>
-              <a
-                href="#features"
+              <Link
+                to="/features"
                 className="font-['Instrument_Sans',sans-serif] text-[14px] leading-[20px] text-black hover:text-primary transition-colors"
                 style={{ fontVariationSettings: "'wdth' 100" }}
               >
                 Features
-              </a>
+              </Link>
             </li>
             <li>
               <a
@@ -93,13 +105,13 @@ export function Footer() {
           </h3>
           <ul className="flex flex-col gap-[8px]">
             <li>
-              <a
-                href="#about"
+              <Link
+                to="/about"
                 className="font-['Instrument_Sans',sans-serif] text-[14px] leading-[20px] text-black hover:text-primary transition-colors"
                 style={{ fontVariationSettings: "'wdth' 100" }}
               >
                 About
-              </a>
+              </Link>
             </li>
             <li>
               <a
@@ -123,6 +135,38 @@ export function Footer() {
         </div>
       </div>
     </footer>
+  );
+}
+
+function CompactFooter() {
+  return (
+    <footer className="w-full px-[120px] py-[22px] border-t border-border mt-auto">
+      <div className="max-w-[1268px] mx-auto flex items-center justify-center">
+        <Copyright />
+      </div>
+    </footer>
+  );
+}
+
+function Copyright() {
+  return (
+    <p
+      className="font-['Instrument_Sans',sans-serif] text-[14px] leading-[20px] text-muted-foreground"
+      style={{ fontVariationSettings: "'wdth' 100" }}
+    >
+      {"© "}
+      {new Date().getFullYear()}
+      {" "}
+      <a
+        href="https://buildinlime.com"
+        className="hover:text-primary transition-colors"
+        target="_blank"
+        rel="noreferrer"
+      >
+        buildinlime.com
+      </a>
+      {". All rights reserved."}
+    </p>
   );
 }
 

--- a/web-app/code/src/presentation/components/buildInlime/Hero.tsx
+++ b/web-app/code/src/presentation/components/buildInlime/Hero.tsx
@@ -15,7 +15,8 @@ export function Hero() {
           style={{ fontVariationSettings: "'wdth' 100" }}
         >
           streamlined communication between client, architect and
-          site-supervisors. out-of-the-box project documentation and tracking
+          site-supervisors. out-of-the-box data collation, project documentation
+          and realtime-tracking
         </p>
 
         {/* CTA Buttons */}
@@ -27,12 +28,13 @@ export function Hero() {
           >
             Start Building
           </Link>
-          <button
+          <Link
+            to="/features"
             className="bg-white border-[1.833px] border-border text-primary px-[33.833px] py-[17.833px] rounded-[10px] font-['Instrument_Sans',sans-serif] font-medium text-[18px] leading-[28px] hover:bg-card-surface transition-colors"
             style={{ fontVariationSettings: "'wdth' 100" }}
           >
             Learn More
-          </button>
+          </Link>
         </div>
       </div>
     </section>

--- a/web-app/code/src/presentation/components/buildInlime/LoginForm.tsx
+++ b/web-app/code/src/presentation/components/buildInlime/LoginForm.tsx
@@ -243,6 +243,21 @@ export function LoginForm() {
                 </>
               )}
             </button>
+
+            {/* Signup only — let users return to the email login if they picked
+                signup by mistake or mistyped their address. */}
+            {isSignup && (
+              <div className="text-center">
+                <button
+                  type="button"
+                  onClick={() => router.navigate({ to: '/login', search: { mode: 'login', returnTo } })}
+                  className="font-['Instrument_Sans',sans-serif] text-[14px] text-muted-foreground hover:text-foreground flex items-center justify-center gap-1 mx-auto"
+                >
+                  <ArrowLeft className="w-4 h-4" />
+                  Back to login
+                </button>
+              </div>
+            )}
           </form>
         )}
 

--- a/web-app/code/src/presentation/components/buildInlime/PageHeading.tsx
+++ b/web-app/code/src/presentation/components/buildInlime/PageHeading.tsx
@@ -1,0 +1,31 @@
+/**
+ * The gradient band every marketing page opens with, under the header.
+ *
+ * Was copied verbatim across /resources and /get-started before /blog and
+ * /documentation made it four.
+ */
+export function PageHeading({
+  title,
+  description,
+}: {
+  title: string;
+  description: string;
+}) {
+  return (
+    <section className="w-full bg-gradient-to-b from-white to-muted px-[120px] pt-[40px] pb-[28px]">
+      <div className="max-w-[1270px] mx-auto flex flex-col items-center gap-[12px]">
+        <h1 className="font-['Inria_Sans',sans-serif] font-bold text-[26px] leading-[40px] text-foreground text-center max-w-[786px]">
+          {title}
+        </h1>
+        <p
+          className="font-['Instrument_Sans',sans-serif] text-[18px] leading-[26px] text-muted-foreground text-center max-w-[788px]"
+          style={{ fontVariationSettings: "'wdth' 100" }}
+        >
+          {description}
+        </p>
+      </div>
+    </section>
+  );
+}
+
+export default PageHeading;

--- a/web-app/code/src/presentation/components/buildInlime/ProseSection.tsx
+++ b/web-app/code/src/presentation/components/buildInlime/ProseSection.tsx
@@ -1,0 +1,32 @@
+/**
+ * A heading plus body copy, for the prose pages (/about).
+ *
+ * Narrower than the card sections on /features — long-form text wants a
+ * measure it can be read at, not the full 1270px band.
+ */
+
+import type { AboutSection } from "../../content/about";
+
+export function ProseSection({ section }: { section: AboutSection }) {
+  return (
+    <section className="w-full px-[120px] py-[20px]">
+      <div className="max-w-[788px] mx-auto flex flex-col gap-[12px]">
+        <h2 className="font-['Inria_Sans',sans-serif] font-bold text-[22px] leading-[31px] text-foreground">
+          {section.title}
+        </h2>
+
+        {section.paragraphs.map((paragraph) => (
+          <p
+            key={paragraph}
+            className="font-['Instrument_Sans',sans-serif] text-[16px] leading-[26px] text-black"
+            style={{ fontVariationSettings: "'wdth' 100" }}
+          >
+            {paragraph}
+          </p>
+        ))}
+      </div>
+    </section>
+  );
+}
+
+export default ProseSection;

--- a/web-app/code/src/presentation/components/buildInlime/ResourceSection.tsx
+++ b/web-app/code/src/presentation/components/buildInlime/ResourceSection.tsx
@@ -1,0 +1,136 @@
+/**
+ * One resource section — Blog or Documentation — on the /resources page.
+ *
+ * A single box stacked vertically: the latest article on top, the full history
+ * beneath it. Both sections are structurally identical, so they share this
+ * rather than the markup being written out twice.
+ */
+
+import { Link } from "@tanstack/react-router";
+import { CategoryChip } from "./CategoryChip";
+import type { Article } from "../../content/articles";
+
+export type { Article };
+
+export type ResourceSectionProps = {
+  title: string;
+  description: string;
+  /** The full listing this section previews — /blog or /documentation. */
+  to: "/blog" | "/documentation";
+  /** Newest first — the head of the list is the featured article. */
+  articles: Article[];
+};
+
+export function ResourceSection({ title, description, to, articles }: ResourceSectionProps) {
+  const [latest, ...history] = articles;
+
+  return (
+    <section className="w-full px-[120px] py-[56px]">
+      <div className="max-w-[1270px] mx-auto flex flex-col gap-[32px]">
+        {/* Section heading */}
+        <div className="flex flex-col gap-[8px]">
+          <h2 className="font-['Inria_Sans',sans-serif] font-bold text-[22px] leading-[31px] text-foreground">
+            <Link to={to} className="hover:text-primary transition-colors">
+              {title}
+            </Link>
+          </h2>
+          <p
+            className="font-['Instrument_Sans',sans-serif] text-[15px] leading-[22px] text-muted-foreground max-w-[788px]"
+            style={{ fontVariationSettings: "'wdth' 100" }}
+          >
+            {description}
+          </p>
+        </div>
+
+        {/* One box: latest article on top, history beneath */}
+        <div className="bg-white border border-border rounded-[10px] overflow-hidden">
+          {/* Latest */}
+          <article className="p-[32px] flex flex-col gap-[16px] border-b border-border">
+            <div className="flex items-center gap-[12px]">
+              <span
+                className="font-['Instrument_Sans',sans-serif] font-medium text-[13px] leading-[18px] text-primary uppercase tracking-[0.08em]"
+                style={{ fontVariationSettings: "'wdth' 100" }}
+              >
+                Latest
+              </span>
+              <CategoryChip category={latest.category} />
+            </div>
+
+            <h3
+              className="font-['Instrument_Sans',sans-serif] font-semibold text-[20px] leading-[29px] text-black"
+              style={{ fontVariationSettings: "'wdth' 100" }}
+            >
+              {latest.title}
+            </h3>
+
+            <p
+              className="font-['Instrument_Sans',sans-serif] text-[13px] leading-[18px] text-muted-foreground"
+              style={{ fontVariationSettings: "'wdth' 100" }}
+            >
+              <time dateTime={latest.date}>{latest.displayDate}</time>
+              {" · by "}
+              {latest.author}
+            </p>
+
+            <p
+              className="font-['Instrument_Sans',sans-serif] text-[15px] leading-[22px] text-black"
+              style={{ fontVariationSettings: "'wdth' 100" }}
+            >
+              {latest.excerpt}
+            </p>
+          </article>
+
+          {/* History */}
+          <div className="p-[32px] flex flex-col gap-[16px]">
+            <div className="flex items-baseline justify-between gap-[16px]">
+              <h3
+                className="font-['Instrument_Sans',sans-serif] font-semibold text-[18px] leading-[26px] text-black"
+                style={{ fontVariationSettings: "'wdth' 100" }}
+              >
+                All {title}
+              </h3>
+              <Link
+                to={to}
+                className="shrink-0 font-['Instrument_Sans',sans-serif] font-medium text-[13px] leading-[18px] text-primary hover:underline"
+                style={{ fontVariationSettings: "'wdth' 100" }}
+              >
+                View all →
+              </Link>
+            </div>
+
+            {/* Caps at roughly four rows; the rest scrolls rather than growing
+                the box without bound as the archive fills up. */}
+            <ul className="flex flex-col max-h-[320px] overflow-y-auto pr-[8px]">
+              {history.map((article) => (
+                <li
+                  key={article.title}
+                  className="flex flex-col gap-[8px] py-[16px] border-b border-border last:border-b-0 last:pb-0"
+                >
+                  <h4
+                    className="font-['Instrument_Sans',sans-serif] font-medium text-[15px] leading-[22px] text-black"
+                    style={{ fontVariationSettings: "'wdth' 100" }}
+                  >
+                    {article.title}
+                  </h4>
+                  <div className="flex items-center gap-[12px]">
+                    <span
+                      className="font-['Instrument_Sans',sans-serif] text-[13px] leading-[18px] text-muted-foreground"
+                      style={{ fontVariationSettings: "'wdth' 100" }}
+                    >
+                      <time dateTime={article.date}>{article.displayDate}</time>
+                      {" · by "}
+                      {article.author}
+                    </span>
+                    <CategoryChip category={article.category} />
+                  </div>
+                </li>
+              ))}
+            </ul>
+          </div>
+        </div>
+      </div>
+    </section>
+  );
+}
+
+export default ResourceSection;

--- a/web-app/code/src/presentation/components/buildInlime/StepSection.tsx
+++ b/web-app/code/src/presentation/components/buildInlime/StepSection.tsx
@@ -1,0 +1,102 @@
+/**
+ * One numbered section — Signup or Sample Project — on the /get-started page.
+ *
+ * Structurally the sibling of ResourceSection: same section chrome (heading,
+ * description, 1270px container), but the body is an ordered list of steps
+ * rather than articles. `children` renders between the description and the
+ * steps, which is where the sample project puts its brief and BuildUnit map.
+ */
+
+import type { ReactNode } from "react";
+
+export type Step = {
+  title: string;
+  detail: string;
+  /** Optional sub-points, rendered under the detail as a bulleted list. */
+  points?: string[];
+};
+
+export type StepSectionProps = {
+  /** Anchor target, so the nav and footer can deep-link to a section. */
+  id: string;
+  title: string;
+  description: string;
+  steps: Step[];
+  children?: ReactNode;
+};
+
+function StepNumber({ n }: { n: number }) {
+  return (
+    <span
+      className="shrink-0 inline-flex items-center justify-center w-[32px] h-[32px] rounded-full bg-card-surface text-primary font-['Instrument_Sans',sans-serif] font-semibold text-[13px] leading-[18px]"
+      style={{ fontVariationSettings: "'wdth' 100" }}
+      aria-hidden="true"
+    >
+      {n}
+    </span>
+  );
+}
+
+export function StepSection({ id, title, description, steps, children }: StepSectionProps) {
+  return (
+    <section id={id} className="w-full px-[120px] py-[56px]">
+      <div className="max-w-[1270px] mx-auto flex flex-col gap-[32px]">
+        {/* Section heading */}
+        <div className="flex flex-col gap-[8px]">
+          <h2 className="font-['Inria_Sans',sans-serif] font-bold text-[22px] leading-[31px] text-foreground">
+            {title}
+          </h2>
+          <p
+            className="font-['Instrument_Sans',sans-serif] text-[15px] leading-[22px] text-muted-foreground max-w-[788px]"
+            style={{ fontVariationSettings: "'wdth' 100" }}
+          >
+            {description}
+          </p>
+        </div>
+
+        {children}
+
+        {/* Steps */}
+        <ol className="bg-white border border-border rounded-[10px] p-[32px] flex flex-col">
+          {steps.map((step, i) => (
+            <li
+              key={step.title}
+              className="flex items-start gap-[16px] py-[20px] border-b border-border first:pt-0 last:border-b-0 last:pb-0"
+            >
+              <StepNumber n={i + 1} />
+              <div className="flex flex-col gap-[8px]">
+                <h3
+                  className="font-['Instrument_Sans',sans-serif] font-semibold text-[18px] leading-[26px] text-black"
+                  style={{ fontVariationSettings: "'wdth' 100" }}
+                >
+                  {step.title}
+                </h3>
+                <p
+                  className="font-['Instrument_Sans',sans-serif] text-[15px] leading-[22px] text-black"
+                  style={{ fontVariationSettings: "'wdth' 100" }}
+                >
+                  {step.detail}
+                </p>
+                {step.points && (
+                  <ul className="flex flex-col gap-[4px] pl-[20px] list-disc marker:text-primary">
+                    {step.points.map((point) => (
+                      <li
+                        key={point}
+                        className="font-['Instrument_Sans',sans-serif] text-[13px] leading-[18px] text-muted-foreground"
+                        style={{ fontVariationSettings: "'wdth' 100" }}
+                      >
+                        {point}
+                      </li>
+                    ))}
+                  </ul>
+                )}
+              </div>
+            </li>
+          ))}
+        </ol>
+      </div>
+    </section>
+  );
+}
+
+export default StepSection;

--- a/web-app/code/src/presentation/components/buildInlime/admin/UserInfo.tsx
+++ b/web-app/code/src/presentation/components/buildInlime/admin/UserInfo.tsx
@@ -1,6 +1,6 @@
 import { useState } from "react";
 import { Link } from "@tanstack/react-router";
-import { ChevronDown, User, LogOut } from "lucide-react";
+import { ChevronDown, User, LogOut, Home } from "lucide-react";
 import { signOutAndDispose } from "%/infrastructure/auth/client";
 
 interface UserInfoProps {
@@ -43,6 +43,15 @@ export function UserInfo({ initials, name }: UserInfoProps) {
         <>
           <div className="fixed inset-0 z-40" onClick={() => setUserMenuOpen(false)} />
           <div className="absolute left-4 right-4 top-14 bg-white border border-gray-200 shadow-lg rounded-lg z-50 overflow-hidden">
+            <Link
+              to="/"
+              onClick={() => setUserMenuOpen(false)}
+              className="w-full flex items-center gap-2 px-4 py-2.5 text-sm text-foreground hover:bg-gray-50 transition-colors text-left"
+            >
+              <Home className="w-4 h-4 text-muted-foreground" />
+              <span>Home</span>
+            </Link>
+            <div className="border-t border-gray-200" />
             <Link
               to="/account"
               onClick={() => setUserMenuOpen(false)}

--- a/web-app/code/src/presentation/components/buildInlime/admin/UserInfo.tsx
+++ b/web-app/code/src/presentation/components/buildInlime/admin/UserInfo.tsx
@@ -1,5 +1,6 @@
 import { useState } from "react";
-import { ChevronDown, Settings, LogOut } from "lucide-react";
+import { Link } from "@tanstack/react-router";
+import { ChevronDown, User, LogOut } from "lucide-react";
 import { signOutAndDispose } from "%/infrastructure/auth/client";
 
 interface UserInfoProps {
@@ -42,10 +43,14 @@ export function UserInfo({ initials, name }: UserInfoProps) {
         <>
           <div className="fixed inset-0 z-40" onClick={() => setUserMenuOpen(false)} />
           <div className="absolute left-4 right-4 top-14 bg-white border border-gray-200 shadow-lg rounded-lg z-50 overflow-hidden">
-            <button className="w-full flex items-center gap-2 px-4 py-2.5 text-sm text-foreground hover:bg-gray-50 transition-colors text-left">
-              <Settings className="w-4 h-4 text-muted-foreground" />
-              <span>Settings</span>
-            </button>
+            <Link
+              to="/account"
+              onClick={() => setUserMenuOpen(false)}
+              className="w-full flex items-center gap-2 px-4 py-2.5 text-sm text-foreground hover:bg-gray-50 transition-colors text-left"
+            >
+              <User className="w-4 h-4 text-muted-foreground" />
+              <span>Account</span>
+            </Link>
             <div className="border-t border-gray-200" />
             <button
               onClick={handleLogout}

--- a/web-app/code/src/presentation/components/buildInlime/index.tsx
+++ b/web-app/code/src/presentation/components/buildInlime/index.tsx
@@ -50,8 +50,12 @@ export { TeamSection } from "./admin/TeamSection";
 export { UserInfo } from "./admin/UserInfo";
 
 // shared / landing / login (remain flat in buildInlime/)
+export { ArticleList, type ArticleListProps } from "./ArticleList";
 export { BottomSection } from "./BottomSection";
+export { CategoryChip } from "./CategoryChip";
+export { PageHeading } from "./PageHeading";
 export { DisplayButton } from "./DisplayButton";
+export { FeatureSection } from "./FeatureSection";
 export { FeaturesCarousel } from "./FeaturesCarousel";
 export { FilterButton } from "./FilterButton";
 export { Footer } from "./Footer";
@@ -64,6 +68,9 @@ export { LoginForm } from "./LoginForm";
 export { LoginHeader } from "./LoginHeader";
 export { LoginTerms } from "./LoginTerms";
 export { NavButton } from "./NavButton";
+export { ProseSection } from "./ProseSection";
+export { ResourceSection, type Article, type ResourceSectionProps } from "./ResourceSection";
 export { RoutePendingComponent } from "./RoutePendingComponent";
+export { StepSection, type Step, type StepSectionProps } from "./StepSection";
 export { ToolbarButton } from "./ToolbarButton";
 export { TrySection } from "./TrySection";

--- a/web-app/code/src/presentation/components/buildInlime/shared/MarketingNav.tsx
+++ b/web-app/code/src/presentation/components/buildInlime/shared/MarketingNav.tsx
@@ -4,14 +4,13 @@ import { HEADER_LINK_CLASS, HEADER_LINK_STYLE } from "./HeaderShell";
 /**
  * The marketing nav, byte-identical in Header and HeaderLoggedIn before this.
  *
- * Items whose page exists link to it; Pricing still points at "/" as a
- * placeholder, which is preserved rather than quietly fixed.
+ * Every item links to a real page.
  */
 const ITEMS = [
   { label: "About", to: "/about" },
   { label: "Resources", to: "/resources" },
   { label: "Get Started", to: "/get-started" },
-  { label: "Pricing", to: "/" },
+  { label: "Pricing", to: "/pricing" },
 ] as const;
 
 export function MarketingNav() {

--- a/web-app/code/src/presentation/components/buildInlime/shared/MarketingNav.tsx
+++ b/web-app/code/src/presentation/components/buildInlime/shared/MarketingNav.tsx
@@ -4,16 +4,21 @@ import { HEADER_LINK_CLASS, HEADER_LINK_STYLE } from "./HeaderShell";
 /**
  * The marketing nav, byte-identical in Header and HeaderLoggedIn before this.
  *
- * Every item points at "/" — they are placeholders for pages that do not exist
- * yet, which is preserved here rather than quietly fixed.
+ * Items whose page exists link to it; Pricing still points at "/" as a
+ * placeholder, which is preserved rather than quietly fixed.
  */
-const ITEMS = ["About", "Resources", "Get Started", "Pricing"] as const;
+const ITEMS = [
+  { label: "About", to: "/about" },
+  { label: "Resources", to: "/resources" },
+  { label: "Get Started", to: "/get-started" },
+  { label: "Pricing", to: "/" },
+] as const;
 
 export function MarketingNav() {
   return (
     <nav className="flex items-center gap-8 ml-auto">
-      {ITEMS.map((label) => (
-        <Link key={label} to="/" className={HEADER_LINK_CLASS} style={HEADER_LINK_STYLE}>
+      {ITEMS.map(({ label, to }) => (
+        <Link key={label} to={to} className={HEADER_LINK_CLASS} style={HEADER_LINK_STYLE}>
           {label}
         </Link>
       ))}

--- a/web-app/code/src/presentation/content/about.ts
+++ b/web-app/code/src/presentation/content/about.ts
@@ -1,0 +1,45 @@
+/**
+ * Who we are and what we believe, for /about.
+ *
+ * Prose rather than feature claims — this is the one page that says why the
+ * software is shaped the way it is, so it stays in the first person and avoids
+ * promising anything the product doesn't do yet.
+ */
+
+export type AboutSection = {
+  title: string;
+  paragraphs: string[];
+};
+
+export const ABOUT_INTRO =
+  "We are a small group of professionals with a shared interest in alternative ways of living. We build software at community scale and customized for the community needs.";
+
+export const ABOUT_SECTIONS: AboutSection[] = [
+  {
+    title: "Where we come from",
+    paragraphs: [
+      "As part of our exploration of alternative ways of living we came across natural and eco-friendly architecture and buildings — mud, lime, local materials and methods that sit light on the places they are built in.",
+      "Our thinking is motivated by the work of Laurie Baker, Thannal, and the many other natural builders who showed that thoughtful, low-cost, climate-appropriate building is not a compromise but a craft.",
+    ],
+  },
+  {
+    title: "Software at community scale",
+    paragraphs: [
+      "We build software for the community we are ourselves a part of. That proximity is the point: we would rather solve a real problem for the people around us than a generic one for nobody in particular.",
+      "So we believe in community-scale, custom solutions that cater to the actual needs of our community, rather than tools that ask a community to reshape itself to fit the software.",
+    ],
+  },
+  {
+    title: "The community keeps its data",
+    paragraphs: [
+      "We believe in data sovereignty. The information a community generates through our applications — its drawings, its costs, its site records — belongs to that community, and we are particular about keeping it in the community's control.",
+      "In support of this, we are members of the Mozilla Data Collective.",
+    ],
+  },
+  {
+    title: "AI that is built and run locally",
+    paragraphs: [
+      "We believe AI should be built and run locally, close to the people it serves, and shaped around local community needs rather than delivered as a remote service that decides on their behalf.",
+    ],
+  },
+];

--- a/web-app/code/src/presentation/content/about.ts
+++ b/web-app/code/src/presentation/content/about.ts
@@ -18,8 +18,8 @@ export const ABOUT_SECTIONS: AboutSection[] = [
   {
     title: "Where we come from",
     paragraphs: [
-      "As part of our exploration of alternative ways of living we came across natural and eco-friendly architecture and buildings — mud, lime, local materials and methods that sit light on the places they are built in.",
-      "Our thinking is motivated by the work of Laurie Baker, Thannal, and the many other natural builders who showed that thoughtful, low-cost, climate-appropriate building is not a compromise but a craft.",
+      "As part of our exploration of alternative ways of living we came across natural and eco-friendly architecture and buildings — mud, lime, local materials and vernacular methods that are closely aligned to the places they are built in and communities they are built for.",
+      "Our thinking is motivated by the works of Laurie Baker, Thannal, and many other natural builders who showed that thoughtful, low-cost, climate-appropriate building is not a compromise but a craft.",
     ],
   },
   {

--- a/web-app/code/src/presentation/content/articles.ts
+++ b/web-app/code/src/presentation/content/articles.ts
@@ -1,0 +1,121 @@
+/**
+ * Blog and documentation content, newest first.
+ *
+ * There is no articles table yet, so this sits here the way FeaturesCarousel's
+ * slides do — swap it for a query when one exists. It lives outside the pages
+ * because /resources, /blog and /documentation all read the same lists.
+ */
+
+export type Article = {
+  title: string;
+  /** ISO date, used for the <time> machine-readable value. */
+  date: string;
+  /** How the date reads on screen. */
+  displayDate: string;
+  author: string;
+  category: string;
+  /** One-line standfirst — all /resources shows, and the lead on the listings. */
+  excerpt: string;
+  /** Full text, one string per paragraph. Only the listing pages render it. */
+  body: string[];
+};
+
+export const BLOG_ARTICLES: Article[] = [
+  {
+    title: "Why we organize construction around BuildUnits",
+    date: "2026-07-14",
+    displayDate: "14 July 2026",
+    author: "Partha",
+    category: "Product",
+    excerpt:
+      "Drawings, budgets and site updates all describe the same thing from different angles. BuildUnits give every one of them a shared address.",
+    body: [
+      "Most construction software organizes around trades. There is a masonry section, a plumbing section, an electrical section, and every document gets filed under whoever produced it. That matches how work is contracted, so it feels natural. It does not match how anyone on site actually thinks.",
+      "On site, the unit of thought is the thing being built. The roof. The verandah. The external bathroom. When the site supervisor calls the architect, the call is about a place, not a trade — and it usually crosses three trades at once, because that is what the place needs. Filing that conversation under a trade means it lands somewhere none of the participants would look for it.",
+      "A BuildUnit is that place, made into an address. The drawings for the roof, the lime and tandur stone the roof consumes, the roof's share of the budget, the photographs from the day it was poured, and the conversation about whether the coursing was right — all of it hangs off one node. Nothing has to be cross-referenced, because nothing was split apart in the first place.",
+      "The test we apply when deciding whether something deserves its own BuildUnit is simple: does it get built and signed off as a unit? Rainwater harvesting does — it has its own materials, its own budget line and its own completion date. Flooring does not; it runs inside every room, and pulling it out into its own unit would break each room's record in half.",
+    ],
+  },
+  {
+    title: "Notes from a site visit: what gets lost between calls",
+    date: "2026-06-28",
+    displayDate: "28 June 2026",
+    author: "Partha",
+    category: "Field Notes",
+    excerpt:
+      "A week of watching handoffs between the architect and the site supervisor, and where the information fell through.",
+    body: [
+      "We spent a week on a site with no intention of demonstrating anything. The brief was to watch how a decision travels from the architect to the mason, and to write down every point where it stopped travelling.",
+      "The pattern was consistent. Decisions were made on phone calls, and phone calls leave no residue. A mix ratio agreed on Tuesday was re-agreed on Friday, slightly differently, because nobody could recall the first version with confidence. Neither party was careless — the information simply had nowhere to live between the two conversations.",
+      "Photographs were the second gap. The supervisor took them constantly, and they were genuinely good: close, well-lit, taken at the moment that mattered. They went into a chat thread, where they were unfindable within about two days. By the time anyone wanted to compare a cure at seven days against the same panel at fourteen, the earlier photograph had scrolled into the past and nobody was willing to hunt for it.",
+      "The third gap was the one that cost money. A material lead time — lime slaking, which cannot be hurried — was known to the architect and not written anywhere the supervisor would see it. The crew arrived ready to work on a wall that could not be plastered for another ten days.",
+      "None of these are communication failures in the usual sense. Everyone spoke to everyone. What was missing was a place for the outcome of a conversation to sit, attached to the thing it was about, where the next person to need it would trip over it without having to know it existed.",
+    ],
+  },
+  {
+    title: "Lime plaster, and why the schedule bends around it",
+    date: "2026-06-02",
+    displayDate: "2 June 2026",
+    author: "Partha",
+    category: "Materials",
+    excerpt:
+      "Natural materials cure on their own timeline. Planning around that beats planning against it.",
+    body: [
+      "Cement sets on a schedule you can plan around. Lime does not set so much as slowly become itself, and it does that at a pace decided by humidity, temperature and how thickly it was applied. Any schedule that treats a lime coat as a fixed-duration task is a schedule that will be wrong.",
+      "The practical consequence is that sequencing matters more than crew availability. A double coat of lime plaster needs the first coat to have carbonated enough to take the second — push it early and the finish crazes, wait too long and the coats bond poorly. The window is real but it is not a date you can print in advance.",
+      "This is why we put the roof before the interior plaster in the sample project, and why that ordering is not negotiable. Plaster mid-cure that gets rained on is plaster you redo. The roof is not on the critical path because it is difficult; it is there because everything downstream of it is vulnerable until it exists.",
+      "The scheduling habit that works is to set target dates off cure times and let crew allocation follow, rather than the reverse. It feels backwards to anyone used to cement, and it is the single change that most reliably keeps a natural-building project from compounding small delays into large ones.",
+    ],
+  },
+];
+
+export const DOCUMENTATION_ARTICLES: Article[] = [
+  {
+    title: "Getting started: your first project",
+    date: "2026-07-10",
+    displayDate: "10 July 2026",
+    author: "Partha",
+    category: "Guide",
+    excerpt:
+      "Create a project, break it into BuildUnits, and invite your architect and site supervisor to their first channel.",
+    body: [
+      "Signing up takes a name and an email address. There is no password to choose — we email a six-digit code, and entering it both confirms the address and signs you in. The name you give is what teammates see on comments and task assignments, so use the name you go by on site.",
+      "Once you are in, click New Project. Name it for the building, not the client, and put the one-paragraph brief in the description. You need to be online to create a project; everything after that syncs.",
+      "Next, break the house into BuildUnits. Add one for each piece that gets built and signed off as a unit — foundation, each room, roof, rainwater harvesting. Resist splitting by trade. Flooring and plastering run inside every room and belong as tasks in that room's Execution channel, not as units of their own.",
+      "Inside each BuildUnit, open the channels it needs. There are seven types — Finance, Requirements, Design, Materials, Tools, Execution and Experimentation — and each type can be opened once per BuildUnit, so a channel name is never ambiguous. Most units start with Requirements and Design and grow the rest as work begins.",
+      "Finally, invite the people building it. The architect, the site supervisor and the mason lead see the same BuildUnits and channels you do, and photographs uploaded from a phone on site sync to everyone on the project.",
+    ],
+  },
+  {
+    title: "Channels, tasks and comments",
+    date: "2026-06-20",
+    displayDate: "20 June 2026",
+    author: "Partha",
+    category: "Guide",
+    excerpt:
+      "How conversation is scoped in BuildInLime, and when to open a channel instead of a task.",
+    body: [
+      "A channel is a subject area within a BuildUnit. A task is a piece of work with an owner and a date. The distinction matters because putting work in a channel loses its accountability, and putting a subject in a task buries it under something that will eventually be marked done.",
+      "The seven channel types are fixed deliberately. Finance holds estimates and actuals for that unit, so an overrun on the roof stays visible as a roof problem instead of dissolving into a project total. Requirements holds decisions already made. Design holds drawings. Materials holds what the unit consumes, including lead times. Tools holds equipment. Execution holds the build itself. Experimentation holds trial panels and mixes.",
+      "Experimentation is the one people skip and then wish they had not. Run a panel of the limecrete bed or the double-coat plaster, photograph it at each cure stage, and comment the mix ratio the panel actually used. When a mix is approved, it becomes the reference every room is built against — and the photographs are the evidence for why.",
+      "Comments belong on the task or channel they concern, not in a general thread. This is the habit that takes longest to build and pays back the most: six months later, the reason a decision was made is attached to the thing it was made about.",
+    ],
+  },
+  {
+    title: "Uploading drawings and site photographs",
+    date: "2026-05-30",
+    displayDate: "30 May 2026",
+    author: "Partha",
+    category: "Reference",
+    excerpt:
+      "Attachment limits, supported formats, and how uploads sync to everyone else on the project.",
+    body: [
+      "Attachments go on channels and tasks. Drawings belong in the BuildUnit's Design channel; site photographs usually belong on the Execution task they document, so the record of what happened sits with the work it happened to.",
+      "Heavy files can be scheduled rather than sent immediately. Pick a date and an hour when you attach the file, and the upload waits until then — useful when you are on site with a slow connection and a folder of full-resolution photographs, and would rather they went up overnight than fought you for bandwidth while you are still working.",
+      "Everything uploaded anywhere in a channel is collected in that channel's Resources section. You do not have to remember which task or comment a drawing arrived on: the Resources view is the single list of every file on the channel, which is usually the fastest way back to something somebody attached weeks ago.",
+      "You can delete an attachment you own. The delete control appears on files you uploaded — and on files attached to a task you created — and removing one removes it for everyone on the project, so you are asked to confirm first.",
+      "The roof build-up and the verandah wall detail are worth their own drawings rather than being folded into a general plan. Exposed laterite gives you no opportunity to correct coursing afterwards, so the detail needs to be legible on its own on a phone screen in daylight.",
+      "Photographs of trial panels should be taken at each cure stage from roughly the same position and distance. Consistency is what makes them comparable later, and comparison is the entire point of running a panel.",
+    ],
+  },
+];

--- a/web-app/code/src/presentation/content/features.ts
+++ b/web-app/code/src/presentation/content/features.ts
@@ -1,0 +1,219 @@
+/**
+ * What the two clients can actually do, grouped for /features.
+ *
+ * Written against the shipping code rather than the roadmap: a feature only
+ * appears here if a user can reach it in the UI today. Where web and mobile
+ * differ, `platform` says which one has it and `note` says what the other is
+ * missing — the alternative is a page that promises parity we don't have.
+ *
+ * Deliberately absent, because they are stubs or unbuilt: global search, the
+ * notifications bell, custom views, push notifications, in-app camera and voice
+ * recording, message editing, and role-based permissions.
+ */
+
+export type Platform = "both" | "web" | "mobile";
+
+export type Feature = {
+  name: string;
+  description: string;
+  platform: Platform;
+  /** How the clients differ, where they do. */
+  note?: string;
+};
+
+export type FeatureGroup = {
+  title: string;
+  description: string;
+  features: Feature[];
+};
+
+export const PLATFORM_LABELS: Record<Platform, string> = {
+  both: "Web & mobile",
+  web: "Web",
+  mobile: "Mobile",
+};
+
+export const FEATURE_GROUPS: FeatureGroup[] = [
+  {
+    title: "Structure",
+    description:
+      "Every project is a hierarchy — project, BuildUnit, channel — so a drawing, a bill and a site photograph can all point at the same thing",
+    features: [
+      {
+        name: "Projects and BuildUnits",
+        description:
+          "Break a build into the units that get built and signed off separately — a foundation, a room, a roof. Everything else hangs off them.",
+        platform: "both",
+        note: "Created on web; mobile browses the hierarchy rather than editing it.",
+      },
+      {
+        name: "Seven fixed channels per BuildUnit",
+        description:
+          "Finance, Requirements, Design, Materials, Tools, Execution and Experimentation. The set is fixed on purpose, so the same aspect of a build is always in the same place across every project.",
+        platform: "both",
+        note: "Opened on web; visible on both.",
+      },
+      {
+        name: "Per-channel membership",
+        description:
+          "Add people to the channels they belong in. Only members can see a channel's contents, so the client can sit in Design without also being in Finance.",
+        platform: "web",
+        note: "Membership is managed on web; mobile respects it.",
+      },
+      {
+        name: "Teams",
+        description:
+          "Group the people you work with repeatedly so they are easier to pull into a new project.",
+        platform: "web",
+      },
+    ],
+  },
+  {
+    title: "Working together",
+    description:
+      "Conversation is scoped to the channel it belongs to, so it stays findable months later",
+    features: [
+      {
+        name: "Messages and threaded replies",
+        description:
+          "Post to a channel and reply in a thread. Deleting your own message leaves the replies under it intact.",
+        platform: "both",
+        note: "Web threads nest several levels deep; mobile threads go one level.",
+      },
+      {
+        name: "File attachments",
+        description:
+          "Attach photographs, drawings, PDFs, spreadsheets, and audio or video files to any message. Image and video attachments preview inline.",
+        platform: "both",
+        note: "Web picks several files at once; mobile picks one at a time and lets you rename it first.",
+      },
+      {
+        name: "Mentions and the Inbox",
+        description:
+          "Mention someone and it lands in their Inbox, with the project, BuildUnit and channel it came from. Opening it jumps straight to the message.",
+        platform: "both",
+        note: "Mentions are written on web; both clients receive and read them.",
+      },
+    ],
+  },
+  {
+    title: "Tasks",
+    description: "The work itself, assigned and tracked inside the channel it belongs to",
+    features: [
+      {
+        name: "Create and assign",
+        description:
+          "Open a task in any channel and assign it to someone on the project.",
+        platform: "both",
+      },
+      {
+        name: "Completion notes as history",
+        description:
+          "Closing or reopening a task requires a note. Those notes accumulate into the task's history, so months later you can read why something changed, not just that it did.",
+        platform: "both",
+      },
+      {
+        name: "Properties",
+        description:
+          "Priority, status, start and target dates, percent complete and labels — on tasks, and on projects, BuildUnits and channels too.",
+        platform: "web",
+        note: "Edited on web; mobile displays them and sets task status.",
+      },
+      {
+        name: "My Tasks",
+        description:
+          "Everything assigned to you across every project, open first, with a live count.",
+        platform: "both",
+      },
+      {
+        name: "Filter BuildUnits",
+        description:
+          "Narrow a project by name, health, priority, target date, the task it is waiting on, or how far along it is.",
+        platform: "web",
+      },
+    ],
+  },
+  {
+    title: "Files",
+    description: "Drawings, photographs and documents, kept against the unit they describe",
+    features: [
+      {
+        name: "Upload to a channel, message or task",
+        description:
+          "Files carry a name and description and stay attached to the thing they document.",
+        platform: "both",
+      },
+      {
+        name: "Scheduled upload",
+        description:
+          "Hold a large upload until a chosen date and hour — useful when the site has metered or intermittent data and you would rather send at night.",
+        platform: "both",
+      },
+      {
+        name: "Uploads that survive a bad connection",
+        description:
+          "Interrupted uploads retry with backoff instead of failing outright.",
+        platform: "both",
+        note: "Mobile resumes an interrupted upload automatically; web hands it back to you to restart.",
+      },
+      {
+        name: "Download to the device",
+        description:
+          "Pull a drawing down to look at it away from signal.",
+        platform: "both",
+        note: "Mobile saves to a folder you choose on Android, or through the share sheet on iOS.",
+      },
+    ],
+  },
+  {
+    title: "Offline",
+    description:
+      "Sites lose signal. The app is built so that the work does not stop when the connection does",
+    features: [
+      {
+        name: "Work without a connection",
+        description:
+          "Send messages and replies, create tasks, assign them, close and reopen them, and edit properties — all offline. Changes queue in order on the device and sync when you are back in range.",
+        platform: "both",
+      },
+      {
+        name: "A local copy of your projects",
+        description:
+          "Your projects are stored on the device, so opening the app offline shows real data rather than an error.",
+        platform: "both",
+        note: "Mobile syncs one project at a time, keeping the working set small on a phone.",
+      },
+      {
+        name: "Offline in the browser too",
+        description:
+          "The web app installs as a PWA and opens offline — including on a direct URL or a refresh.",
+        platform: "web",
+      },
+      {
+        name: "What still needs signal",
+        description:
+          "Creating a project, BuildUnit or channel, logging in, and the actual transfer of file uploads. The app tells you plainly rather than queueing something it cannot complete.",
+        platform: "both",
+      },
+    ],
+  },
+  {
+    title: "Accounts",
+    description: "Getting in, and keeping the device safe afterwards",
+    features: [
+      {
+        name: "Passwordless sign-in",
+        description:
+          "A six-digit code by email — nothing to choose, forget or reuse.",
+        platform: "both",
+        note: "New accounts are created on web; mobile signs in an existing account.",
+      },
+      {
+        name: "Sign-out clears the device",
+        description:
+          "Signing out wipes the local copy of your projects, so a shared or handed-on phone does not keep them.",
+        platform: "both",
+      },
+    ],
+  },
+];

--- a/web-app/code/src/presentation/pages/AboutPage.tsx
+++ b/web-app/code/src/presentation/pages/AboutPage.tsx
@@ -1,0 +1,27 @@
+import { Header, HeaderLoggedIn, Footer, PageHeading, ProseSection } from "../components/buildInlime";
+import { ABOUT_INTRO, ABOUT_SECTIONS } from "../content/about";
+import { signOutAndDispose, useRequireAuth } from "../../infrastructure/auth/client";
+
+export default function AboutPage() {
+  const { user } = useRequireAuth();
+  const loggedIn = !!user;
+
+  const handleSignOut = async () => {
+    await signOutAndDispose();
+    window.location.href = "/";
+  };
+
+  return (
+    <div className="bg-white flex flex-col items-start min-h-screen">
+      {loggedIn ? <HeaderLoggedIn onSignOut={handleSignOut} /> : <Header />}
+
+      <PageHeading title="About us" description={ABOUT_INTRO} />
+
+      {ABOUT_SECTIONS.map((section) => (
+        <ProseSection key={section.title} section={section} />
+      ))}
+
+      <Footer compact />
+    </div>
+  );
+}

--- a/web-app/code/src/presentation/pages/AccountPage.tsx
+++ b/web-app/code/src/presentation/pages/AccountPage.tsx
@@ -1,0 +1,53 @@
+import { ArrowLeft } from "lucide-react";
+import { Sidebar } from "../components/buildInlime";
+import { useSession } from "%/infrastructure/auth/client";
+
+/** One label/value row of account detail. */
+function DetailRow({ label, value }: { label: string; value: string }) {
+  return (
+    <div className="flex flex-col gap-1 py-4 border-b border-card-border last:border-b-0">
+      <span className="text-xs text-muted-foreground">{label}</span>
+      <span className="text-sm text-foreground break-words">{value}</span>
+    </div>
+  );
+}
+
+export function AccountPage() {
+  const { data: session, isPending } = useSession();
+  const user = session?.user;
+
+  return (
+    <div className="flex h-screen bg-white font-['Instrument_Sans',sans-serif]">
+      <Sidebar />
+
+      <main className="flex-1 flex flex-col overflow-hidden">
+        {/* Top nav */}
+        <header className="h-12 bg-white border-b border-card-border flex items-center gap-3 px-6">
+          <button
+            onClick={() => window.history.back()}
+            className="p-1 text-muted-foreground hover:text-foreground hover:bg-icon-chip rounded transition-colors"
+          >
+            <ArrowLeft className="w-4 h-4" />
+          </button>
+          <h1 className="font-semibold text-[16px] text-foreground">Account</h1>
+        </header>
+
+        {/* Content */}
+        <div className="flex-1 overflow-y-auto px-8 py-6">
+          {isPending ? (
+            <p className="text-sm text-muted-foreground">Loading…</p>
+          ) : !user ? (
+            <p className="text-sm text-muted-foreground">Not signed in.</p>
+          ) : (
+            <div className="max-w-2xl">
+              <DetailRow label="Name" value={user.name || "—"} />
+              <DetailRow label="Email" value={user.email || "—"} />
+            </div>
+          )}
+        </div>
+      </main>
+    </div>
+  );
+}
+
+export default AccountPage;

--- a/web-app/code/src/presentation/pages/BlogPage.tsx
+++ b/web-app/code/src/presentation/pages/BlogPage.tsx
@@ -1,0 +1,36 @@
+import { Header, HeaderLoggedIn, Footer, ArticleList, PageHeading } from "../components/buildInlime";
+import { BLOG_ARTICLES } from "../content/articles";
+import { signOutAndDispose, useRequireAuth } from "../../infrastructure/auth/client";
+
+export default function BlogPage() {
+  const { user } = useRequireAuth();
+  const loggedIn = !!user;
+
+  const handleSignOut = async () => {
+    await signOutAndDispose();
+    window.location.href = "/";
+  };
+
+  return (
+    // Fixed to the viewport: header, heading and footer stay put while the
+    // articles scroll in the middle.
+    <div className="bg-white flex flex-col h-screen overflow-hidden">
+      <div className="shrink-0">
+        {loggedIn ? <HeaderLoggedIn onSignOut={handleSignOut} /> : <Header />}
+
+        <PageHeading
+          title="Blog"
+          description="Notes from the field on natural building, and what we are changing in the product"
+        />
+      </div>
+
+      <div className="flex-1 min-h-0 overflow-y-auto">
+        <ArticleList articles={BLOG_ARTICLES} />
+      </div>
+
+      <div className="shrink-0">
+        <Footer compact />
+      </div>
+    </div>
+  );
+}

--- a/web-app/code/src/presentation/pages/DocumentationPage.tsx
+++ b/web-app/code/src/presentation/pages/DocumentationPage.tsx
@@ -1,0 +1,36 @@
+import { Header, HeaderLoggedIn, Footer, ArticleList, PageHeading } from "../components/buildInlime";
+import { DOCUMENTATION_ARTICLES } from "../content/articles";
+import { signOutAndDispose, useRequireAuth } from "../../infrastructure/auth/client";
+
+export default function DocumentationPage() {
+  const { user } = useRequireAuth();
+  const loggedIn = !!user;
+
+  const handleSignOut = async () => {
+    await signOutAndDispose();
+    window.location.href = "/";
+  };
+
+  return (
+    // Fixed to the viewport: header, heading and footer stay put while the
+    // articles scroll in the middle.
+    <div className="bg-white flex flex-col h-screen overflow-hidden">
+      <div className="shrink-0">
+        {loggedIn ? <HeaderLoggedIn onSignOut={handleSignOut} /> : <Header />}
+
+        <PageHeading
+          title="Documentation"
+          description="Guides and reference material for getting your project running"
+        />
+      </div>
+
+      <div className="flex-1 min-h-0 overflow-y-auto">
+        <ArticleList articles={DOCUMENTATION_ARTICLES} />
+      </div>
+
+      <div className="shrink-0">
+        <Footer compact />
+      </div>
+    </div>
+  );
+}

--- a/web-app/code/src/presentation/pages/FeaturesPage.tsx
+++ b/web-app/code/src/presentation/pages/FeaturesPage.tsx
@@ -1,0 +1,30 @@
+import { Header, HeaderLoggedIn, Footer, PageHeading, FeatureSection } from "../components/buildInlime";
+import { FEATURE_GROUPS } from "../content/features";
+import { signOutAndDispose, useRequireAuth } from "../../infrastructure/auth/client";
+
+export default function FeaturesPage() {
+  const { user } = useRequireAuth();
+  const loggedIn = !!user;
+
+  const handleSignOut = async () => {
+    await signOutAndDispose();
+    window.location.href = "/";
+  };
+
+  return (
+    <div className="bg-white flex flex-col items-start min-h-screen">
+      {loggedIn ? <HeaderLoggedIn onSignOut={handleSignOut} /> : <Header />}
+
+      <PageHeading
+        title="Features"
+        description="What the web app and the mobile app can each do today — including where they differ, and what still needs a connection"
+      />
+
+      {FEATURE_GROUPS.map((group) => (
+        <FeatureSection key={group.title} group={group} />
+      ))}
+
+      <Footer compact />
+    </div>
+  );
+}

--- a/web-app/code/src/presentation/pages/GettingStartedPage.tsx
+++ b/web-app/code/src/presentation/pages/GettingStartedPage.tsx
@@ -1,0 +1,200 @@
+import { Header, HeaderLoggedIn, Footer, StepSection } from "../components/buildInlime";
+import type { Step } from "../components/buildInlime";
+import { signOutAndDispose, useRequireAuth } from "../../infrastructure/auth/client";
+
+/**
+ * Placeholder content in the same spirit as ResourcesPage's article lists — the
+ * copy lives here rather than in a CMS, because there isn't one yet.
+ */
+
+/**
+ * The eight BuildUnits the sample house breaks into. Rendered as the "how would
+ * I model this" answer before the steps that build it.
+ */
+const SAMPLE_BUILD_UNITS: { name: string; scope: string }[] = [
+  {
+    name: "Foundation & Plinth",
+    scope:
+      "Shallow excavation — the rocky terrain rules out a deep basement. Laterite stone footings set in lime concrete.",
+  },
+  {
+    name: "Verandah",
+    scope:
+      "Exposed laterite walls, no plaster. Tandur stone flooring on a limecrete bed.",
+  },
+  {
+    name: "Hall",
+    scope: "Double-coat lime plaster inside. Tandur stone flooring on limecrete.",
+  },
+  {
+    name: "Kitchen & Dining",
+    scope:
+      "Double-coat lime plaster, tandur stone flooring, and the wet-area detailing the room needs.",
+  },
+  {
+    name: "Bedroom",
+    scope: "Double-coat lime plaster inside, tandur stone flooring on limecrete.",
+  },
+  {
+    name: "External Bathroom",
+    scope:
+      "Detached from the main block. Its own drainage, and lime plaster specified for constant damp.",
+  },
+  {
+    name: "Roof",
+    scope:
+      "Limecrete variation of a Madras terrace, tandur stone joists, finished with thin tandur stone slabs against rainwater seepage.",
+  },
+  {
+    name: "Rainwater Harvesting",
+    scope:
+      "Gutters, downpipes, filtration and the storage tank — sized off the roof area, so it depends on the Roof unit.",
+  },
+];
+
+const SAMPLE_PROJECT_STEPS: Step[] = [
+  {
+    title: "Create your account",
+    detail:
+      "Click Login in the header and choose Create an account. Give your full name and email address — there is no password to choose.",
+    points: [
+      "Your name is what teammates see on comments, task assignments and channel activity, so use the name you go by on site.",
+      "If an account already exists for that email, we tell you and offer to log you in instead.",
+    ],
+  },
+  {
+    title: "Verify with the emailed code",
+    detail:
+      "We email you a six-digit code. Enter it to confirm the address, which signs you in and saves your name to your profile.",
+    points: [
+      "Codes expire; use Resend if one goes stale or never arrives.",
+      "Check spam if the email is slow to land.",
+      "Back to email lets you correct a typo in the address without starting over.",
+    ],
+  },
+  {
+    title: "Create the project",
+    detail:
+      'From your workspace, click New Project. Name it something like "Laterite Village Home" and put the one-paragraph brief in the description. You have to be online to create a project.',
+  },
+  {
+    title: "Break the house into BuildUnits",
+    detail:
+      "Open the project and add a BuildUnit for each of the eight pieces above. A BuildUnit is the shared address that drawings, budgets, materials and site updates all hang off — so split by what gets built and signed off as a unit, not by trade.",
+    points: [
+      "Flooring and plastering are deliberately not their own BuildUnits — they run inside each room, as tasks in that room's Execution channel.",
+      "Rainwater Harvesting is its own unit because it has its own materials, its own budget and its own completion date.",
+    ],
+  },
+  {
+    title: "Open the channels each BuildUnit needs",
+    detail:
+      "Inside a BuildUnit, click New Channel and pick from the seven types: Finance, Requirements, Design, Materials, Tools, Execution and Experimentation. Each type corresponds to a particular aspect of the BuildUnit. Everything related to a channel of the BuildUnit is communicated through messages and tasks.",
+  },
+  {
+    title: "Add people to the channels and start talking",
+    detail:
+      "Add the relevant people to each channel and start the conversation through messages, images, audio and video. Only invited users can see a channel's details — so you might want only the architect and the client in Design.",
+  },
+];
+
+function SampleBrief() {
+  return (
+    <div className="bg-card-surface border border-border rounded-[10px] p-[32px] flex flex-col gap-[24px]">
+      <div className="flex flex-col gap-[8px]">
+        <h3
+          className="font-['Instrument_Sans',sans-serif] font-semibold text-[18px] leading-[26px] text-black"
+          style={{ fontVariationSettings: "'wdth' 100" }}
+        >
+          The brief
+        </h3>
+        <p
+          className="font-['Instrument_Sans',sans-serif] text-[15px] leading-[22px] text-black max-w-[788px]"
+          style={{ fontVariationSettings: "'wdth' 100" }}
+        >
+          A laterite stone village home — verandah, hall, kitchen/dining, bedroom
+          and an external bathroom. The terrain is rocky, so the basement stays
+          shallow. Lime concrete replaces cement throughout. The roof is a
+          limecrete variation of a Madras terrace carried on tandur stones and
+          covered with thin tandur slabs against rainwater seepage. Floors are
+          tandur stone on a limecrete bed. The verandah and all outer walls are
+          left exposed; the remaining interior walls take a double coat of lime
+          plaster. Rainwater is harvested off the roof.
+        </p>
+      </div>
+
+      <div className="flex flex-col gap-[12px]">
+        <h4
+          className="font-['Instrument_Sans',sans-serif] font-medium text-[15px] leading-[22px] text-black"
+          style={{ fontVariationSettings: "'wdth' 100" }}
+        >
+          How it breaks into BuildUnits
+        </h4>
+        <ul className="flex flex-col">
+          {SAMPLE_BUILD_UNITS.map((unit) => (
+            <li
+              key={unit.name}
+              className="flex flex-col gap-[4px] py-[12px] border-b border-border last:border-b-0 last:pb-0"
+            >
+              <span
+                className="font-['Instrument_Sans',sans-serif] font-medium text-[15px] leading-[22px] text-black"
+                style={{ fontVariationSettings: "'wdth' 100" }}
+              >
+                {unit.name}
+              </span>
+              <span
+                className="font-['Instrument_Sans',sans-serif] text-[13px] leading-[18px] text-muted-foreground"
+                style={{ fontVariationSettings: "'wdth' 100" }}
+              >
+                {unit.scope}
+              </span>
+            </li>
+          ))}
+        </ul>
+      </div>
+    </div>
+  );
+}
+
+export default function GettingStartedPage() {
+  const { user } = useRequireAuth();
+  const loggedIn = !!user;
+
+  const handleSignOut = async () => {
+    await signOutAndDispose();
+    window.location.href = "/";
+  };
+
+  return (
+    <div className="bg-white flex flex-col items-start min-h-screen">
+      {loggedIn ? <HeaderLoggedIn onSignOut={handleSignOut} /> : <Header />}
+
+      {/* Page heading */}
+      <section className="w-full bg-gradient-to-b from-white to-muted px-[120px] pt-[40px] pb-[28px]">
+        <div className="max-w-[1270px] mx-auto flex flex-col items-center gap-[12px]">
+          <h1 className="font-['Inria_Sans',sans-serif] font-bold text-[26px] leading-[40px] text-foreground text-center max-w-[786px]">
+            Getting Started
+          </h1>
+          <p
+            className="font-['Instrument_Sans',sans-serif] text-[18px] leading-[26px] text-muted-foreground text-center max-w-[788px]"
+            style={{ fontVariationSettings: "'wdth' 100" }}
+          >
+            Create your account, then walk a real natural-building project
+            through the platform from brief to site
+          </p>
+        </div>
+      </section>
+
+      <StepSection
+        id="sample-project"
+        title="Sample Project on BuildInLime"
+        description="A worked example, start to finish: signing up, then setting up a laterite and lime village home and running it through projects, BuildUnits and channels"
+        steps={SAMPLE_PROJECT_STEPS}
+      >
+        <SampleBrief />
+      </StepSection>
+
+      <Footer compact />
+    </div>
+  );
+}

--- a/web-app/code/src/presentation/pages/LoginPage.tsx
+++ b/web-app/code/src/presentation/pages/LoginPage.tsx
@@ -1,4 +1,4 @@
-import { LoginHeader, LoginDecorativeImage , LoginForm , LoginTerms  } from "../components/buildInlime";
+import { LoginHeader, LoginDecorativeImage , LoginForm , LoginTerms, Footer  } from "../components/buildInlime";
 
 export default function LoginPage2() {
   return (
@@ -17,6 +17,8 @@ export default function LoginPage2() {
           </div>
         </div>
       </div>
+
+      <Footer compact />
     </div>
   );
 }

--- a/web-app/code/src/presentation/pages/PricingPage.tsx
+++ b/web-app/code/src/presentation/pages/PricingPage.tsx
@@ -1,0 +1,67 @@
+import { Link } from "@tanstack/react-router";
+import { Header, HeaderLoggedIn, Footer, PageHeading } from "../components/buildInlime";
+import { signOutAndDispose, useRequireAuth } from "../../infrastructure/auth/client";
+
+export default function PricingPage() {
+  const { user } = useRequireAuth();
+  const loggedIn = !!user;
+
+  const handleSignOut = async () => {
+    await signOutAndDispose();
+    window.location.href = "/";
+  };
+
+  return (
+    // Same fixed-viewport shell as the other marketing pages: header and
+    // heading pinned, the middle scrolls, footer pinned.
+    <div className="bg-white flex flex-col h-screen overflow-hidden">
+      <div className="shrink-0">
+        {loggedIn ? <HeaderLoggedIn onSignOut={handleSignOut} /> : <Header />}
+
+        <PageHeading
+          title="Pricing"
+          description="We are still working out what the plans should look like"
+        />
+      </div>
+
+      <div className="flex-1 min-h-0 overflow-y-auto">
+        <section className="px-[120px] py-[64px]">
+          <div className="max-w-[640px] mx-auto flex flex-col items-center gap-[16px] bg-icon-chip border border-card-border rounded-lg px-[40px] py-[48px]">
+            <p
+              className="font-['Instrument_Sans',sans-serif] font-medium text-[14px] leading-[20px] text-primary uppercase tracking-[0.08em]"
+              style={{ fontVariationSettings: "'wdth' 100" }}
+            >
+              Coming Soon
+            </p>
+
+            <h2 className="font-['Inria_Sans',sans-serif] font-bold text-[26px] leading-[36px] text-foreground text-center">
+              Plans are not ready yet
+            </h2>
+
+            <p
+              className="font-['Instrument_Sans',sans-serif] text-[16px] leading-[26px] text-muted-foreground text-center"
+              style={{ fontVariationSettings: "'wdth' 100" }}
+            >
+              BuildInLime is free to use while we are building it out with the
+              people on site. When there is something to charge for, we will
+              publish it here first — no surprise bills on an account you
+              already set up.
+            </p>
+
+            <Link
+              to="/get-started"
+              className="mt-[8px] inline-flex items-center rounded-md bg-primary px-[20px] py-[10px] font-['Instrument_Sans',sans-serif] text-[14px] leading-[20px] text-primary-foreground hover:opacity-90 transition-opacity"
+              style={{ fontVariationSettings: "'wdth' 100" }}
+            >
+              Get started for free
+            </Link>
+          </div>
+        </section>
+      </div>
+
+      <div className="shrink-0">
+        <Footer compact />
+      </div>
+    </div>
+  );
+}

--- a/web-app/code/src/presentation/pages/ResourcesPage.tsx
+++ b/web-app/code/src/presentation/pages/ResourcesPage.tsx
@@ -1,0 +1,40 @@
+import { Header, HeaderLoggedIn, Footer, ResourceSection, PageHeading } from "../components/buildInlime";
+import { BLOG_ARTICLES, DOCUMENTATION_ARTICLES } from "../content/articles";
+import { signOutAndDispose, useRequireAuth } from "../../infrastructure/auth/client";
+
+export default function ResourcesPage() {
+  const { user } = useRequireAuth();
+  const loggedIn = !!user;
+
+  const handleSignOut = async () => {
+    await signOutAndDispose();
+    window.location.href = "/";
+  };
+
+  return (
+    <div className="bg-white flex flex-col items-start min-h-screen">
+      {loggedIn ? <HeaderLoggedIn onSignOut={handleSignOut} /> : <Header />}
+
+      <PageHeading
+        title="Resources"
+        description="What we are learning about building natural homes, and how to get the most out of the platform"
+      />
+
+      <ResourceSection
+        title="Blog"
+        to="/blog"
+        description="Notes from the field on natural building, and what we are changing in the product"
+        articles={BLOG_ARTICLES}
+      />
+
+      <ResourceSection
+        title="Documentation"
+        to="/documentation"
+        description="Guides and reference material for getting your project running"
+        articles={DOCUMENTATION_ARTICLES}
+      />
+
+      <Footer compact />
+    </div>
+  );
+}

--- a/web-app/code/src/presentation/routeTree.gen.ts
+++ b/web-app/code/src/presentation/routeTree.gen.ts
@@ -10,6 +10,7 @@
 
 import { Route as rootRouteImport } from './routes/__root'
 import { Route as ResourcesRouteImport } from './routes/resources'
+import { Route as PricingRouteImport } from './routes/pricing'
 import { Route as LoginRouteImport } from './routes/login'
 import { Route as GetStartedRouteImport } from './routes/get-started'
 import { Route as FeaturesRouteImport } from './routes/features'
@@ -52,6 +53,11 @@ import { Route as AuthenticatedProjectsProjectIdBuildUnitNameChannelNameTaskName
 const ResourcesRoute = ResourcesRouteImport.update({
   id: '/resources',
   path: '/resources',
+  getParentRoute: () => rootRouteImport,
+} as any)
+const PricingRoute = PricingRouteImport.update({
+  id: '/pricing',
+  path: '/pricing',
   getParentRoute: () => rootRouteImport,
 } as any)
 const LoginRoute = LoginRouteImport.update({
@@ -267,6 +273,7 @@ export interface FileRoutesByFullPath {
   '/features': typeof FeaturesRoute
   '/get-started': typeof GetStartedRoute
   '/login': typeof LoginRoute
+  '/pricing': typeof PricingRoute
   '/resources': typeof ResourcesRoute
   '/account': typeof AuthenticatedAccountRoute
   '/inbox': typeof AuthenticatedInboxRoute
@@ -307,6 +314,7 @@ export interface FileRoutesByTo {
   '/features': typeof FeaturesRoute
   '/get-started': typeof GetStartedRoute
   '/login': typeof LoginRoute
+  '/pricing': typeof PricingRoute
   '/resources': typeof ResourcesRoute
   '/account': typeof AuthenticatedAccountRoute
   '/inbox': typeof AuthenticatedInboxRoute
@@ -346,6 +354,7 @@ export interface FileRoutesById {
   '/features': typeof FeaturesRoute
   '/get-started': typeof GetStartedRoute
   '/login': typeof LoginRoute
+  '/pricing': typeof PricingRoute
   '/resources': typeof ResourcesRoute
   '/_authenticated/account': typeof AuthenticatedAccountRoute
   '/_authenticated/inbox': typeof AuthenticatedInboxRoute
@@ -388,6 +397,7 @@ export interface FileRouteTypes {
     | '/features'
     | '/get-started'
     | '/login'
+    | '/pricing'
     | '/resources'
     | '/account'
     | '/inbox'
@@ -428,6 +438,7 @@ export interface FileRouteTypes {
     | '/features'
     | '/get-started'
     | '/login'
+    | '/pricing'
     | '/resources'
     | '/account'
     | '/inbox'
@@ -466,6 +477,7 @@ export interface FileRouteTypes {
     | '/features'
     | '/get-started'
     | '/login'
+    | '/pricing'
     | '/resources'
     | '/_authenticated/account'
     | '/_authenticated/inbox'
@@ -508,6 +520,7 @@ export interface RootRouteChildren {
   FeaturesRoute: typeof FeaturesRoute
   GetStartedRoute: typeof GetStartedRoute
   LoginRoute: typeof LoginRoute
+  PricingRoute: typeof PricingRoute
   ResourcesRoute: typeof ResourcesRoute
   ApiBuildunitsRoute: typeof ApiBuildunitsRoute
   ApiChannelMembersRoute: typeof ApiChannelMembersRoute
@@ -535,6 +548,13 @@ declare module '@tanstack/react-router' {
       path: '/resources'
       fullPath: '/resources'
       preLoaderRoute: typeof ResourcesRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/pricing': {
+      id: '/pricing'
+      path: '/pricing'
+      fullPath: '/pricing'
+      preLoaderRoute: typeof PricingRouteImport
       parentRoute: typeof rootRouteImport
     }
     '/login': {
@@ -904,6 +924,7 @@ const rootRouteChildren: RootRouteChildren = {
   FeaturesRoute: FeaturesRoute,
   GetStartedRoute: GetStartedRoute,
   LoginRoute: LoginRoute,
+  PricingRoute: PricingRoute,
   ResourcesRoute: ResourcesRoute,
   ApiBuildunitsRoute: ApiBuildunitsRoute,
   ApiChannelMembersRoute: ApiChannelMembersRoute,

--- a/web-app/code/src/presentation/routeTree.gen.ts
+++ b/web-app/code/src/presentation/routeTree.gen.ts
@@ -9,7 +9,13 @@
 // Additionally, you should also exclude this file from your linter and/or formatter to prevent it from being checked or modified.
 
 import { Route as rootRouteImport } from './routes/__root'
+import { Route as ResourcesRouteImport } from './routes/resources'
 import { Route as LoginRouteImport } from './routes/login'
+import { Route as GetStartedRouteImport } from './routes/get-started'
+import { Route as FeaturesRouteImport } from './routes/features'
+import { Route as DocumentationRouteImport } from './routes/documentation'
+import { Route as BlogRouteImport } from './routes/blog'
+import { Route as AboutRouteImport } from './routes/about'
 import { Route as AuthenticatedRouteImport } from './routes/_authenticated'
 import { Route as IndexRouteImport } from './routes/index'
 import { Route as ApiUsersRouteImport } from './routes/api/users'
@@ -29,6 +35,7 @@ import { Route as ApiChannelMembersRouteImport } from './routes/api/channel-memb
 import { Route as ApiBuildunitsRouteImport } from './routes/api/buildunits'
 import { Route as AuthenticatedMyTasksRouteImport } from './routes/_authenticated/my-tasks'
 import { Route as AuthenticatedInboxRouteImport } from './routes/_authenticated/inbox'
+import { Route as AuthenticatedAccountRouteImport } from './routes/_authenticated/account'
 import { Route as AuthenticatedProjectsIndexRouteImport } from './routes/_authenticated/projects/index'
 import { Route as ApiTrpcSplatRouteImport } from './routes/api/trpc/$'
 import { Route as ApiResourcesUploadRouteImport } from './routes/api/resources/upload'
@@ -42,9 +49,39 @@ import { Route as AuthenticatedProjectsProjectIdBuildUnitNameChannelNameRouteImp
 import { Route as AuthenticatedProjectsProjectIdBuildUnitNameChannelNameIndexRouteImport } from './routes/_authenticated/projects/$projectId/$buildUnitName/$channelName/index'
 import { Route as AuthenticatedProjectsProjectIdBuildUnitNameChannelNameTaskNameRouteImport } from './routes/_authenticated/projects/$projectId/$buildUnitName/$channelName/$taskName'
 
+const ResourcesRoute = ResourcesRouteImport.update({
+  id: '/resources',
+  path: '/resources',
+  getParentRoute: () => rootRouteImport,
+} as any)
 const LoginRoute = LoginRouteImport.update({
   id: '/login',
   path: '/login',
+  getParentRoute: () => rootRouteImport,
+} as any)
+const GetStartedRoute = GetStartedRouteImport.update({
+  id: '/get-started',
+  path: '/get-started',
+  getParentRoute: () => rootRouteImport,
+} as any)
+const FeaturesRoute = FeaturesRouteImport.update({
+  id: '/features',
+  path: '/features',
+  getParentRoute: () => rootRouteImport,
+} as any)
+const DocumentationRoute = DocumentationRouteImport.update({
+  id: '/documentation',
+  path: '/documentation',
+  getParentRoute: () => rootRouteImport,
+} as any)
+const BlogRoute = BlogRouteImport.update({
+  id: '/blog',
+  path: '/blog',
+  getParentRoute: () => rootRouteImport,
+} as any)
+const AboutRoute = AboutRouteImport.update({
+  id: '/about',
+  path: '/about',
   getParentRoute: () => rootRouteImport,
 } as any)
 const AuthenticatedRoute = AuthenticatedRouteImport.update({
@@ -141,6 +178,11 @@ const AuthenticatedInboxRoute = AuthenticatedInboxRouteImport.update({
   path: '/inbox',
   getParentRoute: () => AuthenticatedRoute,
 } as any)
+const AuthenticatedAccountRoute = AuthenticatedAccountRouteImport.update({
+  id: '/account',
+  path: '/account',
+  getParentRoute: () => AuthenticatedRoute,
+} as any)
 const AuthenticatedProjectsIndexRoute =
   AuthenticatedProjectsIndexRouteImport.update({
     id: '/projects/',
@@ -219,7 +261,14 @@ const AuthenticatedProjectsProjectIdBuildUnitNameChannelNameTaskNameRoute =
 
 export interface FileRoutesByFullPath {
   '/': typeof IndexRoute
+  '/about': typeof AboutRoute
+  '/blog': typeof BlogRoute
+  '/documentation': typeof DocumentationRoute
+  '/features': typeof FeaturesRoute
+  '/get-started': typeof GetStartedRoute
   '/login': typeof LoginRoute
+  '/resources': typeof ResourcesRoute
+  '/account': typeof AuthenticatedAccountRoute
   '/inbox': typeof AuthenticatedInboxRoute
   '/my-tasks': typeof AuthenticatedMyTasksRoute
   '/api/buildunits': typeof ApiBuildunitsRoute
@@ -252,7 +301,14 @@ export interface FileRoutesByFullPath {
 }
 export interface FileRoutesByTo {
   '/': typeof IndexRoute
+  '/about': typeof AboutRoute
+  '/blog': typeof BlogRoute
+  '/documentation': typeof DocumentationRoute
+  '/features': typeof FeaturesRoute
+  '/get-started': typeof GetStartedRoute
   '/login': typeof LoginRoute
+  '/resources': typeof ResourcesRoute
+  '/account': typeof AuthenticatedAccountRoute
   '/inbox': typeof AuthenticatedInboxRoute
   '/my-tasks': typeof AuthenticatedMyTasksRoute
   '/api/buildunits': typeof ApiBuildunitsRoute
@@ -284,7 +340,14 @@ export interface FileRoutesById {
   __root__: typeof rootRouteImport
   '/': typeof IndexRoute
   '/_authenticated': typeof AuthenticatedRouteWithChildren
+  '/about': typeof AboutRoute
+  '/blog': typeof BlogRoute
+  '/documentation': typeof DocumentationRoute
+  '/features': typeof FeaturesRoute
+  '/get-started': typeof GetStartedRoute
   '/login': typeof LoginRoute
+  '/resources': typeof ResourcesRoute
+  '/_authenticated/account': typeof AuthenticatedAccountRoute
   '/_authenticated/inbox': typeof AuthenticatedInboxRoute
   '/_authenticated/my-tasks': typeof AuthenticatedMyTasksRoute
   '/api/buildunits': typeof ApiBuildunitsRoute
@@ -319,7 +382,14 @@ export interface FileRouteTypes {
   fileRoutesByFullPath: FileRoutesByFullPath
   fullPaths:
     | '/'
+    | '/about'
+    | '/blog'
+    | '/documentation'
+    | '/features'
+    | '/get-started'
     | '/login'
+    | '/resources'
+    | '/account'
     | '/inbox'
     | '/my-tasks'
     | '/api/buildunits'
@@ -352,7 +422,14 @@ export interface FileRouteTypes {
   fileRoutesByTo: FileRoutesByTo
   to:
     | '/'
+    | '/about'
+    | '/blog'
+    | '/documentation'
+    | '/features'
+    | '/get-started'
     | '/login'
+    | '/resources'
+    | '/account'
     | '/inbox'
     | '/my-tasks'
     | '/api/buildunits'
@@ -383,7 +460,14 @@ export interface FileRouteTypes {
     | '__root__'
     | '/'
     | '/_authenticated'
+    | '/about'
+    | '/blog'
+    | '/documentation'
+    | '/features'
+    | '/get-started'
     | '/login'
+    | '/resources'
+    | '/_authenticated/account'
     | '/_authenticated/inbox'
     | '/_authenticated/my-tasks'
     | '/api/buildunits'
@@ -418,7 +502,13 @@ export interface FileRouteTypes {
 export interface RootRouteChildren {
   IndexRoute: typeof IndexRoute
   AuthenticatedRoute: typeof AuthenticatedRouteWithChildren
+  AboutRoute: typeof AboutRoute
+  BlogRoute: typeof BlogRoute
+  DocumentationRoute: typeof DocumentationRoute
+  FeaturesRoute: typeof FeaturesRoute
+  GetStartedRoute: typeof GetStartedRoute
   LoginRoute: typeof LoginRoute
+  ResourcesRoute: typeof ResourcesRoute
   ApiBuildunitsRoute: typeof ApiBuildunitsRoute
   ApiChannelMembersRoute: typeof ApiChannelMembersRoute
   ApiChannelsRoute: typeof ApiChannelsRoute
@@ -440,11 +530,53 @@ export interface RootRouteChildren {
 
 declare module '@tanstack/react-router' {
   interface FileRoutesByPath {
+    '/resources': {
+      id: '/resources'
+      path: '/resources'
+      fullPath: '/resources'
+      preLoaderRoute: typeof ResourcesRouteImport
+      parentRoute: typeof rootRouteImport
+    }
     '/login': {
       id: '/login'
       path: '/login'
       fullPath: '/login'
       preLoaderRoute: typeof LoginRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/get-started': {
+      id: '/get-started'
+      path: '/get-started'
+      fullPath: '/get-started'
+      preLoaderRoute: typeof GetStartedRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/features': {
+      id: '/features'
+      path: '/features'
+      fullPath: '/features'
+      preLoaderRoute: typeof FeaturesRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/documentation': {
+      id: '/documentation'
+      path: '/documentation'
+      fullPath: '/documentation'
+      preLoaderRoute: typeof DocumentationRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/blog': {
+      id: '/blog'
+      path: '/blog'
+      fullPath: '/blog'
+      preLoaderRoute: typeof BlogRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/about': {
+      id: '/about'
+      path: '/about'
+      fullPath: '/about'
+      preLoaderRoute: typeof AboutRouteImport
       parentRoute: typeof rootRouteImport
     }
     '/_authenticated': {
@@ -578,6 +710,13 @@ declare module '@tanstack/react-router' {
       path: '/inbox'
       fullPath: '/inbox'
       preLoaderRoute: typeof AuthenticatedInboxRouteImport
+      parentRoute: typeof AuthenticatedRoute
+    }
+    '/_authenticated/account': {
+      id: '/_authenticated/account'
+      path: '/account'
+      fullPath: '/account'
+      preLoaderRoute: typeof AuthenticatedAccountRouteImport
       parentRoute: typeof AuthenticatedRoute
     }
     '/_authenticated/projects/': {
@@ -722,6 +861,7 @@ const AuthenticatedProjectsProjectIdRouteWithChildren =
   )
 
 interface AuthenticatedRouteChildren {
+  AuthenticatedAccountRoute: typeof AuthenticatedAccountRoute
   AuthenticatedInboxRoute: typeof AuthenticatedInboxRoute
   AuthenticatedMyTasksRoute: typeof AuthenticatedMyTasksRoute
   AuthenticatedProjectsProjectIdRoute: typeof AuthenticatedProjectsProjectIdRouteWithChildren
@@ -729,6 +869,7 @@ interface AuthenticatedRouteChildren {
 }
 
 const AuthenticatedRouteChildren: AuthenticatedRouteChildren = {
+  AuthenticatedAccountRoute: AuthenticatedAccountRoute,
   AuthenticatedInboxRoute: AuthenticatedInboxRoute,
   AuthenticatedMyTasksRoute: AuthenticatedMyTasksRoute,
   AuthenticatedProjectsProjectIdRoute:
@@ -757,7 +898,13 @@ const ApiResourcesRouteWithChildren = ApiResourcesRoute._addFileChildren(
 const rootRouteChildren: RootRouteChildren = {
   IndexRoute: IndexRoute,
   AuthenticatedRoute: AuthenticatedRouteWithChildren,
+  AboutRoute: AboutRoute,
+  BlogRoute: BlogRoute,
+  DocumentationRoute: DocumentationRoute,
+  FeaturesRoute: FeaturesRoute,
+  GetStartedRoute: GetStartedRoute,
   LoginRoute: LoginRoute,
+  ResourcesRoute: ResourcesRoute,
   ApiBuildunitsRoute: ApiBuildunitsRoute,
   ApiChannelMembersRoute: ApiChannelMembersRoute,
   ApiChannelsRoute: ApiChannelsRoute,

--- a/web-app/code/src/presentation/routes/_authenticated/account.tsx
+++ b/web-app/code/src/presentation/routes/_authenticated/account.tsx
@@ -1,0 +1,8 @@
+import { createFileRoute } from '@tanstack/react-router'
+import { AccountPage } from '../../pages/AccountPage'
+import { RoutePendingComponent } from '../../components/buildInlime'
+
+export const Route = createFileRoute('/_authenticated/account')({
+  component: AccountPage,
+  pendingComponent: RoutePendingComponent,
+})

--- a/web-app/code/src/presentation/routes/about.tsx
+++ b/web-app/code/src/presentation/routes/about.tsx
@@ -1,0 +1,9 @@
+import { createFileRoute } from '@tanstack/react-router'
+import AboutPage from '../pages/AboutPage'
+
+export const Route = createFileRoute('/about')({
+  head: () => ({
+    meta: [{ title: 'About - BuildInLime' }],
+  }),
+  component: AboutPage,
+})

--- a/web-app/code/src/presentation/routes/blog.tsx
+++ b/web-app/code/src/presentation/routes/blog.tsx
@@ -1,0 +1,9 @@
+import { createFileRoute } from '@tanstack/react-router'
+import BlogPage from '../pages/BlogPage'
+
+export const Route = createFileRoute('/blog')({
+  head: () => ({
+    meta: [{ title: 'Blog - BuildInLime' }],
+  }),
+  component: BlogPage,
+})

--- a/web-app/code/src/presentation/routes/documentation.tsx
+++ b/web-app/code/src/presentation/routes/documentation.tsx
@@ -1,0 +1,9 @@
+import { createFileRoute } from '@tanstack/react-router'
+import DocumentationPage from '../pages/DocumentationPage'
+
+export const Route = createFileRoute('/documentation')({
+  head: () => ({
+    meta: [{ title: 'Documentation - BuildInLime' }],
+  }),
+  component: DocumentationPage,
+})

--- a/web-app/code/src/presentation/routes/features.tsx
+++ b/web-app/code/src/presentation/routes/features.tsx
@@ -1,0 +1,9 @@
+import { createFileRoute } from '@tanstack/react-router'
+import FeaturesPage from '../pages/FeaturesPage'
+
+export const Route = createFileRoute('/features')({
+  head: () => ({
+    meta: [{ title: 'Features - BuildInLime' }],
+  }),
+  component: FeaturesPage,
+})

--- a/web-app/code/src/presentation/routes/get-started.tsx
+++ b/web-app/code/src/presentation/routes/get-started.tsx
@@ -1,0 +1,9 @@
+import { createFileRoute } from '@tanstack/react-router'
+import GettingStartedPage from '../pages/GettingStartedPage'
+
+export const Route = createFileRoute('/get-started')({
+  head: () => ({
+    meta: [{ title: 'Getting Started - BuildInLime' }],
+  }),
+  component: GettingStartedPage,
+})

--- a/web-app/code/src/presentation/routes/pricing.tsx
+++ b/web-app/code/src/presentation/routes/pricing.tsx
@@ -1,0 +1,9 @@
+import { createFileRoute } from '@tanstack/react-router'
+import PricingPage from '../pages/PricingPage'
+
+export const Route = createFileRoute('/pricing')({
+  head: () => ({
+    meta: [{ title: 'Pricing - BuildInLime' }],
+  }),
+  component: PricingPage,
+})

--- a/web-app/code/src/presentation/routes/resources.tsx
+++ b/web-app/code/src/presentation/routes/resources.tsx
@@ -1,0 +1,9 @@
+import { createFileRoute } from '@tanstack/react-router'
+import ResourcesPage from '../pages/ResourcesPage'
+
+export const Route = createFileRoute('/resources')({
+  head: () => ({
+    meta: [{ title: 'Resources - BuildInLime' }],
+  }),
+  component: ResourcesPage,
+})


### PR DESCRIPTION
## Summary
Re-targets the home-page work at `main`. The original PR #57 was accidentally merged into `docs/deploy-cicd-proven` (not `main`), so none of this reached `main`.

Commits:
- `4f79528` feat(web): add marketing pages and refresh the landing page
- `6374a6a` feat(web): add a coming-soon pricing page, and polish the marketing shell

## Context
- PR #56 (`docs/deploy-cicd-proven` → `main`) landed correctly and is the current `main` tip.
- PR #57 (this branch) mistakenly used `docs/deploy-cicd-proven` as its base and merged there after #56 closed, so its work never flowed into `main`.

This PR corrects that by merging the same work directly into `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FZ8fsH5zG1iAFYF4GhYXzn