### PR TITLE
feat(web): soft-delete for projects, build units and channels

### DIFF
--- a/packages/contracts/src/schemas/rows.ts
+++ b/packages/contracts/src/schemas/rows.ts
@@ -106,6 +106,10 @@ export const projectRowSchema = z.object({
   status_percent: z.string().nullish(),
   owner_id: z.string(),
   created_at: wireTimestamp.optional(),
+  // Carried even though projectsShape filters soft-deleted rows out server-side
+  // (`deleted_at IS NULL`) — see the same note on taskRowSchema below.
+  deleted_at: wireTimestamp.nullish(),
+  deleted_by_id: z.string().nullish(),
 })
 
 export const buildUnitRowSchema = z.object({
@@ -122,6 +126,8 @@ export const buildUnitRowSchema = z.object({
   project_id: z.string(),
   owner_id: z.string(),
   created_at: wireTimestamp.optional(),
+  deleted_at: wireTimestamp.nullish(),
+  deleted_by_id: z.string().nullish(),
 })
 
 export const channelRowSchema = z.object({
@@ -131,6 +137,8 @@ export const channelRowSchema = z.object({
   buildunit_id: z.string(),
   owner_id: z.string(),
   created_at: wireTimestamp.optional(),
+  deleted_at: wireTimestamp.nullish(),
+  deleted_by_id: z.string().nullish(),
 })
 
 /**

--- a/packages/sync-core/src/collections.ts
+++ b/packages/sync-core/src/collections.ts
@@ -130,7 +130,7 @@ export function makeShapeRetry(log?: (message: string) => void): ShapeRetry {
  * is the point: bump it whenever any row schema changes shape, so cached rows that
  * predate the change are discarded rather than validated as undefined.
  */
-export const COLLECTION_SCHEMA_VERSION = 3
+export const COLLECTION_SCHEMA_VERSION = 4
 
 /** The tanstack builders + per-app primitives a collection definition needs. */
 export interface CollectionRuntime {

--- a/web-app/code/drizzle/0008_rare_groot.sql
+++ b/web-app/code/drizzle/0008_rare_groot.sql
@@ -1,0 +1,9 @@
+ALTER TABLE "build_units" ADD COLUMN "deleted_at" timestamp with time zone;--> statement-breakpoint
+ALTER TABLE "build_units" ADD COLUMN "deleted_by_id" text;--> statement-breakpoint
+ALTER TABLE "channels" ADD COLUMN "deleted_at" timestamp with time zone;--> statement-breakpoint
+ALTER TABLE "channels" ADD COLUMN "deleted_by_id" text;--> statement-breakpoint
+ALTER TABLE "projects" ADD COLUMN "deleted_at" timestamp with time zone;--> statement-breakpoint
+ALTER TABLE "projects" ADD COLUMN "deleted_by_id" text;--> statement-breakpoint
+ALTER TABLE "build_units" ADD CONSTRAINT "build_units_deleted_by_id_users_id_fk" FOREIGN KEY ("deleted_by_id") REFERENCES "public"."users"("id") ON DELETE set null ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "channels" ADD CONSTRAINT "channels_deleted_by_id_users_id_fk" FOREIGN KEY ("deleted_by_id") REFERENCES "public"."users"("id") ON DELETE set null ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "projects" ADD CONSTRAINT "projects_deleted_by_id_users_id_fk" FOREIGN KEY ("deleted_by_id") REFERENCES "public"."users"("id") ON DELETE set null ON UPDATE no action;

--- a/web-app/code/drizzle/meta/0008_snapshot.json
+++ b/web-app/code/drizzle/meta/0008_snapshot.json
@@ -1,0 +1,1788 @@
+{
+  "id": "e9582d93-0062-4632-a3be-9359e1916747",
+  "prevId": "f7df5ce4-d016-40fd-879f-77b471d43810",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.accounts": {
+      "name": "accounts",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "access_token": {
+          "name": "access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token": {
+          "name": "refresh_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "id_token": {
+          "name": "id_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "access_token_expires_at": {
+          "name": "access_token_expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token_expires_at": {
+          "name": "refresh_token_expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "password": {
+          "name": "password",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "accounts_user_id_users_id_fk": {
+          "name": "accounts_user_id_users_id_fk",
+          "tableFrom": "accounts",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.sessions": {
+      "name": "sessions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ip_address": {
+          "name": "ip_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "sessions_user_id_users_id_fk": {
+          "name": "sessions_user_id_users_id_fk",
+          "tableFrom": "sessions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "sessions_token_unique": {
+          "name": "sessions_token_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "token"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.users": {
+      "name": "users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email_verified": {
+          "name": "email_verified",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "image": {
+          "name": "image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "users_email_unique": {
+          "name": "users_email_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "email"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.verifications": {
+      "name": "verifications",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "identifier": {
+          "name": "identifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.build_units": {
+      "name": "build_units",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "health": {
+          "name": "health",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "priority": {
+          "name": "priority",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "task_name": {
+          "name": "task_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "task_assignee": {
+          "name": "task_assignee",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "task_since": {
+          "name": "task_since",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "target_date": {
+          "name": "target_date",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status_percent": {
+          "name": "status_percent",
+          "type": "varchar(10)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "owner_id": {
+          "name": "owner_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "deleted_by_id": {
+          "name": "deleted_by_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "build_units_project_id_projects_id_fk": {
+          "name": "build_units_project_id_projects_id_fk",
+          "tableFrom": "build_units",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "build_units_owner_id_users_id_fk": {
+          "name": "build_units_owner_id_users_id_fk",
+          "tableFrom": "build_units",
+          "tableTo": "users",
+          "columnsFrom": [
+            "owner_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "build_units_deleted_by_id_users_id_fk": {
+          "name": "build_units_deleted_by_id_users_id_fk",
+          "tableFrom": "build_units",
+          "tableTo": "users",
+          "columnsFrom": [
+            "deleted_by_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.channels": {
+      "name": "channels",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "buildunit_id": {
+          "name": "buildunit_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "owner_id": {
+          "name": "owner_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "deleted_by_id": {
+          "name": "deleted_by_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "channels_buildunit_id_build_units_id_fk": {
+          "name": "channels_buildunit_id_build_units_id_fk",
+          "tableFrom": "channels",
+          "tableTo": "build_units",
+          "columnsFrom": [
+            "buildunit_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "channels_owner_id_users_id_fk": {
+          "name": "channels_owner_id_users_id_fk",
+          "tableFrom": "channels",
+          "tableTo": "users",
+          "columnsFrom": [
+            "owner_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "channels_deleted_by_id_users_id_fk": {
+          "name": "channels_deleted_by_id_users_id_fk",
+          "tableFrom": "channels",
+          "tableTo": "users",
+          "columnsFrom": [
+            "deleted_by_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.memberships": {
+      "name": "memberships",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "channel_id": {
+          "name": "channel_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "buildunit_id": {
+          "name": "buildunit_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "member_flag": {
+          "name": "member_flag",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'viewer'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "memberships_user_channel_unique": {
+          "name": "memberships_user_channel_unique",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "channel_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "memberships_user_id_users_id_fk": {
+          "name": "memberships_user_id_users_id_fk",
+          "tableFrom": "memberships",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "memberships_channel_id_channels_id_fk": {
+          "name": "memberships_channel_id_channels_id_fk",
+          "tableFrom": "memberships",
+          "tableTo": "channels",
+          "columnsFrom": [
+            "channel_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "memberships_buildunit_id_build_units_id_fk": {
+          "name": "memberships_buildunit_id_build_units_id_fk",
+          "tableFrom": "memberships",
+          "tableTo": "build_units",
+          "columnsFrom": [
+            "buildunit_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "memberships_project_id_projects_id_fk": {
+          "name": "memberships_project_id_projects_id_fk",
+          "tableFrom": "memberships",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.projects": {
+      "name": "projects",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "priority": {
+          "name": "priority",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "target_date": {
+          "name": "target_date",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "owner_id": {
+          "name": "owner_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status_percent": {
+          "name": "status_percent",
+          "type": "varchar(10)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "deleted_by_id": {
+          "name": "deleted_by_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "projects_owner_id_users_id_fk": {
+          "name": "projects_owner_id_users_id_fk",
+          "tableFrom": "projects",
+          "tableTo": "users",
+          "columnsFrom": [
+            "owner_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "projects_deleted_by_id_users_id_fk": {
+          "name": "projects_deleted_by_id_users_id_fk",
+          "tableFrom": "projects",
+          "tableTo": "users",
+          "columnsFrom": [
+            "deleted_by_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.messages": {
+      "name": "messages",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "text": {
+          "name": "text",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "channel_id": {
+          "name": "channel_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "buildunit_id": {
+          "name": "buildunit_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "createdby_id": {
+          "name": "createdby_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "mention_ids": {
+          "name": "mention_ids",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "resource_ids": {
+          "name": "resource_ids",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "parent_id": {
+          "name": "parent_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "task_id": {
+          "name": "task_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "deleted_by_id": {
+          "name": "deleted_by_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "messages_channel_id_channels_id_fk": {
+          "name": "messages_channel_id_channels_id_fk",
+          "tableFrom": "messages",
+          "tableTo": "channels",
+          "columnsFrom": [
+            "channel_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "messages_buildunit_id_build_units_id_fk": {
+          "name": "messages_buildunit_id_build_units_id_fk",
+          "tableFrom": "messages",
+          "tableTo": "build_units",
+          "columnsFrom": [
+            "buildunit_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "messages_project_id_projects_id_fk": {
+          "name": "messages_project_id_projects_id_fk",
+          "tableFrom": "messages",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "messages_createdby_id_users_id_fk": {
+          "name": "messages_createdby_id_users_id_fk",
+          "tableFrom": "messages",
+          "tableTo": "users",
+          "columnsFrom": [
+            "createdby_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "messages_parent_id_messages_id_fk": {
+          "name": "messages_parent_id_messages_id_fk",
+          "tableFrom": "messages",
+          "tableTo": "messages",
+          "columnsFrom": [
+            "parent_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "messages_task_id_tasks_id_fk": {
+          "name": "messages_task_id_tasks_id_fk",
+          "tableFrom": "messages",
+          "tableTo": "tasks",
+          "columnsFrom": [
+            "task_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "messages_deleted_by_id_users_id_fk": {
+          "name": "messages_deleted_by_id_users_id_fk",
+          "tableFrom": "messages",
+          "tableTo": "users",
+          "columnsFrom": [
+            "deleted_by_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.properties": {
+      "name": "properties",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "entity": {
+          "name": "entity",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "entity_id": {
+          "name": "entity_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "channel_id": {
+          "name": "channel_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdby_id": {
+          "name": "createdby_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status_value": {
+          "name": "status_value",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "priority_value": {
+          "name": "priority_value",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "task_status_value": {
+          "name": "task_status_value",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "target_date": {
+          "name": "target_date",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "start_date": {
+          "name": "start_date",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "pending_task": {
+          "name": "pending_task",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "percent_complete": {
+          "name": "percent_complete",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "label_value": {
+          "name": "label_value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "properties_channel_id_channels_id_fk": {
+          "name": "properties_channel_id_channels_id_fk",
+          "tableFrom": "properties",
+          "tableTo": "channels",
+          "columnsFrom": [
+            "channel_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "properties_createdby_id_users_id_fk": {
+          "name": "properties_createdby_id_users_id_fk",
+          "tableFrom": "properties",
+          "tableTo": "users",
+          "columnsFrom": [
+            "createdby_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.reads": {
+      "name": "reads",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "item_type": {
+          "name": "item_type",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "item_id": {
+          "name": "item_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "channel_id": {
+          "name": "channel_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "read_at": {
+          "name": "read_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "reads_user_id_users_id_fk": {
+          "name": "reads_user_id_users_id_fk",
+          "tableFrom": "reads",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "reads_channel_id_channels_id_fk": {
+          "name": "reads_channel_id_channels_id_fk",
+          "tableFrom": "reads",
+          "tableTo": "channels",
+          "columnsFrom": [
+            "channel_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "reads_user_id_item_type_item_id_pk": {
+          "name": "reads_user_id_item_type_item_id_pk",
+          "columns": [
+            "user_id",
+            "item_type",
+            "item_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.resources_raw": {
+      "name": "resources_raw",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "resource_id": {
+          "name": "resource_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "storage_path": {
+          "name": "storage_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "original_filename": {
+          "name": "original_filename",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "mime_type": {
+          "name": "mime_type",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "file_size_bytes": {
+          "name": "file_size_bytes",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "uploaded_at": {
+          "name": "uploaded_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "resources_raw_resource_id_resources_id_fk": {
+          "name": "resources_raw_resource_id_resources_id_fk",
+          "tableFrom": "resources_raw",
+          "tableTo": "resources",
+          "columnsFrom": [
+            "resource_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.resources": {
+      "name": "resources",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "file_location": {
+          "name": "file_location",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "mime_type": {
+          "name": "mime_type",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "file_size_bytes": {
+          "name": "file_size_bytes",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "uploaded_at": {
+          "name": "uploaded_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "message_id": {
+          "name": "message_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "task_id": {
+          "name": "task_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "channel_id": {
+          "name": "channel_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "buildunit_id": {
+          "name": "buildunit_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "createdby_id": {
+          "name": "createdby_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "deleted_by_id": {
+          "name": "deleted_by_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "resources_message_id_messages_id_fk": {
+          "name": "resources_message_id_messages_id_fk",
+          "tableFrom": "resources",
+          "tableTo": "messages",
+          "columnsFrom": [
+            "message_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "resources_task_id_tasks_id_fk": {
+          "name": "resources_task_id_tasks_id_fk",
+          "tableFrom": "resources",
+          "tableTo": "tasks",
+          "columnsFrom": [
+            "task_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "resources_channel_id_channels_id_fk": {
+          "name": "resources_channel_id_channels_id_fk",
+          "tableFrom": "resources",
+          "tableTo": "channels",
+          "columnsFrom": [
+            "channel_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "resources_buildunit_id_build_units_id_fk": {
+          "name": "resources_buildunit_id_build_units_id_fk",
+          "tableFrom": "resources",
+          "tableTo": "build_units",
+          "columnsFrom": [
+            "buildunit_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "resources_project_id_projects_id_fk": {
+          "name": "resources_project_id_projects_id_fk",
+          "tableFrom": "resources",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "resources_createdby_id_users_id_fk": {
+          "name": "resources_createdby_id_users_id_fk",
+          "tableFrom": "resources",
+          "tableTo": "users",
+          "columnsFrom": [
+            "createdby_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "resources_deleted_by_id_users_id_fk": {
+          "name": "resources_deleted_by_id_users_id_fk",
+          "tableFrom": "resources",
+          "tableTo": "users",
+          "columnsFrom": [
+            "deleted_by_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.seen_state": {
+      "name": "seen_state",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "scope": {
+          "name": "scope",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "scope_id": {
+          "name": "scope_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "seen_at": {
+          "name": "seen_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "seen_state_user_id_users_id_fk": {
+          "name": "seen_state_user_id_users_id_fk",
+          "tableFrom": "seen_state",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "seen_state_user_id_scope_scope_id_pk": {
+          "name": "seen_state_user_id_scope_scope_id_pk",
+          "columns": [
+            "user_id",
+            "scope",
+            "scope_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.tasks": {
+      "name": "tasks",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "completed": {
+          "name": "completed",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "opened_at": {
+          "name": "opened_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "closed_at": {
+          "name": "closed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "channel_id": {
+          "name": "channel_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "buildunit_id": {
+          "name": "buildunit_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "createdby_id": {
+          "name": "createdby_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "assignee_id": {
+          "name": "assignee_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "deleted_by_id": {
+          "name": "deleted_by_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "tasks_channel_name_unique": {
+          "name": "tasks_channel_name_unique",
+          "columns": [
+            {
+              "expression": "channel_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "lower(\"name\")",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"tasks\".\"deleted_at\" IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "tasks_channel_id_channels_id_fk": {
+          "name": "tasks_channel_id_channels_id_fk",
+          "tableFrom": "tasks",
+          "tableTo": "channels",
+          "columnsFrom": [
+            "channel_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "tasks_buildunit_id_build_units_id_fk": {
+          "name": "tasks_buildunit_id_build_units_id_fk",
+          "tableFrom": "tasks",
+          "tableTo": "build_units",
+          "columnsFrom": [
+            "buildunit_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "tasks_createdby_id_users_id_fk": {
+          "name": "tasks_createdby_id_users_id_fk",
+          "tableFrom": "tasks",
+          "tableTo": "users",
+          "columnsFrom": [
+            "createdby_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "tasks_assignee_id_users_id_fk": {
+          "name": "tasks_assignee_id_users_id_fk",
+          "tableFrom": "tasks",
+          "tableTo": "users",
+          "columnsFrom": [
+            "assignee_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "tasks_deleted_by_id_users_id_fk": {
+          "name": "tasks_deleted_by_id_users_id_fk",
+          "tableFrom": "tasks",
+          "tableTo": "users",
+          "columnsFrom": [
+            "deleted_by_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.teams": {
+      "name": "teams",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "owner_id": {
+          "name": "owner_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "member_ids": {
+          "name": "member_ids",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "teams_owner_id_users_id_fk": {
+          "name": "teams_owner_id_users_id_fk",
+          "tableFrom": "teams",
+          "tableTo": "users",
+          "columnsFrom": [
+            "owner_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "teams_project_id_projects_id_fk": {
+          "name": "teams_project_id_projects_id_fk",
+          "tableFrom": "teams",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {},
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/web-app/code/drizzle/meta/_journal.json
+++ b/web-app/code/drizzle/meta/_journal.json
@@ -57,6 +57,13 @@
       "when": 1784103500249,
       "tag": "0007_fluffy_nemesis",
       "breakpoints": true
+    },
+    {
+      "idx": 8,
+      "version": "7",
+      "when": 1784602573117,
+      "tag": "0008_rare_groot",
+      "breakpoints": true
     }
   ]
 }

--- a/web-app/code/src/infrastructure/database/schema/organization-tables.ts
+++ b/web-app/code/src/infrastructure/database/schema/organization-tables.ts
@@ -25,6 +25,14 @@ export const projectsTable = pgTable(`projects`, {
     .notNull()
     .references(() => users.id, { onDelete: `cascade` }),
   status_percent: varchar({ length: 10 }),
+  // Soft delete — mirrors tasks/resources. A deleted project is filtered OUT of
+  // projectsShape (`deleted_at IS NULL`) and vanishes for every client. Its
+  // descendants (build units, channels, tasks, resources) are soft-deleted in the
+  // same transaction by the projects router, because the child shapes don't check
+  // the parent's deleted state — without the cascade they'd be orphaned yet visible.
+  deleted_at: timestamp({ withTimezone: true }),
+  deleted_by_id: text(`deleted_by_id`)
+    .references(() => users.id, { onDelete: `set null` }),
 })
 
 export const buildUnitsTable = pgTable(`build_units`, {
@@ -45,6 +53,11 @@ export const buildUnitsTable = pgTable(`build_units`, {
     .notNull()
     .references(() => users.id, { onDelete: `cascade` }),
   created_at: timestamp({ withTimezone: true }).notNull().defaultNow(),
+  // Soft delete — see projectsTable. Filtered out of buildUnitsShape; its channels,
+  // tasks and resources are soft-deleted with it by the build-units router.
+  deleted_at: timestamp({ withTimezone: true }),
+  deleted_by_id: text(`deleted_by_id`)
+    .references(() => users.id, { onDelete: `set null` }),
 })
 
 export const CHANNEL_NAMES = ["Finance", "Requirements", "Design", "Materials", "Tools", "Execution", "Experimentation"] as const
@@ -61,6 +74,11 @@ export const channelsTable = pgTable(`channels`, {
     .notNull()
     .references(() => users.id, { onDelete: `cascade` }),
   created_at: timestamp({ withTimezone: true }).notNull().defaultNow(),
+  // Soft delete — see projectsTable. Filtered out of channelsShape; its tasks and
+  // resources are soft-deleted with it by the channels router.
+  deleted_at: timestamp({ withTimezone: true }),
+  deleted_by_id: text(`deleted_by_id`)
+    .references(() => users.id, { onDelete: `set null` }),
 })
 
 export const MEMBERSHIP_ROLES = [`owner`, `co-owner`, `viewer`] as const
@@ -77,14 +95,23 @@ export const membershipTable = pgTable(`memberships`, {
   created_at: timestamp({ withTimezone: true }).notNull().defaultNow(),
 }, (t) => [uniqueIndex(`memberships_user_channel_unique`).on(t.user_id, t.channel_id)])
 
+// deleted_at / deleted_by_id are nullish in every SELECT schema and omitted from
+// every INSERT schema, for the reasons documented at length in
+// communication-tables.ts: the select schemas double as the client-side validators
+// on the Electric collections (a required deleted_at would reject every optimistic
+// insert), and soft-deletion is the server's to stamp, never a client's to assert.
 export const selectProjectSchema = createSelectSchema(projectsTable).extend({
   description: z.string().nullish(),
   priority: z.enum(["High", "Mid", "Low"]).nullish(),
   target_date: z.string().nullish(),
   status_percent: z.string().nullish(),
+  deleted_at: z.coerce.date().nullish(),
+  deleted_by_id: z.string().nullish(),
 })
 export const createProjectSchema = createInsertSchema(projectsTable).omit({
   created_at: true,
+  deleted_at: true,
+  deleted_by_id: true,
 })
 export const updateProjectSchema = createUpdateSchema(projectsTable)
 
@@ -97,17 +124,25 @@ export const selectBuildUnitSchema = createSelectSchema(buildUnitsTable).extend(
   task_since: z.string().nullish(),
   target_date: z.string().nullish(),
   status_percent: z.string().nullish(),
+  deleted_at: z.coerce.date().nullish(),
+  deleted_by_id: z.string().nullish(),
 })
 export const createBuildUnitSchema = createInsertSchema(buildUnitsTable).omit({
   created_at: true,
+  deleted_at: true,
+  deleted_by_id: true,
 })
 export const updateBuildUnitSchema = createUpdateSchema(buildUnitsTable)
 
 export const selectChannelSchema = createSelectSchema(channelsTable).extend({
   name: z.enum(CHANNEL_NAMES),
+  deleted_at: z.coerce.date().nullish(),
+  deleted_by_id: z.string().nullish(),
 })
 export const createChannelSchema = createInsertSchema(channelsTable).omit({
   created_at: true,
+  deleted_at: true,
+  deleted_by_id: true,
 })
 export const updateChannelSchema = createUpdateSchema(channelsTable)
 

--- a/web-app/code/src/infrastructure/database/shapes.ts
+++ b/web-app/code/src/infrastructure/database/shapes.ts
@@ -87,11 +87,18 @@ export const readsShape: ShapeDef = {
 // grants you membership. ARCHITECTURE.md §4.
 // ---------------------------------------------------------------------------
 
+// notDeleted is AND-ed OUTSIDE the owner/member `or(...)` on all three so it can
+// only ever remove rows: a soft-deleted project you own must still fall out of the
+// shape, and without the outer AND the `owner_id = me` escape hatch would keep
+// resurfacing it. Deleting an entity cascades the soft-delete to its descendants
+// (see the routers), because these child shapes don't check a parent's deleted
+// state — an undeleted build unit under a deleted project would otherwise stay
+// visible via its own owner/member match.
 export const projectsShape: ShapeDef = {
   table: `projects`,
   scope: `member`,
   where: ({ userId, scope }) =>
-    or(idSetOrOmit(`id`, scope.projectIds), isMe(`owner_id`, userId)),
+    and(or(idSetOrOmit(`id`, scope.projectIds), isMe(`owner_id`, userId)), notDeleted),
 }
 
 export const buildUnitsShape: ShapeDef = {
@@ -105,7 +112,7 @@ export const buildUnitsShape: ShapeDef = {
     // Optional narrowing filter (a specific project). AND-ed with the access
     // boundary above, so it can only restrict — never broaden — visibility.
     const projectId = url.searchParams.get(`project_id`)
-    return and(visible, projectId && UUID_REGEX.test(projectId) && `project_id = '${projectId}'`)
+    return and(visible, projectId && UUID_REGEX.test(projectId) && `project_id = '${projectId}'`, notDeleted)
   },
 }
 
@@ -114,7 +121,7 @@ export const channelsShape: ShapeDef = {
   table: `channels`,
   scope: `member`,
   where: ({ userId, scope }) =>
-    or(idSetOrOmit(`id`, scope.channelIds), isMe(`owner_id`, userId)),
+    and(or(idSetOrOmit(`id`, scope.channelIds), isMe(`owner_id`, userId)), notDeleted),
 }
 
 // ---------------------------------------------------------------------------

--- a/web-app/code/src/infrastructure/trpc/routers/buildunits.ts
+++ b/web-app/code/src/infrastructure/trpc/routers/buildunits.ts
@@ -1,7 +1,13 @@
 import { router, authedProcedure, generateTxId } from "../lib/trpc"
 import { TRPCError } from "@trpc/server"
-import { eq, and, ilike } from "drizzle-orm"
-import { buildUnitsTable, projectsTable } from "../../database/schema/admin-schema"
+import { eq, and, ilike, isNull } from "drizzle-orm"
+import {
+  buildUnitsTable,
+  projectsTable,
+  channelsTable,
+  tasksTable,
+  resourcesTable,
+} from "../../database/schema/admin-schema"
 import {
   createBuildUnitInput,
   updateBuildUnitInput,
@@ -77,27 +83,53 @@ export const buildUnitsRouter = router({
       return result
     }),
 
+  /**
+   * SOFT delete, owner-only, cascading to its channels, tasks and resources. Same
+   * design as projects.delete — see the long note there for why the cascade is done
+   * by hand rather than left to a FK, and why messages are untouched.
+   */
   delete: authedProcedure
     .input(deleteBuildUnitInput)
     .mutation(async ({ ctx, input }) => {
       const result = await ctx.db.transaction(async (tx) => {
         const txid = await generateTxId(tx)
-        const [deletedItem] = await tx
-          .delete(buildUnitsTable)
-          .where(
-            and(
-              eq(buildUnitsTable.id, input.id),
-              eq(buildUnitsTable.owner_id, ctx.session.user.id)
-            )
-          )
-          .returning()
 
-        if (!deletedItem) {
+        const [buildUnit] = await tx
+          .select()
+          .from(buildUnitsTable)
+          .where(eq(buildUnitsTable.id, input.id))
+
+        if (!buildUnit || buildUnit.owner_id !== ctx.session.user.id) {
           throw new TRPCError({
             code: `NOT_FOUND`,
             message: `Build unit not found or you do not have permission to delete it`,
           })
         }
+
+        if (buildUnit.deleted_at) return { item: buildUnit, txid }
+
+        const stamp = { deleted_at: new Date(), deleted_by_id: ctx.session.user.id }
+
+        const [deletedItem] = await tx
+          .update(buildUnitsTable)
+          .set(stamp)
+          .where(eq(buildUnitsTable.id, input.id))
+          .returning()
+
+        await tx
+          .update(channelsTable)
+          .set(stamp)
+          .where(and(eq(channelsTable.buildunit_id, input.id), isNull(channelsTable.deleted_at)))
+
+        await tx
+          .update(tasksTable)
+          .set(stamp)
+          .where(and(eq(tasksTable.buildunit_id, input.id), isNull(tasksTable.deleted_at)))
+
+        await tx
+          .update(resourcesTable)
+          .set(stamp)
+          .where(and(eq(resourcesTable.buildunit_id, input.id), isNull(resourcesTable.deleted_at)))
 
         return { item: deletedItem, txid }
       })

--- a/web-app/code/src/infrastructure/trpc/routers/channels.ts
+++ b/web-app/code/src/infrastructure/trpc/routers/channels.ts
@@ -1,12 +1,14 @@
 import { router, authedProcedure, generateTxId } from "../lib/trpc"
 import { z } from "zod"
 import { TRPCError } from "@trpc/server"
-import { eq, and, sql } from "drizzle-orm"
+import { eq, and, sql, isNull } from "drizzle-orm"
 import {
   channelsTable,
   buildUnitsTable,
   projectsTable,
   membershipTable,
+  tasksTable,
+  resourcesTable,
 } from "../../database/schema/admin-schema"
 import {
   createChannelInput,
@@ -201,27 +203,49 @@ export const channelsRouter = router({
       return result
     }),
 
+  /**
+   * SOFT delete, owner-only, cascading to its tasks and resources. Same design as
+   * projects.delete — see the long note there. Messages in the channel are left
+   * intact (redacted-in-place elsewhere) and become unreachable once the channel
+   * drops out of channelsShape.
+   */
   delete: authedProcedure
     .input(deleteChannelInput)
     .mutation(async ({ ctx, input }) => {
       const result = await ctx.db.transaction(async (tx) => {
         const txid = await generateTxId(tx)
-        const [deletedItem] = await tx
-          .delete(channelsTable)
-          .where(
-            and(
-              eq(channelsTable.id, input.id),
-              eq(channelsTable.owner_id, ctx.session.user.id)
-            )
-          )
-          .returning()
 
-        if (!deletedItem) {
+        const [channel] = await tx
+          .select()
+          .from(channelsTable)
+          .where(eq(channelsTable.id, input.id))
+
+        if (!channel || channel.owner_id !== ctx.session.user.id) {
           throw new TRPCError({
             code: `NOT_FOUND`,
             message: `Channel not found or you do not have permission to delete it`,
           })
         }
+
+        if (channel.deleted_at) return { item: channel, txid }
+
+        const stamp = { deleted_at: new Date(), deleted_by_id: ctx.session.user.id }
+
+        const [deletedItem] = await tx
+          .update(channelsTable)
+          .set(stamp)
+          .where(eq(channelsTable.id, input.id))
+          .returning()
+
+        await tx
+          .update(tasksTable)
+          .set(stamp)
+          .where(and(eq(tasksTable.channel_id, input.id), isNull(tasksTable.deleted_at)))
+
+        await tx
+          .update(resourcesTable)
+          .set(stamp)
+          .where(and(eq(resourcesTable.channel_id, input.id), isNull(resourcesTable.deleted_at)))
 
         return { item: deletedItem, txid }
       })

--- a/web-app/code/src/infrastructure/trpc/routers/projects.ts
+++ b/web-app/code/src/infrastructure/trpc/routers/projects.ts
@@ -1,7 +1,13 @@
 import { router, authedProcedure, generateTxId } from "../lib/trpc"
 import { TRPCError } from "@trpc/server"
-import { eq, and } from "drizzle-orm"
-import { projectsTable } from "../../database/schema/admin-schema"
+import { eq, and, isNull, inArray } from "drizzle-orm"
+import {
+  projectsTable,
+  buildUnitsTable,
+  channelsTable,
+  tasksTable,
+  resourcesTable,
+} from "../../database/schema/admin-schema"
 import {
   createProjectInput,
   updateProjectInput,
@@ -61,27 +67,78 @@ export const projectsRouter = router({
       return result
     }),
 
+  /**
+   * SOFT delete, owner-only, cascading to the whole subtree.
+   *
+   * Was a hard `DELETE` that leaned on `ON DELETE CASCADE` to take the build units,
+   * channels, tasks and resources with it. Soft-deletion cannot lean on the FK — the
+   * row still exists — so the cascade is done by hand here, in one transaction. It is
+   * NOT optional: the child shapes (buildUnitsShape, channelsShape, tasksShape,
+   * resourcesShape) filter on their OWN deleted_at and never look at the parent, so a
+   * project whose build units were left undeleted would vanish while its build units
+   * stayed visible via their own owner/member match.
+   *
+   * Messages are deliberately left untouched (redacted-in-place elsewhere); a deleted
+   * project's channels drop out of channelsShape, so its messages simply become
+   * unreachable rather than being destroyed — and the whole subtree is recoverable by
+   * clearing deleted_at.
+   */
   delete: authedProcedure
     .input(deleteProjectInput)
     .mutation(async ({ ctx, input }) => {
       const result = await ctx.db.transaction(async (tx) => {
         const txid = await generateTxId(tx)
-        const [deletedItem] = await tx
-          .delete(projectsTable)
-          .where(
-            and(
-              eq(projectsTable.id, input.id),
-              eq(projectsTable.owner_id, ctx.session.user.id)
-            )
-          )
-          .returning()
 
-        if (!deletedItem) {
+        const [project] = await tx
+          .select()
+          .from(projectsTable)
+          .where(eq(projectsTable.id, input.id))
+
+        if (!project || project.owner_id !== ctx.session.user.id) {
           throw new TRPCError({
             code: `NOT_FOUND`,
             message: `Project not found or you do not have permission to delete it`,
           })
         }
+
+        // Already deleted — idempotent, so an outbox retry is harmless.
+        if (project.deleted_at) return { item: project, txid }
+
+        const stamp = { deleted_at: new Date(), deleted_by_id: ctx.session.user.id }
+
+        const [deletedItem] = await tx
+          .update(projectsTable)
+          .set(stamp)
+          .where(eq(projectsTable.id, input.id))
+          .returning()
+
+        // The build units of this project, as a subquery reused by the deeper
+        // levels that only carry buildunit_id (channels, tasks).
+        const buildUnitIds = tx
+          .select({ id: buildUnitsTable.id })
+          .from(buildUnitsTable)
+          .where(eq(buildUnitsTable.project_id, input.id))
+
+        await tx
+          .update(buildUnitsTable)
+          .set(stamp)
+          .where(and(eq(buildUnitsTable.project_id, input.id), isNull(buildUnitsTable.deleted_at)))
+
+        await tx
+          .update(channelsTable)
+          .set(stamp)
+          .where(and(inArray(channelsTable.buildunit_id, buildUnitIds), isNull(channelsTable.deleted_at)))
+
+        await tx
+          .update(tasksTable)
+          .set(stamp)
+          .where(and(inArray(tasksTable.buildunit_id, buildUnitIds), isNull(tasksTable.deleted_at)))
+
+        // resources carry a denormalized project_id, so no subquery needed.
+        await tx
+          .update(resourcesTable)
+          .set(stamp)
+          .where(and(eq(resourcesTable.project_id, input.id), isNull(resourcesTable.deleted_at)))
 
         return { item: deletedItem, txid }
       })

--- a/web-app/code/src/presentation/components/buildInlime/organization/BuildUnitCard.tsx
+++ b/web-app/code/src/presentation/components/buildInlime/organization/BuildUnitCard.tsx
@@ -1,30 +1,31 @@
-import { Package } from "lucide-react";
+import { Package, Trash2 } from "lucide-react";
 import type { BuildUnit } from "./BuildUnitsTable";
 import { PropertyPill } from "../communication/PropertyPill";
 
 interface BuildUnitCardProps {
   unit: BuildUnit;
   onClick?: () => void;
+  onDelete?: (unit: BuildUnit) => void;
   isPending?: boolean;
 }
 
-export function BuildUnitCard({ unit, onClick, isPending }: BuildUnitCardProps) {
+export function BuildUnitCard({ unit, onClick, onDelete, isPending }: BuildUnitCardProps) {
   // taskStatus is never meaningful on a build unit; drop it defensively.
   const properties = unit.properties.filter((p) => p.type !== "taskStatus");
 
   return (
     <div
       onClick={!isPending ? onClick : undefined}
-      className={`bg-card-surface border border-card-border rounded-lg p-4 transition-colors ${
+      className={`group bg-card-surface border border-card-border rounded-lg p-4 transition-colors ${
         isPending ? "opacity-70 cursor-default" : "hover:bg-icon-chip cursor-pointer"
       }`}
     >
-      {/* Header: icon + name */}
+      {/* Header: icon + name + delete */}
       <div className="flex items-center gap-3 mb-3">
         <div className="w-10 h-10 rounded bg-icon-chip border border-card-border flex items-center justify-center shrink-0">
           <Package className="w-5 h-5 text-primary" />
         </div>
-        <div className="flex items-center gap-2 min-w-0">
+        <div className="flex items-center gap-2 min-w-0 flex-1">
           <h3 className="font-semibold text-foreground truncate">{unit.name}</h3>
           {isPending && (
             <svg
@@ -38,6 +39,20 @@ export function BuildUnitCard({ unit, onClick, isPending }: BuildUnitCardProps) 
             </svg>
           )}
         </div>
+        {!isPending && onDelete && unit.canDelete && (
+          <button
+            type="button"
+            onClick={(e) => {
+              e.stopPropagation();
+              onDelete(unit);
+            }}
+            title="Delete this build unit"
+            aria-label={`Delete ${unit.name}`}
+            className="p-1.5 rounded text-muted-foreground opacity-0 group-hover:opacity-100 hover:bg-red-50 hover:text-red-600 transition-all shrink-0"
+          >
+            <Trash2 className="w-4 h-4" />
+          </button>
+        )}
       </div>
 
       {/* Properties — value pills, same source of truth as the table */}

--- a/web-app/code/src/presentation/components/buildInlime/organization/BuildUnitsGrid.tsx
+++ b/web-app/code/src/presentation/components/buildInlime/organization/BuildUnitsGrid.tsx
@@ -4,10 +4,11 @@ import type { BuildUnit } from "./BuildUnitsTable";
 interface BuildUnitsGridProps {
   buildUnits: BuildUnit[];
   onBuildUnitClick?: (buildUnit: BuildUnit) => void;
+  onDeleteBuildUnit?: (buildUnit: BuildUnit) => void;
   pendingIds?: Set<string>;
 }
 
-export function BuildUnitsGrid({ buildUnits, onBuildUnitClick, pendingIds }: BuildUnitsGridProps) {
+export function BuildUnitsGrid({ buildUnits, onBuildUnitClick, onDeleteBuildUnit, pendingIds }: BuildUnitsGridProps) {
   return (
     <div className="flex-1 overflow-auto bg-white p-6">
       <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4">
@@ -16,6 +17,7 @@ export function BuildUnitsGrid({ buildUnits, onBuildUnitClick, pendingIds }: Bui
             key={unit.id}
             unit={unit}
             onClick={() => onBuildUnitClick?.(unit)}
+            onDelete={onDeleteBuildUnit}
             isPending={pendingIds?.has(unit.id)}
           />
         ))}

--- a/web-app/code/src/presentation/components/buildInlime/organization/BuildUnitsTable.tsx
+++ b/web-app/code/src/presentation/components/buildInlime/organization/BuildUnitsTable.tsx
@@ -1,4 +1,4 @@
-import { Package } from "lucide-react";
+import { Package, Trash2 } from "lucide-react";
 import type { Property } from "%/domain/communication/types";
 import { PropertyPill } from "../communication/PropertyPill";
 
@@ -19,15 +19,18 @@ export type BuildUnit = {
   };
   targetDate: string;
   statusPercent: number;
+  // Whether the current user owns this build unit — gates the delete affordance.
+  canDelete: boolean;
 };
 
 interface BuildUnitsTableProps {
   buildUnits: BuildUnit[];
   onBuildUnitClick?: (buildUnit: BuildUnit) => void;
+  onDeleteBuildUnit?: (buildUnit: BuildUnit) => void;
   pendingIds?: Set<string>;
 }
 
-export function BuildUnitsTable({ buildUnits, onBuildUnitClick, pendingIds }: BuildUnitsTableProps) {
+export function BuildUnitsTable({ buildUnits, onBuildUnitClick, onDeleteBuildUnit, pendingIds }: BuildUnitsTableProps) {
   return (
     <div className="flex-1 overflow-auto bg-white">
       <table className="w-full">
@@ -45,6 +48,7 @@ export function BuildUnitsTable({ buildUnits, onBuildUnitClick, pendingIds }: Bu
             >
               Properties
             </th>
+            <th className="w-12 px-6 py-3" />
           </tr>
         </thead>
         <tbody>
@@ -55,7 +59,7 @@ export function BuildUnitsTable({ buildUnits, onBuildUnitClick, pendingIds }: Bu
             return (
               <tr
                 key={unit.id}
-                className="border-b border-card-border hover:bg-card-surface transition-colors cursor-pointer"
+                className="group border-b border-card-border hover:bg-card-surface transition-colors cursor-pointer"
                 onClick={() => onBuildUnitClick?.(unit)}
               >
                 <td className="px-6 py-4 align-top">
@@ -94,6 +98,22 @@ export function BuildUnitsTable({ buildUnits, onBuildUnitClick, pendingIds }: Bu
                         <PropertyPill key={property.id} property={property} showValue />
                       ))}
                     </div>
+                  )}
+                </td>
+                <td className="px-6 py-4 align-top text-right">
+                  {onDeleteBuildUnit && unit.canDelete && (
+                    <button
+                      type="button"
+                      onClick={(e) => {
+                        e.stopPropagation();
+                        onDeleteBuildUnit(unit);
+                      }}
+                      title="Delete this build unit"
+                      aria-label={`Delete ${unit.name}`}
+                      className="p-1.5 rounded text-muted-foreground opacity-0 group-hover:opacity-100 hover:bg-red-50 hover:text-red-600 transition-all"
+                    >
+                      <Trash2 className="w-4 h-4" />
+                    </button>
                   )}
                 </td>
               </tr>

--- a/web-app/code/src/presentation/components/buildInlime/organization/ChannelCard.tsx
+++ b/web-app/code/src/presentation/components/buildInlime/organization/ChannelCard.tsx
@@ -1,3 +1,4 @@
+import { Trash2 } from "lucide-react";
 import type { LucideIcon } from "lucide-react";
 import { Link } from "@tanstack/react-router";
 import type { Property } from "%/domain/communication/types";
@@ -24,6 +25,8 @@ interface ChannelCardProps {
   onClick?: () => void;
   isPending?: boolean;
   properties?: Property[];
+  canDelete?: boolean;
+  onDelete?: () => void;
 }
 
 export function ChannelCard({
@@ -34,6 +37,8 @@ export function ChannelCard({
   onClick,
   isPending,
   properties,
+  canDelete,
+  onDelete,
 }: ChannelCardProps) {
   const content = (
     <>
@@ -41,8 +46,8 @@ export function ChannelCard({
         <div className="w-10 h-10 rounded bg-icon-chip border border-card-border flex items-center justify-center">
           <Icon className="w-5 h-5 text-primary" />
         </div>
-        <div className="flex items-center gap-2">
-          <h3 className="font-semibold text-foreground">{title}</h3>
+        <div className="flex items-center gap-2 flex-1 min-w-0">
+          <h3 className="font-semibold text-foreground truncate">{title}</h3>
           {isPending && (
             <svg
               className="animate-spin w-3 h-3 text-primary shrink-0"
@@ -55,6 +60,23 @@ export function ChannelCard({
             </svg>
           )}
         </div>
+        {!isPending && onDelete && canDelete && (
+          <button
+            type="button"
+            // preventDefault stops the enclosing Link from navigating; stopPropagation
+            // stops the div-variant onClick — the card is clickable either way.
+            onClick={(e) => {
+              e.preventDefault();
+              e.stopPropagation();
+              onDelete();
+            }}
+            title="Delete this channel"
+            aria-label={`Delete ${title} channel`}
+            className="p-1.5 rounded text-muted-foreground opacity-0 group-hover:opacity-100 hover:bg-red-50 hover:text-red-600 transition-all shrink-0"
+          >
+            <Trash2 className="w-4 h-4" />
+          </button>
+        )}
       </div>
       <p className="text-sm text-muted-foreground">{description}</p>
       {properties && properties.filter((p) => p.type !== "taskStatus").length > 0 && (
@@ -74,7 +96,7 @@ export function ChannelCard({
       <Link
         to="/projects/$projectId/$buildUnitName/$channelName"
         params={linkParams}
-        className="bg-card-surface border border-card-border rounded-lg p-4 hover:bg-icon-chip transition-colors cursor-pointer block"
+        className="group bg-card-surface border border-card-border rounded-lg p-4 hover:bg-icon-chip transition-colors cursor-pointer block"
       >
         {content}
       </Link>
@@ -84,7 +106,7 @@ export function ChannelCard({
   return (
     <div
       onClick={!isPending ? onClick : undefined}
-      className={`bg-card-surface border border-card-border rounded-lg p-4 transition-colors ${isPending ? "opacity-70 cursor-default" : "hover:bg-icon-chip cursor-pointer"}`}
+      className={`group bg-card-surface border border-card-border rounded-lg p-4 transition-colors ${isPending ? "opacity-70 cursor-default" : "hover:bg-icon-chip cursor-pointer"}`}
     >
       {content}
     </div>

--- a/web-app/code/src/presentation/components/buildInlime/organization/ChannelsSection.tsx
+++ b/web-app/code/src/presentation/components/buildInlime/organization/ChannelsSection.tsx
@@ -14,6 +14,8 @@ export interface Channel {
   linkParams?: { projectId: string; buildUnitName: string; channelName: string };
   onClick?: () => void;
   properties?: Property[];
+  /** Whether the current user owns this channel — gates the delete affordance. */
+  canDelete?: boolean;
 }
 
 export interface ChannelsSectionProps {
@@ -23,9 +25,10 @@ export interface ChannelsSectionProps {
   addPending: (item: PendingItem) => void;
   removePending: (id: string) => void;
   onTrpcComplete: (id: string) => void;
+  onDeleteChannel?: (channel: Channel) => void;
 }
 
-export function ChannelsSection({ channels, buildUnitId, pendingIds, addPending, removePending, onTrpcComplete }: ChannelsSectionProps) {
+export function ChannelsSection({ channels, buildUnitId, pendingIds, addPending, removePending, onTrpcComplete, onDeleteChannel }: ChannelsSectionProps) {
   return (
     <div className="border-t border-gray-200 pt-6 mb-8">
       <div className="flex items-center justify-between mb-4">
@@ -52,6 +55,8 @@ export function ChannelsSection({ channels, buildUnitId, pendingIds, addPending,
             onClick={channel.onClick}
             isPending={pendingIds.has(channel.id)}
             properties={channel.properties}
+            canDelete={channel.canDelete}
+            onDelete={onDeleteChannel ? () => onDeleteChannel(channel) : undefined}
           />
         ))}
       </div>

--- a/web-app/code/src/presentation/components/buildInlime/organization/ProjectsTable.tsx
+++ b/web-app/code/src/presentation/components/buildInlime/organization/ProjectsTable.tsx
@@ -1,4 +1,4 @@
-import { Boxes } from "lucide-react";
+import { Boxes, Trash2 } from "lucide-react";
 
 type Project = {
   id: string;
@@ -8,14 +8,19 @@ type Project = {
   // function exists — see the future-work note in projects/index.tsx.
   createdBy: string;
   createdAt: string;
+  // Whether the current user owns this project. The delete affordance is shown
+  // only for owned projects — the server enforces owner-only delete regardless
+  // (projects.delete returns NOT_FOUND otherwise); hiding the button is courtesy.
+  canDelete: boolean;
 };
 
 interface ProjectsTableProps {
   projects: Project[];
   onProjectClick?: (project: Project) => void;
+  onDeleteProject?: (project: Project) => void;
 }
 
-export function ProjectsTable({ projects, onProjectClick }: ProjectsTableProps) {
+export function ProjectsTable({ projects, onProjectClick, onDeleteProject }: ProjectsTableProps) {
   return (
     <div className="flex-1 overflow-auto bg-white">
       <table className="w-full">
@@ -39,6 +44,8 @@ export function ProjectsTable({ projects, onProjectClick }: ProjectsTableProps) 
             >
               Created At
             </th>
+            {/* Actions column — header intentionally blank, matches the row action. */}
+            <th className="w-12 px-6 py-3" />
           </tr>
         </thead>
         <tbody>
@@ -46,7 +53,7 @@ export function ProjectsTable({ projects, onProjectClick }: ProjectsTableProps) 
             <tr
               key={project.id}
               onClick={() => onProjectClick?.(project)}
-              className="border-b border-card-border hover:bg-card-surface transition-colors cursor-pointer"
+              className="group border-b border-card-border hover:bg-card-surface transition-colors cursor-pointer"
             >
               <td className="px-6 py-4">
                 <div className="flex items-center gap-2">
@@ -74,6 +81,23 @@ export function ProjectsTable({ projects, onProjectClick }: ProjectsTableProps) 
                 >
                   {project.createdAt}
                 </span>
+              </td>
+              <td className="px-6 py-4 text-right">
+                {onDeleteProject && project.canDelete && (
+                  <button
+                    type="button"
+                    // stopPropagation so deleting doesn't also navigate into the row.
+                    onClick={(e) => {
+                      e.stopPropagation();
+                      onDeleteProject(project);
+                    }}
+                    title="Delete this project"
+                    aria-label={`Delete ${project.name}`}
+                    className="p-1.5 rounded text-muted-foreground opacity-0 group-hover:opacity-100 hover:bg-red-50 hover:text-red-600 transition-all"
+                  >
+                    <Trash2 className="w-4 h-4" />
+                  </button>
+                )}
               </td>
             </tr>
           ))}

--- a/web-app/code/src/presentation/components/buildInlime/shared/ConfirmDeleteModal.tsx
+++ b/web-app/code/src/presentation/components/buildInlime/shared/ConfirmDeleteModal.tsx
@@ -1,0 +1,83 @@
+import { AlertTriangle, Loader2 } from "lucide-react";
+import { Modal } from "./Modal";
+
+interface ConfirmDeleteModalProps {
+  open: boolean;
+  onClose: () => void;
+  onConfirm: () => void;
+  /** The thing being deleted, e.g. the project or channel name. */
+  entityName: string;
+  /**
+   * A human phrase for the child entities that go with it, e.g.
+   * "build units, channels and tasks". Omit for a leaf with no children.
+   */
+  constituents?: string;
+  /** Disables the buttons and shows a spinner while the delete is in flight. */
+  busy?: boolean;
+}
+
+/**
+ * A destructive-action confirmation dialog, built on the shared Modal. Replaces
+ * the browser `window.confirm` the delete flows used to call: it spells out that
+ * the child entities go too, that the records are retained (soft-deleted) for
+ * auditing, and that only attachments are on a 30-day retrieval clock — none of
+ * which a one-line native confirm can convey.
+ */
+export function ConfirmDeleteModal({
+  open,
+  onClose,
+  onConfirm,
+  entityName,
+  constituents,
+  busy,
+}: ConfirmDeleteModalProps) {
+  return (
+    <Modal open={open} onClose={busy ? () => {} : onClose}>
+      <div className="flex items-start gap-3 mb-4">
+        <div className="w-10 h-10 rounded-full bg-red-50 flex items-center justify-center shrink-0">
+          <AlertTriangle className="w-5 h-5 text-red-600" />
+        </div>
+        <div className="min-w-0">
+          <h2 className="text-lg font-semibold text-gray-800">
+            Delete &ldquo;{entityName}&rdquo;?
+          </h2>
+          <p className="text-sm text-muted-foreground mt-1">
+            {constituents ? (
+              <>
+                This will also remove all its {constituents} for everyone.
+              </>
+            ) : (
+              <>Everyone loses access immediately.</>
+            )}
+          </p>
+        </div>
+      </div>
+
+      <p className="text-sm text-muted-foreground mb-6">
+        Any attachments stay retrievable for{" "}
+        <span className="font-medium text-foreground">30 days</span>, after which
+        they are permanently deleted.
+      </p>
+
+      <div className="flex justify-end gap-3">
+        <button
+          type="button"
+          onClick={onClose}
+          disabled={busy}
+          className="px-4 h-[40px] rounded-[10px] border border-border text-foreground font-medium text-[14px] hover:bg-card-surface transition-colors disabled:opacity-50"
+        >
+          Cancel
+        </button>
+        <button
+          type="button"
+          onClick={onConfirm}
+          disabled={busy}
+          className="px-4 h-[40px] rounded-[10px] bg-red-600 hover:bg-red-700 text-white font-medium text-[14px] flex items-center justify-center gap-2 transition-colors disabled:opacity-60"
+        >
+          {busy && <Loader2 className="w-4 h-4 animate-spin" />}
+          Delete
+        </button>
+      </div>
+    </Modal>
+  );
+}

--- a/web-app/code/src/presentation/hooks/use-build-unit-channels.ts
+++ b/web-app/code/src/presentation/hooks/use-build-unit-channels.ts
@@ -2,6 +2,7 @@ import { useEffect, useCallback, useRef } from 'react'
 import { useLiveQuery, eq, inArray } from "@tanstack/react-db"
 import { ClipboardCheck } from 'lucide-react'
 import { channelsCollection, propertiesCollection } from '%/infrastructure/database/tanstack-db-electric/admincollections'
+import { useSession } from '%/infrastructure/auth/client'
 import type { CHANNEL_NAMES } from '%/domain/shared/types'
 import { CHANNEL_ICONS } from '%/presentation/lib/channelIcons'
 import { unwrapJsonb, mapPropertyRow } from '%/presentation/lib/utils'
@@ -14,6 +15,7 @@ export type BuildUnitChannelsStatus = 'loading' | 'ready'
 // buildUnitId is pre-resolved by the $buildUnitName layout route via BuildUnitContext —
 // no need to re-query buildUnitsCollection or projectsCollection here.
 export function useBuildUnitChannels(buildUnitId: string, projectId: string, buildUnitName: string) {
+  const { data: session } = useSession()
   const { pendingItems: pendingChannels, pendingIds: pendingChannelIds, addPending, removePending } = usePendingItems()
   const pendingChannelIdsRef = useRef(pendingChannelIds)
   pendingChannelIdsRef.current = pendingChannelIds
@@ -73,6 +75,8 @@ export function useBuildUnitChannels(buildUnitId: string, projectId: string, bui
       icon: CHANNEL_ICONS[name] ?? ClipboardCheck,
       linkParams: { projectId, buildUnitName, channelName: name },
       properties: channelPropsByEntity.get(channel.id) ?? [],
+      // Owner-only delete — server-enforced (channels.delete); the button is courtesy.
+      canDelete: !!session?.user && channel.owner_id === session.user.id,
     }
   })
 
@@ -87,11 +91,21 @@ export function useBuildUnitChannels(buildUnitId: string, projectId: string, bui
       icon: CHANNEL_ICONS[p.name as typeof CHANNEL_NAMES[number]] ?? ClipboardCheck,
       linkParams: undefined,
       properties: [],
+      // A ghost channel is still reconciling its create — never offer to delete it.
+      canDelete: false,
     }))
 
   const channels = [...dbChannelList, ...ghostChannels]
 
   const properties: Property[] = (dbProperties ?? []).map(mapPropertyRow)
+
+  // Soft delete, owner-only. The channel and its tasks/resources fall out of their
+  // Electric shapes — the server cascades the soft-delete (channels.delete). The
+  // collection.delete triggers onDelete → trpc.channels.delete. Confirmation is the
+  // page's job (ConfirmDeleteModal); this is the raw action run once confirmed.
+  const deleteChannel = (id: string) => {
+    channelsCollection.delete(id)
+  }
 
   return {
     status: 'ready' as const,
@@ -101,5 +115,6 @@ export function useBuildUnitChannels(buildUnitId: string, projectId: string, bui
     addPending,
     removePending,
     onChannelTrpcComplete,
+    deleteChannel,
   }
 }

--- a/web-app/code/src/presentation/hooks/use-project-build-units.ts
+++ b/web-app/code/src/presentation/hooks/use-project-build-units.ts
@@ -2,12 +2,14 @@ import { useCallback, useEffect, useRef } from "react"
 import { useNavigate } from "@tanstack/react-router"
 import { useLiveQuery, eq, inArray } from "@tanstack/react-db"
 import { projectsCollection, buildUnitsCollection, propertiesCollection } from "%/infrastructure/database/tanstack-db-electric/admincollections"
+import { useSession } from "%/infrastructure/auth/client"
 import { mapPropertyRow } from "%/presentation/lib/utils"
 import type { Property } from "%/domain/communication/types"
 import { usePendingBuildUnits } from "./use-pending-build-units"
 
 export function useProjectBuildUnits(projectId: string) {
   const navigate = useNavigate()
+  const { data: session } = useSession()
   const { pendingItems, pendingIds, addPending, removePending } = usePendingBuildUnits()
 
   const pendingIdsRef = useRef(pendingIds)
@@ -72,6 +74,9 @@ export function useProjectBuildUnits(projectId: string) {
     },
     targetDate: bu.target_date ?? "—",
     statusPercent: parseInt(bu.status_percent ?? "0", 10),
+    // Owner-only delete. The server enforces it (buildUnits.delete returns
+    // NOT_FOUND otherwise); hiding the trash button is courtesy.
+    canDelete: !!session?.user && bu.owner_id === session.user.id,
   }))
 
   // Ghost rows: keep pending items visible during Electric txid reconciliation
@@ -88,6 +93,8 @@ export function useProjectBuildUnits(projectId: string) {
       waitingOnTask: { name: "—", assignee: "—", since: "—" },
       targetDate: "—",
       statusPercent: 0,
+      // A ghost row is still reconciling its create — never offer to delete it.
+      canDelete: false,
     }))
 
   const buildUnits = [...dbBuildUnits, ...ghostRows]
@@ -105,6 +112,15 @@ export function useProjectBuildUnits(projectId: string) {
     })
   }
 
+  // Soft delete, owner-only. The build unit and its channels/tasks/resources fall
+  // out of their Electric shapes — the server cascades the soft-delete in one
+  // transaction (buildUnits.delete). The collection.delete triggers onDelete →
+  // trpc.buildUnits.delete. Confirmation is the page's job (ConfirmDeleteModal);
+  // this is the raw action run once the user confirms.
+  const deleteBuildUnit = (id: string) => {
+    buildUnitsCollection.delete(id)
+  }
+
   return {
     projectName,
     buildUnits,
@@ -113,5 +129,6 @@ export function useProjectBuildUnits(projectId: string) {
     removePending,
     onTrpcComplete,
     onBuildUnitClick,
+    deleteBuildUnit,
   }
 }

--- a/web-app/code/src/presentation/pages/BuildUnitPage.tsx
+++ b/web-app/code/src/presentation/pages/BuildUnitPage.tsx
@@ -9,14 +9,22 @@ import {
   PropertiesPanel,
   PageTopBar,
 } from "../components/buildInlime";
+import { ConfirmDeleteModal } from "../components/buildInlime/shared/ConfirmDeleteModal";
 import type { Channel } from "../components/buildInlime";
 import type { Property } from "%/domain/communication/types";
 import type { PendingItem } from "%/presentation/hooks/use-pending-items";
 
 
 
-export function BuildUnitPage({ projectId, buildUnitName, buildUnitId, projectName, buildUnitDesc, channels, properties: dbProperties, pendingChannelIds, addPendingChannel, removePendingChannel, onChannelTrpcComplete }: { projectId: string; buildUnitName: string; buildUnitId: string; projectName: string; buildUnitDesc: string; channels?: Channel[]; properties?: Property[]; pendingChannelIds: Set<string>; addPendingChannel: (item: PendingItem) => void; removePendingChannel: (id: string) => void; onChannelTrpcComplete: (id: string) => void }) {
+export function BuildUnitPage({ projectId, buildUnitName, buildUnitId, projectName, buildUnitDesc, channels, properties: dbProperties, pendingChannelIds, addPendingChannel, removePendingChannel, onChannelTrpcComplete, deleteChannel }: { projectId: string; buildUnitName: string; buildUnitId: string; projectName: string; buildUnitDesc: string; channels?: Channel[]; properties?: Property[]; pendingChannelIds: Set<string>; addPendingChannel: (item: PendingItem) => void; removePendingChannel: (id: string) => void; onChannelTrpcComplete: (id: string) => void; deleteChannel?: (id: string) => void }) {
   const [rightPanelOpen, setRightPanelOpen] = useState(true);
+  // The channel awaiting delete confirmation — drives the modal. null = closed.
+  const [channelToDelete, setChannelToDelete] = useState<{ id: string; title: string } | null>(null);
+  const confirmDeleteChannel = () => {
+    if (!channelToDelete) return;
+    deleteChannel?.(channelToDelete.id);
+    setChannelToDelete(null);
+  };
 
   return (
     <div className="flex h-screen bg-white font-['Instrument_Sans',sans-serif]">
@@ -70,6 +78,7 @@ export function BuildUnitPage({ projectId, buildUnitName, buildUnitId, projectNa
                 addPending={addPendingChannel}
                 removePending={removePendingChannel}
                 onTrpcComplete={onChannelTrpcComplete}
+                onDeleteChannel={deleteChannel ? (channel) => setChannelToDelete({ id: channel.id, title: channel.title }) : undefined}
               />
             </div>
           </div>
@@ -94,9 +103,17 @@ export function BuildUnitPage({ projectId, buildUnitName, buildUnitId, projectNa
               </div>
             </aside>
           )}
-          
+
         </div>
       </main>
+
+      <ConfirmDeleteModal
+        open={!!channelToDelete}
+        onClose={() => setChannelToDelete(null)}
+        onConfirm={confirmDeleteChannel}
+        entityName={channelToDelete?.title ?? ""}
+        constituents="tasks"
+      />
     </div>
   );
 }

--- a/web-app/code/src/presentation/routes/_authenticated/projects/$projectId/$buildUnitName/index.tsx
+++ b/web-app/code/src/presentation/routes/_authenticated/projects/$projectId/$buildUnitName/index.tsx
@@ -18,7 +18,7 @@ function BuildUnitIndexRoute() {
     return <div className="flex h-screen items-center justify-center text-muted-foreground">Loading…</div>
   }
 
-  const { channels, properties, pendingChannelIds, addPending, removePending, onChannelTrpcComplete } = result
+  const { channels, properties, pendingChannelIds, addPending, removePending, onChannelTrpcComplete, deleteChannel } = result
 
   return (
     <BuildUnitPage
@@ -33,6 +33,7 @@ function BuildUnitIndexRoute() {
       addPendingChannel={addPending}
       removePendingChannel={removePending}
       onChannelTrpcComplete={onChannelTrpcComplete}
+      deleteChannel={deleteChannel}
     />
   )
 }

--- a/web-app/code/src/presentation/routes/_authenticated/projects/$projectId/index.tsx
+++ b/web-app/code/src/presentation/routes/_authenticated/projects/$projectId/index.tsx
@@ -13,6 +13,7 @@ import {
   EMPTY_BUILD_UNIT_FILTERS,
   RoutePendingComponent,
 } from "../../../../components/buildInlime";
+import { ConfirmDeleteModal } from "../../../../components/buildInlime/shared/ConfirmDeleteModal";
 import { useProjectBuildUnits } from "../../../../hooks/use-project-build-units";
 
 export const Route = createFileRoute('/_authenticated/projects/$projectId/')({
@@ -22,8 +23,16 @@ export const Route = createFileRoute('/_authenticated/projects/$projectId/')({
 
 function ProjectRoute() {
   const { projectId } = Route.useParams()
-  const { projectName, buildUnits, pendingIds, addPending, removePending, onTrpcComplete, onBuildUnitClick } =
+  const { projectName, buildUnits, pendingIds, addPending, removePending, onTrpcComplete, onBuildUnitClick, deleteBuildUnit } =
     useProjectBuildUnits(projectId)
+
+  // The build unit awaiting delete confirmation — drives the modal. null = closed.
+  const [buildUnitToDelete, setBuildUnitToDelete] = useState<{ id: string; name: string } | null>(null)
+  const confirmDeleteBuildUnit = () => {
+    if (!buildUnitToDelete) return
+    deleteBuildUnit(buildUnitToDelete.id)
+    setBuildUnitToDelete(null)
+  }
 
   // Toggle between the tabular view (default) and a thumbnail/card grid,
   // driven by the "Display" toolbar button.
@@ -103,9 +112,9 @@ function ProjectRoute() {
             right — both sit below the toolbar and share the remaining height. */}
         <div className="flex flex-1 overflow-hidden">
           {viewMode === "table" ? (
-            <BuildUnitsTable buildUnits={visibleBuildUnits} onBuildUnitClick={onBuildUnitClick} pendingIds={pendingIds} />
+            <BuildUnitsTable buildUnits={visibleBuildUnits} onBuildUnitClick={onBuildUnitClick} onDeleteBuildUnit={(bu) => setBuildUnitToDelete({ id: bu.id, name: bu.name })} pendingIds={pendingIds} />
           ) : (
-            <BuildUnitsGrid buildUnits={visibleBuildUnits} onBuildUnitClick={onBuildUnitClick} pendingIds={pendingIds} />
+            <BuildUnitsGrid buildUnits={visibleBuildUnits} onBuildUnitClick={onBuildUnitClick} onDeleteBuildUnit={(bu) => setBuildUnitToDelete({ id: bu.id, name: bu.name })} pendingIds={pendingIds} />
           )}
           {filterOpen && (
             <BuildUnitsFilterPanel
@@ -116,6 +125,14 @@ function ProjectRoute() {
           )}
         </div>
       </div>
+
+      <ConfirmDeleteModal
+        open={!!buildUnitToDelete}
+        onClose={() => setBuildUnitToDelete(null)}
+        onConfirm={confirmDeleteBuildUnit}
+        entityName={buildUnitToDelete?.name ?? ""}
+        constituents="channels and tasks"
+      />
     </div>
   );
 }

--- a/web-app/code/src/presentation/routes/_authenticated/projects/index.tsx
+++ b/web-app/code/src/presentation/routes/_authenticated/projects/index.tsx
@@ -1,8 +1,11 @@
+import { useState } from 'react'
 import { createFileRoute, useNavigate } from '@tanstack/react-router'
 import { Sidebar, NewProjectButton, RoutePendingComponent, ProjectsTable } from "../../../components/buildInlime";
+import { ConfirmDeleteModal } from "../../../components/buildInlime/shared/ConfirmDeleteModal";
 // import { DisplayButton } from "../../../components/buildInlime";
 // import { FilterButton } from "../../../components/buildInlime";
 import { projectsCollection, usersCollection } from '%/infrastructure/database/tanstack-db-electric/admincollections'
+import { useSession } from '%/infrastructure/auth/client'
 
 import { useLiveQuery } from "@tanstack/react-db"
 import { toDate } from "@buildinlime/contracts"
@@ -14,6 +17,9 @@ export const Route = createFileRoute('/_authenticated/projects/')({
 
 function ProjectsRoute() {
   const navigate = useNavigate()
+  const { data: session } = useSession()
+  // The project awaiting delete confirmation — drives the modal. null = closed.
+  const [projectToDelete, setProjectToDelete] = useState<{ id: string; name: string } | null>(null)
 
   const { data: projectsFromDB } = useLiveQuery((q) => q.from({ projectsCollection }), [])
   const { data: usersFromDB } = useLiveQuery((q) => q.from({ usersCollection }), [])
@@ -33,12 +39,24 @@ function ProjectsRoute() {
       name: p.name,
       createdBy: creator?.name || creator?.email || "Unknown",
       createdAt: p.created_at ? toDate(p.created_at).toLocaleDateString() : "—",
+      canDelete: !!session?.user && p.owner_id === session.user.id,
     }
   })
 
   const onProjectClick = (project: { id: string; name: string }) => {
     // `state: { projectName }` removed — never read; see use-project-build-units.
     navigate({ to: '/projects/$projectId', params: { projectId: project.id } })
+  }
+
+  // Soft delete, owner-only. The project and its whole subtree (build units,
+  // channels, tasks, resources) fall out of their Electric shapes — the server
+  // cascades the soft-delete in one transaction (projects.delete). Deleting from
+  // the collection triggers its onDelete → trpc.projects.delete. The trash button
+  // opens the confirmation modal; the actual delete runs on confirm below.
+  const confirmDeleteProject = () => {
+    if (!projectToDelete) return
+    projectsCollection.delete(projectToDelete.id)
+    setProjectToDelete(null)
   }
 
 return (
@@ -86,9 +104,17 @@ return (
         {projectsFromDB === undefined ? (
           <div className="flex flex-1 items-center justify-center text-muted-foreground">Loading projects…</div>
         ) : (
-          <ProjectsTable projects={projects} onProjectClick={onProjectClick} />
+          <ProjectsTable projects={projects} onProjectClick={onProjectClick} onDeleteProject={(p) => setProjectToDelete({ id: p.id, name: p.name })} />
         )}
       </div>
+
+      <ConfirmDeleteModal
+        open={!!projectToDelete}
+        onClose={() => setProjectToDelete(null)}
+        onConfirm={confirmDeleteProject}
+        entityName={projectToDelete?.name ?? ""}
+        constituents="build units, channels and tasks"
+      />
     </div>
   );
 }

--- a/web-app/code/tests/unit/shapes.test.ts
+++ b/web-app/code/tests/unit/shapes.test.ts
@@ -65,16 +65,17 @@ describe("user-scoped shapes", () => {
 })
 
 describe("owner-escape shapes", () => {
-  it("projects ORs the member set with ownership", () => {
-    // Was: `id = ANY(...) OR owner_id = '...'` — same, now parenthesised.
+  it("projects ORs the member set with ownership and hides soft-deleted rows", () => {
+    // The OR is parenthesised and notDeleted is AND-ed outside it, so an owned
+    // project that has been soft-deleted still falls out of the shape.
     expect(whereOf(shapes.projectsShape)).toBe(
-      `(id = ANY(ARRAY['${PR}']::text[]) OR owner_id = '${ME}')`,
+      `(id = ANY(ARRAY['${PR}']::text[]) OR owner_id = '${ME}') AND deleted_at IS NULL`,
     )
   })
 
-  it("channels ORs the member set with ownership", () => {
+  it("channels ORs the member set with ownership and hides soft-deleted rows", () => {
     expect(whereOf(shapes.channelsShape)).toBe(
-      `(id = ANY(ARRAY['${CH}']::text[]) OR owner_id = '${ME}')`,
+      `(id = ANY(ARRAY['${CH}']::text[]) OR owner_id = '${ME}') AND deleted_at IS NULL`,
     )
   })
 
@@ -82,7 +83,7 @@ describe("owner-escape shapes", () => {
     // The whole point of the escape hatch: you see what you own before anyone
     // grants you membership. Must NOT collapse to `1 = 0`.
     expect(whereOf(shapes.projectsShape, { scope: emptyScope })).toBe(
-      `owner_id = '${ME}'`,
+      `owner_id = '${ME}' AND deleted_at IS NULL`,
     )
   })
 
@@ -90,7 +91,7 @@ describe("owner-escape shapes", () => {
     // Precedence is the thing under test: the OR must be grouped, or the
     // project filter would leak every owned build unit past the boundary.
     expect(whereOf(shapes.buildUnitsShape, { query: `?project_id=${PR}` })).toBe(
-      `(id = ANY(ARRAY['${BU}']::text[]) OR owner_id = '${ME}') AND project_id = '${PR}'`,
+      `(id = ANY(ARRAY['${BU}']::text[]) OR owner_id = '${ME}') AND project_id = '${PR}' AND deleted_at IS NULL`,
     )
   })
 
@@ -99,7 +100,7 @@ describe("owner-escape shapes", () => {
       query: `?project_id='; DROP TABLE build_units;--`,
     })
     expect(where).not.toContain("DROP")
-    expect(where).toBe(`(id = ANY(ARRAY['${BU}']::text[]) OR owner_id = '${ME}')`)
+    expect(where).toBe(`(id = ANY(ARRAY['${BU}']::text[]) OR owner_id = '${ME}') AND deleted_at IS NULL`)
   })
 })
 


### PR DESCRIPTION
## Summary
Adds soft-delete support across projects, build units, and channels — records are marked deleted (and hidden) rather than removed, with confirmation UX.

Commit:
- `afbc502` feat(web): soft-delete for projects, build units and channels

## Changes
- **Schema/data:** `organization-tables.ts`, `shapes.ts` (+ updated `shapes.test.ts`)
- **API (tRPC):** `projects`, `buildunits`, `channels` routers gain soft-delete paths
- **UI:** build-unit / channel cards, tables & grids; new `ConfirmDeleteModal.tsx`; new hooks (`use-project-build-units`, `use-build-unit-channels`); updated route pages

## Notes
~24 files, ~2.3k insertions. Rebased onto current `main` (`2f088db`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FZ8fsH5zG1iAFYF4GhYXzn