### PR TITLE
fix(mobile): restore AbortSignal.reason so Electric shapes survive backgrounding

### DIFF
--- a/mobile-app/app/_layout.tsx
+++ b/mobile-app/app/_layout.tsx
@@ -1,11 +1,18 @@
 import "react-native-get-random-values"
 import "../global.css"
 import * as ExpoCrypto from "expo-crypto"
+import { installAbortSignalReasonPolyfill } from "@/src/infrastructure/polyfills/abort-signal-reason"
 
 // Polyfill crypto.randomUUID — TanStack DB's collection insert calls this internally.
 if (typeof crypto !== "undefined" && !crypto.randomUUID) {
   ;(crypto as any).randomUUID = ExpoCrypto.randomUUID
 }
+
+// Polyfill AbortSignal.reason. MUST run before any Electric ShapeStream is
+// constructed: without it every wake/refresh abort permanently kills the shape's
+// long-poll. This is the disappearing-message fix — see the module's header and
+// DISAPPEARING_MESSAGES_INVESTIGATION.md §11.
+installAbortSignalReasonPolyfill()
 import "react-native-gesture-handler"
 import { DefaultTheme, ThemeProvider } from "@react-navigation/native"
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query"

--- a/mobile-app/src/infrastructure/polyfills/abort-signal-reason.ts
+++ b/mobile-app/src/infrastructure/polyfills/abort-signal-reason.ts
@@ -1,0 +1,93 @@
+// Polyfill `AbortSignal.reason` (spec: https://dom.spec.whatwg.org/#dom-abortsignal-reason).
+//
+// WHY THIS EXISTS — this is the fix for the disappearing-message bug. See
+// DISAPPEARING_MESSAGES_INVESTIGATION.md §11.
+//
+// React Native installs `abort-controller@3.0.0` as the global AbortController
+// (react-native/Libraries/Core/setUpXHR.js). That package predates the `reason`
+// argument: its `abort()` takes NO parameters and its AbortSignal exposes only
+// `aborted`. So `controller.abort(x)` silently discards `x` and `signal.reason`
+// is permanently `undefined`.
+//
+// @electric-sql/client uses the abort REASON to distinguish "this long-poll was
+// cancelled so we can immediately re-issue it" from "this stream is done"
+// (dist/index.mjs, #requestShape):
+//
+//   const abortReason = requestAbortController.signal.reason
+//   const isRestartAbort = requestAbortController.signal.aborted &&
+//     (abortReason === FORCE_DISCONNECT_AND_REFRESH || abortReason === SYSTEM_WAKE)
+//   if ((e instanceof FetchError || e instanceof FetchBackoffAbortError) && isRestartAbort) {
+//     return this.#requestShape()      // ← re-arms the shape
+//   }
+//   if (e instanceof FetchBackoffAbortError) return   // ← silent, permanent stop
+//
+// With `reason` always undefined, `isRestartAbort` is always false and EVERY
+// restart-intent abort falls into the silent-stop branch instead: no error, no
+// `onError` call, no teardown, no log line — the shape simply never polls again,
+// and nothing re-arms it short of a Metro reload. Two library paths depend on it:
+//
+//   SYSTEM_WAKE                   — #subscribeToWakeDetection. Installed on RN and
+//                                   ONLY on RN, because the library picks it whenever
+//                                   the browser visibility API is absent (`typeof
+//                                   document`). A 2s interval that aborts every
+//                                   in-flight long-poll when it sees a >6s wall-clock
+//                                   gap. Android produces exactly that gap whenever
+//                                   another activity pauses ours — the camera, the
+//                                   gallery, the document picker, or the Home button
+//                                   (RN's JavaTimerManager.onHostPause stops JS timers).
+//   FORCE_DISCONNECT_AND_REFRESH  — ShapeStream.forceDisconnectAndRefresh().
+//
+// That is the whole mobile/web asymmetry: browsers have `document` (so wake
+// detection is never installed) AND a spec-complete `signal.reason`. Mobile had
+// neither, so a single trip to the camera killed every shape that happened to have
+// a request in flight, and optimistic message rows were then dropped at commit with
+// no synced row behind them.
+//
+// Restoring `reason` re-enables the library's OWN recovery path rather than
+// bolting a second one on top of it. Import this for side effects before any
+// ShapeStream is constructed.
+//
+// Remove when React Native ships a spec-complete AbortController (checked on RN
+// 0.83.4 — still abort-controller@3.0.0). The guard below makes that safe: this
+// becomes a no-op the moment the runtime supports `reason` natively.
+
+const supportsReason = (): boolean => {
+  try {
+    const controller = new AbortController()
+    controller.abort("probe")
+    return controller.signal.reason === "probe"
+  } catch {
+    return false
+  }
+}
+
+export function installAbortSignalReasonPolyfill(): void {
+  if (typeof AbortController === "undefined" || supportsReason()) return
+
+  const proto = AbortController.prototype
+  const originalAbort = proto.abort
+
+  proto.abort = function abort(this: AbortController, reason?: unknown): void {
+    // Stamp the reason BEFORE delegating: the original abort() dispatches the
+    // `abort` event synchronously, and listeners must already be able to read it.
+    // Only set it when a reason was actually passed — leaving the absent case as
+    // `undefined` matches today's behaviour exactly, so this can only add
+    // information, never change an existing code path. (The spec would substitute
+    // an AbortError DOMException here; fabricating one risks flipping `if
+    // (signal.reason)` checks in other libraries that have always seen undefined.)
+    if (reason !== undefined && !this.signal.aborted) {
+      try {
+        Object.defineProperty(this.signal, "reason", {
+          value: reason,
+          configurable: true,
+          enumerable: true,
+          writable: true,
+        })
+      } catch {
+        // Non-configurable for some reason — fall through and abort anyway. The
+        // stream loses its restart hint but behaves no worse than before.
+      }
+    }
+    originalAbort.call(this)
+  }
+}

--- a/mobile-app/tests/abort-signal-reason.test.ts
+++ b/mobile-app/tests/abort-signal-reason.test.ts
@@ -1,0 +1,107 @@
+import { describe, it, expect, afterEach } from "vitest"
+
+import { installAbortSignalReasonPolyfill } from "@/src/infrastructure/polyfills/abort-signal-reason"
+
+// The polyfill exists for React Native's global AbortController, which is
+// abort-controller@3.0.0 — abort() takes no arguments and the signal has no
+// `reason`. Node's built-in AbortController is spec-complete, so these tests
+// stand up a faithful stand-in for the legacy one and swap it into the global
+// for the duration. Without that, every assertion here would pass for the wrong
+// reason (Node's native `reason`) and the test would prove nothing.
+class LegacyAbortSignal {
+  aborted = false
+  private listeners: Array<() => void> = []
+  addEventListener(_type: string, listener: () => void) {
+    this.listeners.push(listener)
+  }
+  dispatch() {
+    for (const listener of this.listeners) listener()
+  }
+}
+
+class LegacyAbortController {
+  signal = new LegacyAbortSignal()
+  // Note the empty parameter list — this is the whole defect being polyfilled.
+  abort() {
+    if (this.signal.aborted) return
+    this.signal.aborted = true
+    this.signal.dispatch()
+  }
+}
+
+const native = globalThis.AbortController
+
+function useLegacyAbortController() {
+  ;(globalThis as any).AbortController = LegacyAbortController
+}
+
+afterEach(() => {
+  ;(globalThis as any).AbortController = native
+})
+
+describe("installAbortSignalReasonPolyfill", () => {
+  it("records the abort reason on the signal", () => {
+    useLegacyAbortController()
+    installAbortSignalReasonPolyfill()
+
+    const controller = new AbortController()
+    controller.abort("system-wake")
+
+    expect(controller.signal.aborted).toBe(true)
+    expect(controller.signal.reason).toBe("system-wake")
+  })
+
+  it("exposes the reason to abort listeners synchronously", () => {
+    // Electric reads signal.reason after the fetch rejects, but other consumers
+    // read it inside the abort event. Stamping before delegating is what makes
+    // both work, so pin it.
+    useLegacyAbortController()
+    installAbortSignalReasonPolyfill()
+
+    const controller = new AbortController()
+    let seen: unknown = "not-called"
+    controller.signal.addEventListener("abort", () => {
+      seen = controller.signal.reason
+    })
+    controller.abort("force-disconnect-and-refresh")
+
+    expect(seen).toBe("force-disconnect-and-refresh")
+  })
+
+  it("leaves reason undefined when abort() is called with no argument", () => {
+    // Deliberately NOT spec behaviour (the spec substitutes an AbortError
+    // DOMException). Matching today's observed value keeps the polyfill purely
+    // additive for any library that has only ever seen undefined here.
+    useLegacyAbortController()
+    installAbortSignalReasonPolyfill()
+
+    const controller = new AbortController()
+    controller.abort()
+
+    expect(controller.signal.aborted).toBe(true)
+    expect(controller.signal.reason).toBeUndefined()
+  })
+
+  it("keeps the first reason when abort() is called twice", () => {
+    useLegacyAbortController()
+    installAbortSignalReasonPolyfill()
+
+    const controller = new AbortController()
+    controller.abort("first")
+    controller.abort("second")
+
+    expect(controller.signal.reason).toBe("first")
+  })
+
+  it("is a no-op on a runtime that already supports reason", () => {
+    // Node's native AbortController is left in place here. If the polyfill
+    // patched it anyway, a future RN upgrade would silently get double-wrapped.
+    const before = AbortController.prototype.abort
+    installAbortSignalReasonPolyfill()
+    expect(AbortController.prototype.abort).toBe(before)
+
+    const controller = new AbortController()
+    controller.abort("native")
+    expect(controller.signal.reason).toBe("native")
+  })
+})


### PR DESCRIPTION
## The bug

Messages sent from mobile could vanish whole — bubble, text and all. After that, inbound sync was dead until a Metro reload, while writes kept returning 200. The server had every message the entire time.

It looked like a media bug because only media sends triggered it. It isn't: the media flows are just the ones that leave the app.

## Root cause

React Native installs [`abort-controller@3.0.0`](https://github.com/mysticatea/abort-controller) as the global `AbortController` (`react-native/Libraries/Core/setUpXHR.js:38-39`). That package predates the `reason` argument — its `abort()` takes **no parameters** and `AbortSignal.prototype` exposes only `aborted`. So `controller.abort(x)` silently discards `x`.

`@electric-sql/client@1.5.15` keys its restart-after-abort decision on exactly that value (`dist/index.mjs`, `#requestShape`):

```js
const abortReason = requestAbortController.signal.reason
const isRestartAbort = signal.aborted &&
  (abortReason === FORCE_DISCONNECT_AND_REFRESH || abortReason === SYSTEM_WAKE)
if ((e instanceof FetchError || e instanceof FetchBackoffAbortError) && isRestartAbort) {
  return this.#requestShape()          // ← re-arms the shape
}
if (e instanceof FetchBackoffAbortError) return   // ← silent, permanent stop
```

With `reason` permanently `undefined`, the guard is always false and **every restart-intent abort took the silent-stop branch**: no error, no `onError`, no teardown, no log line, and nothing to re-arm the stream.

Two library paths depend on it — `#subscribeToWakeDetection` (installed on RN and *only* on RN, because the library picks it whenever `document` is absent) and `forceDisconnectAndRefresh()`.

Android supplies the trigger: `expo-image-picker`'s camera and gallery, the document picker, and the Home button each start another activity, which pauses ours, and `JavaTimerManager.onHostPause` stops JS timers. Wake detection sees the resulting >6s wall-clock gap and aborts every in-flight long-poll.

This is also the cleanest explanation of why web never showed it: browsers have `document` (so wake detection is never installed) **and** a spec-complete `signal.reason`.

## The fix

Restore `signal.reason`, which re-enables the library's *own* recovery rather than layering a second one on top.

## Verified on device

Backgrounding ~10s with polls mid-flight aborted all 13 shapes, and all 13 were re-issued on the same path, `inflight` never dropping below 12:

```
[net#564] ✗ /api/my-tasks    THREW after 12290ms: AbortError: Aborted
[net#576] → GET /api/my-tasks (inflight 13)
[net#554] ✗ /api/memberships THREW after 12705ms: AbortError: Aborted
[net#577] → GET /api/memberships (inflight 13)
```

The reproduction window is **6–20s** — shorter and the wake timer never fires; longer and every poll has already been answered by the server, leaving nothing to abort.

## Review notes

Two deliberate choices, both in the module header:

- **`abort()` with no argument still leaves `reason` undefined**, though the spec says it should be an `AbortError` `DOMException`. Fabricating one risks flipping `if (signal.reason)` checks in libraries that have only ever seen `undefined` on this platform. The polyfill is purely additive.
- **It probes for native support first**, so it no-ops once RN ships a spec-complete `AbortController`. That guard turned out to be load-bearing — a duplicated module instance on device ran the installer twice and the second call correctly declined to double-wrap `abort()`.

Tests stand up a faithful `abort-controller@3.0.0` stand-in and swap it into the global; Node's native `AbortController` already supports `reason`, so without the stub every assertion would pass for the wrong reason.

The module header references `DISAPPEARING_MESSAGES_INVESTIGATION.md`, which lands in the next PR in the stack. The header is self-sufficient without it.

Mobile 36/36, typecheck clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FSFjLZSuenUeHWNcaHMWnx