### PR TITLE
fix(sync): txid handshake on message sends, and deterministic shape identity

### DIFF
--- a/mobile-app/DISAPPEARING_MESSAGES_INVESTIGATION.md
+++ b/mobile-app/DISAPPEARING_MESSAGES_INVESTIGATION.md
@@ -332,6 +332,9 @@ read `inflight` as total device network load.
 
 ### 9.3 ROOT CAUSE of the *visible* symptom: there is no txid handshake
 
+> **RESOLVED — see §13.** The handshake is implemented in both apps on branch
+> `fix/message-txid-handshake`. The analysis below stands as written.
+
 Independent of why sync stalls, this is why a stall shows up as the bubble
 **vanishing** rather than the attachment merely being late.
 
@@ -798,9 +801,7 @@ so `installAbortSignalReasonPolyfill()` ran twice. The second call found
 
 ### 11.5 Still outstanding, independent of this
 
-- **§9.3 — no txid handshake.** Worth doing on its own merits: it converts a silent
-  vanish into a bounded wait, so any future stall is legible instead of looking
-  like data loss.
+- ~~**§9.3 — no txid handshake.**~~ **DONE — §13.**
 - **§9.4 — `content-length` from `raw.file_size_bytes` instead of `obj.size`.**
 - **§10.6 — `resolveMemberScope` has no `ORDER BY`**, so the shape `where` string
   is not order-stable.
@@ -851,6 +852,85 @@ diagnostics — `[msg-diag]`, `[net#]`, `wake-probe.ts` — which stay until the
 deliberate long-background re-test in §11.4 is clean. See §11.5.
 
 Verification after cleanup: mobile 38/38, mobile and web typecheck clean.
+
+---
+
+## 13. The txid handshake (§9.3), implemented
+
+Branch `fix/message-txid-handshake`, stacked on the §11 fix.
+
+### 13.1 What changed
+
+`createMessage` no longer resolves when tRPC returns 200. It captures the `txid`
+the router already returns and waits for Electric to deliver the row carrying it,
+so the optimistic row is held until the synced row exists to replace it. The
+window §9.3 describes is closed rather than narrowed.
+
+Nothing new had to be built server-side: every mutation router already calls
+`generateTxId(tx)` and returns `{ item, txid }`. The client was discarding it.
+
+### 13.2 The wiring, and why it is a function
+
+`sync-core` is framework-free and cannot import either app's collections, so the
+capability is injected, exactly as `fetchClient` and `retryOnError` already are:
+
+```ts
+makeCoreMutationFns(trpc, {
+  awaitTxId: { messages: (txid) => messagesCollection.utils.awaitTxId(txid) },
+})
+```
+
+**It must be an arrow function, not a captured collection.** Both apps export
+collections as `export let` and REASSIGN them on project switch / resync; a
+captured value pins a stale, cleaned-up instance whose shape is gone. This mirrors
+the `getCollection: () => xCollection` idiom already used in `actions/*`, and it is
+the same by-value hazard §10.5 flagged for the offline executor.
+
+The hook map is keyed by entity (`messages | tasks | resources | properties |
+teams` — all five routers return a txid), so wiring another later needs no API
+change: capture `result.txid`, then `await settleTxId("<entity>", txid)` after the
+try/catch. Only `messages` is wired today; every other entity keeps the old
+settle-on-200 behaviour.
+
+Wired on **both** apps. Web never exhibited the vanish, but its projects /
+build-units / channels have always run this same handshake — leaving messages out
+would be an asymmetry with no principle behind it.
+
+### 13.3 The three rules, and the one that bites
+
+Recorded in the `mutation-fns.ts` header and pinned by
+`web-app/code/tests/unit/mutation-txid-handshake.test.ts` (6 tests):
+
+1. **The await sits OUTSIDE the retriable try/catch.** A timeout carries no
+   `.data.code`, so routing it through `wrapTrpcError` marks it retriable, the
+   executor re-runs the whole mutation-fn, **re-issues the tRPC write**, and times
+   out again forever. This is not hypothetical — it is how the original pilot
+   jammed. The guard is the "mutate called exactly once" assertion; it looks
+   redundant next to the "doesn't throw" test and is not.
+2. **A timeout is swallowed, never thrown.** Past the tRPC call the server has
+   committed; throwing rolls back a write that succeeded.
+3. **It needs a live shape to carry the txid.** `messages` is `IDLE_GC_MS` and GC
+   aborts the stream — safe here because GC only fires with no mounted live query,
+   sending only happens from the channel screen where one is mounted, and the 60s
+   tier dwarfs `awaitTxId`'s 5s default. Re-check if either constant moves.
+
+### 13.4 What this does and does not buy
+
+**Does:** the bubble survives the reconciliation window. Any stall shorter than 5s
+is now invisible instead of fatal.
+
+**Does not:** survive a real stall. After the 5s timeout the row still drops and
+the message still disappears. This converts an unbounded, silent,
+indistinguishable-from-data-loss failure into a bounded one — it is not a
+persistent outbox UI.
+
+Making the message visibly persist as "sending…" means surfacing the pending
+transaction in `MessageList`, which is a genuinely separate piece of work. Worth
+doing, but it should not be smuggled in here.
+
+Verification: mobile 38/38, web 112/112 (6 new), both typechecks clean. No import
+cycle introduced — `collections/communication` reaches neither app's
+`infrastructure/offline`.
 
 ---
 

--- a/mobile-app/DISAPPEARING_MESSAGES_INVESTIGATION.md
+++ b/mobile-app/DISAPPEARING_MESSAGES_INVESTIGATION.md
@@ -802,9 +802,10 @@ so `installAbortSignalReasonPolyfill()` ran twice. The second call found
 ### 11.5 Still outstanding, independent of this
 
 - ~~**§9.3 — no txid handshake.**~~ **DONE — §13.**
-- **§9.4 — `content-length` from `raw.file_size_bytes` instead of `obj.size`.**
-- **§10.6 — `resolveMemberScope` has no `ORDER BY`**, so the shape `where` string
-  is not order-stable.
+- ~~**§10.6 — `resolveMemberScope` has no `ORDER BY`.**~~ **DONE — §14.**
+- ~~**§9.4 — `content-length` from `raw.file_size_bytes` instead of `obj.size`.**~~
+  **DONE, but on a different branch** — `fix/range-content-length`, which is a
+  sibling of this one rather than an ancestor, so the fix is not in this tree.
 - ~~**Diagnostics stay until the deliberate run.**~~ **DONE — the deliberate run is
   in §11.4b and all instrumentation was removed in §15.**
 
@@ -931,6 +932,38 @@ doing, but it should not be smuggled in here.
 Verification: mobile 38/38, web 112/112 (6 new), both typechecks clean. No import
 cycle introduced — `collections/communication` reaches neither app's
 `infrastructure/offline`.
+
+---
+
+## 14. Shape `where` order stability (§10.6), fixed
+
+`resolveMemberScope` now sorts its three id arrays before returning them.
+
+The arrays are interpolated **positionally** by `idSetWhere` into
+`col = ANY(ARRAY['a','b',…])`, and that string is the Electric shape's identity —
+`shape-where.ts` says so itself: *"a changed string is a new Electric shape, a new
+handle, and a full refetch for every client."* But the two `SELECT`s behind them
+carry no `ORDER BY`, and Postgres guarantees nothing there. A plan flip to an index
+scan, an autovacuum relocating tuples, or an `UPDATE` rewriting a row to a new page
+reorders them, and every connected client refetches messages, tasks, resources and
+properties at once.
+
+Not an authorization bug — the *set* is identical either way, so the same rows are
+authorized. It is a thundering-herd refetch triggered by something as mundane as
+vacuum, and essentially unattributable after the fact.
+
+**The mobile client already did this** (`collections/init.ts` — `uniqSorted` at 127,
+`[...new Set(…)].sort()` at 220) for the ids it puts in the shape URL. The server
+was the missing half of the same invariant, which is decent evidence this was an
+oversight rather than a decision.
+
+`tests/unit/access-scope-order.test.ts` (4 tests) feeds identical rows back in
+different orders and asserts the output does not move, covering the
+membership/owned-channel union as well as the simple case. Verified to FAIL without
+the sort — its two ordering tests break while the de-dup and empty-scope tests keep
+passing, which is the discrimination that makes it worth having.
+
+Web 116/116, typecheck clean.
 
 ---
 

--- a/mobile-app/src/infrastructure/offline/mutation-fns.ts
+++ b/mobile-app/src/infrastructure/offline/mutation-fns.ts
@@ -1,9 +1,19 @@
 import { makeCoreMutationFns } from "@buildinlime/sync-core"
 import { trpc } from "../trpc/client"
+import { messagesCollection } from "@/src/application/collections/communication"
 
 // The shared core spine (tasks / messages / resources / properties / teams / seen)
 // lives in packages/sync-core. Projects, build units, channels and teams are
 // created and managed on web only — mobile reads those collections but never
 // writes them, so it drives no outbox mutations of its own.
 
-export const mutationFns = makeCoreMutationFns(trpc)
+// The txid handshake: hold `messages.create` open until the synced row lands, so
+// the optimistic bubble is never dropped into an empty gap. Read as an arrow
+// function, NOT a captured collection — messagesCollection is reassigned on
+// project switch. See CoreMutationHooks and DISAPPEARING_MESSAGES_INVESTIGATION.md
+// §9.3.
+export const mutationFns = makeCoreMutationFns(trpc, {
+  awaitTxId: {
+    messages: (txid) => messagesCollection.utils.awaitTxId(txid),
+  },
+})

--- a/packages/sync-core/src/mutation-fns.ts
+++ b/packages/sync-core/src/mutation-fns.ts
@@ -12,29 +12,44 @@ import {
 import type { AppRouter } from "@buildinlime/contracts"
 import { coerceBool } from "./collections"
 
-// NOTE: we intentionally do NOT call `collection.utils.awaitTxId(result.txid)`
-// after the tRPC mutation. Electric's normal stream reconciles the optimistic row
-// by id, and the brief pre-reconciliation window has never produced an observable
-// flicker.
+// THE TXID HANDSHAKE (`settleTxId` below).
 //
-// This was once explained as an upstream limitation — that awaiting a txid through
-// a `persistedCollectionOptions`-wrapped collection "never resolves". That is NOT
-// true, so do not repeat it: `awaitTxId` takes a 5s timeout and REJECTS, the
-// persistence wrapper spreads `utils` through untouched, and web's projects /
-// build-units / channels collections have always run this exact handshake through
-// persisted collections (they return `{ txid }`, which electric-db-collection
-// awaits for them).
+// Without it, a mutation-fn resolves the moment tRPC returns 200. TanStack DB then
+// drops the optimistic row, and the bubble's existence depends entirely on the
+// Electric shape delivering the synced row milliseconds later. That window is
+// normally invisible — until sync stalls, at which point the row is dropped with
+// nothing to replace it and the message SILENTLY VANISHES, text and all. An earlier
+// revision of this comment asserted "the brief pre-reconciliation window has never
+// produced an observable flicker"; DISAPPEARING_MESSAGES_INVESTIGATION.md is the
+// counterexample that killed that assumption (§9.3 for this, §11 for the stall that
+// exposed it).
 //
-// What actually jammed the executor: the original pilot awaited INSIDE the
-// try/catch below. A timeout carries no `.data.code`, so wrapTrpcError rethrew it
-// as retriable, the executor re-ran the whole mutation-fn — re-issuing the tRPC
-// call — and timed out again, forever.
+// Every mutation router already returns `{ item, txid }` from `generateTxId(tx)`,
+// and Electric stamps the same txid on the rows it streams back. So awaiting it
+// holds the optimistic row until the real row is there to replace it: no window.
 //
-// So if you re-add it: keep it OUT of the retriable path and swallow a timeout
-// (the server has already committed; retrying re-issues the write and throwing
-// rolls back a mutation that succeeded), and skip it when the collection is
-// idle-GC'd, since GC aborts the shape stream that would carry the txid.
-// See ARCHITECTURE.md §12.6.
+// It is NOT a cure for a stalled shape — after the timeout the row still drops. It
+// converts an unbounded, silent, indistinguishable-from-data-loss failure into a
+// bounded one, which is the honest behaviour and makes every future repro readable.
+//
+// THREE RULES, each of which has already drawn blood:
+//
+// 1. The await MUST sit OUTSIDE the retriable try/catch. The original pilot awaited
+//    inside it: a timeout carries no `.data.code`, so wrapTrpcError rethrew it as
+//    retriable, the executor re-ran the whole mutation-fn — RE-ISSUING the tRPC
+//    write — and timed out again, forever.
+// 2. A timeout MUST be swallowed, never thrown. Past the tRPC call the server has
+//    committed; throwing rolls back a write that succeeded.
+// 3. It needs a live shape to carry the txid. `messages` is IDLE_GC_MS and GC
+//    aborts the stream — but GC only fires with no mounted live query, sending only
+//    happens from the channel screen where one is mounted, and the 60s tier dwarfs
+//    the 5s timeout. Re-check this if either constant moves.
+//
+// Do NOT reintroduce the old claim that awaiting a txid through a
+// `persistedCollectionOptions`-wrapped collection "never resolves". It is false:
+// `awaitTxId` takes a 5s timeout and REJECTS, the persistence wrapper spreads
+// `utils` through untouched, and web's projects / build-units / channels have always
+// run this handshake through persisted collections.
 
 type Inputs = inferRouterInputs<AppRouter>
 
@@ -113,7 +128,57 @@ const MAX_NAME_ATTEMPTS = 50
 // The mutation-fns replay each optimistic transaction against the server. They read
 // the untyped outbox row (`Record<string, unknown>`) and cast fields to build the
 // typed tRPC payload. One copy bound to whichever app's tRPC client is injected.
-export function makeCoreMutationFns(trpc: CoreTrpc): CoreMutationFns {
+/**
+ * Entities whose tRPC mutations return a Postgres txid that Electric echoes back
+ * on the synced row. Every one of these routers already calls `generateTxId(tx)`
+ * and returns `{ item, txid }`, so any of them CAN be wired — only the ones an app
+ * supplies a hook for actually are.
+ */
+export type TxIdEntity = `messages` | `tasks` | `resources` | `properties` | `teams`
+
+export interface CoreMutationHooks {
+  /**
+   * Per-entity "resolve once the synced row carrying this txid has landed".
+   * Each app supplies `(txid) => xCollection.utils.awaitTxId(txid)`.
+   *
+   * MUST be a function, not a captured collection: both apps export their
+   * collections as `export let` and REASSIGN them on project switch / resync, so a
+   * captured value pins a stale, cleaned-up instance whose shape is gone. Mirrors
+   * the `getCollection: () => xCollection` idiom already used in actions/*.
+   *
+   * An entity with no hook keeps the pre-handshake behaviour: settle as soon as
+   * tRPC returns 200. Adding one is two lines in the mutation-fn — capture
+   * `result.txid`, then `await settleTxId("<entity>", txid)` after the try/catch.
+   */
+  awaitTxId?: Partial<Record<TxIdEntity, (txid: number) => Promise<void>>>
+}
+
+export function makeCoreMutationFns(
+  trpc: CoreTrpc,
+  hooks: CoreMutationHooks = {},
+): CoreMutationFns {
+  /**
+   * Wait for `txid` to come back through the entity's shape, then return. Silent
+   * no-op when the app supplied no hook for this entity or the server returned no
+   * txid.
+   *
+   * CALL THIS OUTSIDE THE RETRIABLE try/catch — see rules 1 and 2 in the header.
+   * It never throws, so it cannot roll back or re-drive a write that has already
+   * committed on the server.
+   */
+  const settleTxId = async (entity: TxIdEntity, txid: number | undefined) => {
+    const await_ = hooks.awaitTxId?.[entity]
+    if (!await_ || txid === undefined) return
+    try {
+      await await_(txid)
+    } catch {
+      // Timed out (awaitTxId's own 5s default) waiting for the shape to deliver
+      // this txid, or the collection was torn down mid-flight. Either way the
+      // write SUCCEEDED; swallow and let the optimistic row drop exactly as it
+      // did before the handshake existed — bounded now instead of immediate.
+    }
+  }
+
   // -------------------- tasks --------------------
 
   /**
@@ -191,8 +256,9 @@ export function makeCoreMutationFns(trpc: CoreTrpc): CoreMutationFns {
   const createMessage: MutationFn = async ({ transaction }) => {
     const { modified } = transaction.mutations[0]
     const m = modified as Record<string, unknown>
+    let txid: number | undefined
     try {
-      await trpc.messages.create.mutate({
+      const result = await trpc.messages.create.mutate({
         id: m.id as string,
         text: m.text as string,
         // Forward the client's optimistic send time so the synced row keeps the
@@ -208,9 +274,13 @@ export function makeCoreMutationFns(trpc: CoreTrpc): CoreMutationFns {
         parent_id: (m.parent_id as string | null) ?? null,
         task_id: (m.task_id as string | null) ?? null,
       })
+      txid = (result as { txid?: number } | undefined)?.txid
     } catch (err) {
       wrapTrpcError(err)
     }
+    // Outside the catch on purpose — rule 1 in the header. This is what keeps the
+    // bubble on screen until the synced row exists to replace it.
+    await settleTxId(`messages`, txid)
   }
 
   /**

--- a/web-app/code/src/infrastructure/database/access-scope.ts
+++ b/web-app/code/src/infrastructure/database/access-scope.ts
@@ -60,9 +60,27 @@ export async function resolveMemberScope(userId: string): Promise<MemberScope> {
     buildunitIds.add(c.buildunit_id)
   }
 
+  // SORTED, and that is load-bearing — do not "simplify" it back to [...set].
+  //
+  // These arrays are interpolated positionally by idSetWhere into
+  // `col = ANY(ARRAY['a','b',…])`, and that string IS the Electric shape's
+  // identity. A different string is a new shape, a new handle, and a FULL REFETCH
+  // of messages/tasks/resources/properties for every affected client at once.
+  //
+  // Set insertion order is deterministic given the row order, but the two queries
+  // above have no ORDER BY, and Postgres guarantees nothing there: a plan flip to
+  // an index scan, autovacuum relocating tuples, or an UPDATE rewriting a row to a
+  // new page is enough to reorder them. The set is identical either way, so this
+  // is not an authorization issue — it is a thundering-herd refetch triggered by
+  // something as mundane as vacuum, and near-impossible to attribute afterwards.
+  //
+  // Sorting makes shape identity deterministic by construction instead of by
+  // luck. The mobile client already does this to the ids it puts in the shape URL
+  // (collections/init.ts — uniqSorted / [...new Set(…)].sort()); this is the
+  // server side of the same invariant.
   return {
-    channelIds: [...channelIds],
-    buildunitIds: [...buildunitIds],
-    projectIds: [...projectIds],
+    channelIds: [...channelIds].sort(),
+    buildunitIds: [...buildunitIds].sort(),
+    projectIds: [...projectIds].sort(),
   }
 }

--- a/web-app/code/src/infrastructure/offline/mutation-fns.ts
+++ b/web-app/code/src/infrastructure/offline/mutation-fns.ts
@@ -1,7 +1,19 @@
 import { makeCoreMutationFns } from "@buildinlime/sync-core"
 import { trpc } from "%/infrastructure/trpc/lib/trpc-client"
+import { messagesCollection } from "%/application/collections/communication"
 
 // Web's write surface is exactly the shared core spine (packages/sync-core).
 // Projects, build units and channels are not created through the outbox on web —
 // they are managed elsewhere — so there are no web-only additions here.
-export const mutationFns = makeCoreMutationFns(trpc)
+//
+// The txid handshake holds messages.create open until the synced row lands.
+// Web has never shown the vanish this fixes on mobile (see
+// DISAPPEARING_MESSAGES_INVESTIGATION.md §9.3) — it is wired here so messages match
+// projects / build units / channels, which have always run this same handshake.
+// Read as an arrow function, NOT a captured collection: messagesCollection is
+// reassigned on project switch.
+export const mutationFns = makeCoreMutationFns(trpc, {
+  awaitTxId: {
+    messages: (txid) => messagesCollection.utils.awaitTxId(txid),
+  },
+})

--- a/web-app/code/tests/unit/access-scope-order.test.ts
+++ b/web-app/code/tests/unit/access-scope-order.test.ts
@@ -1,0 +1,121 @@
+import { describe, it, expect, vi, beforeEach } from "vitest"
+
+// resolveMemberScope's arrays are interpolated POSITIONALLY into the Electric
+// `where` clause by idSetWhere, so their order is part of the shape's identity.
+// The two SELECTs behind them carry no ORDER BY, and Postgres guarantees no row
+// order without one — a plan flip, an autovacuum, or an UPDATE moving a row to a
+// new page can reorder them at any time.
+//
+// If that happens without the sort, every client takes a full refetch of
+// messages/tasks/resources/properties simultaneously. These tests feed the same
+// rows back in different orders and assert the output does not move.
+
+const rows = vi.hoisted(() => ({ memberships: [] as unknown[], owned: [] as unknown[] }))
+
+// Minimal stand-in for drizzle's builder: db.select(...).from(...).where(...)
+// resolves to the row array. Which array depends on call order — memberships is
+// queried first, owned channels second (they're issued together in a
+// Promise.all, but constructed in that order).
+vi.mock("%/infrastructure/database/connection", () => {
+  let call = 0
+  return {
+    db: {
+      select: () => ({
+        from: () => ({
+          where: () => Promise.resolve(call++ % 2 === 0 ? rows.memberships : rows.owned),
+        }),
+      }),
+    },
+  }
+})
+
+vi.mock("%/infrastructure/database/schema/admin-schema", () => ({
+  membershipTable: { user_id: "user_id", channel_id: "channel_id", buildunit_id: "buildunit_id", project_id: "project_id", member_flag: "member_flag" },
+  channelsTable: { id: "id", buildunit_id: "buildunit_id", owner_id: "owner_id" },
+}))
+
+const { resolveMemberScope } = await import("%/infrastructure/database/access-scope")
+
+const CH_A = "aaaaaaaa-1111-4111-8111-111111111111"
+const CH_B = "bbbbbbbb-2222-4222-8222-222222222222"
+const CH_C = "cccccccc-3333-4333-8333-333333333333"
+const BU_A = "aaaaaaaa-4444-4444-8444-444444444444"
+const BU_B = "bbbbbbbb-5555-4555-8555-555555555555"
+const PR_A = "aaaaaaaa-6666-4666-8666-666666666666"
+const PR_B = "bbbbbbbb-7777-4777-8777-777777777777"
+
+const membership = (channel: string, buildunit: string, project: string) => ({
+  channel_id: channel,
+  buildunit_id: buildunit,
+  project_id: project,
+})
+
+beforeEach(() => {
+  rows.memberships = []
+  rows.owned = []
+})
+
+describe("resolveMemberScope id ordering", () => {
+  it("returns the same arrays no matter what order Postgres hands the rows back", async () => {
+    rows.memberships = [
+      membership(CH_C, BU_B, PR_B),
+      membership(CH_A, BU_A, PR_A),
+      membership(CH_B, BU_A, PR_A),
+    ]
+    const first = await resolveMemberScope("u1")
+
+    // Same rows, different order — what a plan change or an autovacuum produces.
+    rows.memberships = [
+      membership(CH_B, BU_A, PR_A),
+      membership(CH_C, BU_B, PR_B),
+      membership(CH_A, BU_A, PR_A),
+    ]
+    const second = await resolveMemberScope("u1")
+
+    expect(second).toEqual(first)
+    expect(first.channelIds).toEqual([CH_A, CH_B, CH_C])
+    expect(first.buildunitIds).toEqual([BU_A, BU_B])
+    expect(first.projectIds).toEqual([PR_A, PR_B])
+  })
+
+  it("is stable across the membership/owned-channel union too", async () => {
+    // The owned-channels query is a defensive union, so an id can arrive from
+    // either side. Which side it came from must not change the output either.
+    rows.memberships = [membership(CH_C, BU_B, PR_B)]
+    rows.owned = [
+      { channel_id: CH_A, buildunit_id: BU_A },
+      { channel_id: CH_B, buildunit_id: BU_A },
+    ]
+    const first = await resolveMemberScope("u1")
+
+    rows.memberships = [membership(CH_C, BU_B, PR_B)]
+    rows.owned = [
+      { channel_id: CH_B, buildunit_id: BU_A },
+      { channel_id: CH_A, buildunit_id: BU_A },
+    ]
+    const second = await resolveMemberScope("u1")
+
+    expect(second).toEqual(first)
+    expect(first.channelIds).toEqual([CH_A, CH_B, CH_C])
+  })
+
+  it("still de-duplicates", async () => {
+    // Sorting must not have cost the Set semantics: an owner with a membership
+    // row appears on both sides of the union.
+    rows.memberships = [membership(CH_A, BU_A, PR_A)]
+    rows.owned = [{ channel_id: CH_A, buildunit_id: BU_A }]
+
+    const scope = await resolveMemberScope("u1")
+
+    expect(scope.channelIds).toEqual([CH_A])
+    expect(scope.buildunitIds).toEqual([BU_A])
+  })
+
+  it("keeps an empty scope empty (default-deny stays default-deny)", async () => {
+    const scope = await resolveMemberScope("u1")
+
+    expect(scope.channelIds).toEqual([])
+    expect(scope.buildunitIds).toEqual([])
+    expect(scope.projectIds).toEqual([])
+  })
+})

--- a/web-app/code/tests/unit/mutation-txid-handshake.test.ts
+++ b/web-app/code/tests/unit/mutation-txid-handshake.test.ts
@@ -1,0 +1,126 @@
+import { describe, it, expect, vi } from "vitest"
+import { makeCoreMutationFns } from "@buildinlime/sync-core"
+
+// The txid handshake in packages/sync-core/src/mutation-fns.ts. Its header lists
+// three rules, each of which has already caused a real failure; these tests exist
+// to make breaking one of them loud rather than subtle.
+//
+// The nastiest is rule 1 — awaiting INSIDE the retriable try/catch. That bug does
+// not throw or hang visibly: it makes the offline executor re-run the mutation-fn
+// and RE-ISSUE the write, forever. "mutate called exactly once" is the assertion
+// that catches it, so do not relax it.
+
+const TXID = 4242
+
+function makeTrpc(result: unknown = { item: {}, txid: TXID }) {
+  const mutate = vi.fn().mockResolvedValue(result)
+  // Only messages.create is exercised here; the rest of the surface is stubbed
+  // because makeCoreMutationFns destructures nothing at construction time.
+  return {
+    trpc: { messages: { create: { mutate } } } as never,
+    mutate,
+  }
+}
+
+const transaction = {
+  mutations: [
+    {
+      modified: {
+        id: "m1",
+        text: "hello",
+        created_at: "2026-07-22T00:00:00.000Z",
+        channel_id: "c1",
+        buildunit_id: "b1",
+        project_id: "p1",
+        createdby_id: "u1",
+      },
+      original: {},
+    },
+  ],
+}
+
+const run = (fns: ReturnType<typeof makeCoreMutationFns>) =>
+  fns.createMessage({ transaction, idempotencyKey: "k1" })
+
+describe("createMessage txid handshake", () => {
+  it("waits for the synced row before resolving", async () => {
+    const { trpc, mutate } = makeTrpc()
+    let release: () => void = () => {}
+    const gate = new Promise<void>((resolve) => {
+      release = resolve
+    })
+    const awaitTxId = vi.fn().mockReturnValue(gate)
+
+    const fns = makeCoreMutationFns(trpc, { awaitTxId: { messages: awaitTxId } })
+    let settled = false
+    const pending = run(fns).then(() => {
+      settled = true
+    })
+
+    // The tRPC write has returned, but the handshake has not — this is precisely
+    // the window in which the optimistic row used to be dropped.
+    await Promise.resolve()
+    expect(mutate).toHaveBeenCalledTimes(1)
+    expect(awaitTxId).toHaveBeenCalledWith(TXID)
+    expect(settled).toBe(false)
+
+    release()
+    await pending
+    expect(settled).toBe(true)
+  })
+
+  it("swallows a handshake timeout instead of throwing (rule 2)", async () => {
+    // Throwing here would roll back a write the server has already committed.
+    const { trpc, mutate } = makeTrpc()
+    const awaitTxId = vi.fn().mockRejectedValue(new Error("timeout waiting for txid"))
+
+    const fns = makeCoreMutationFns(trpc, { awaitTxId: { messages: awaitTxId } })
+
+    await expect(run(fns)).resolves.toBeUndefined()
+    expect(mutate).toHaveBeenCalledTimes(1)
+  })
+
+  it("does not re-issue the write when the handshake times out (rule 1)", async () => {
+    // The regression guard. If the await is ever moved inside the try/catch,
+    // wrapTrpcError marks the timeout retriable and the executor re-runs this fn,
+    // re-POSTing the message. A duplicate mutate call is that bug's signature.
+    const { trpc, mutate } = makeTrpc()
+    const awaitTxId = vi.fn().mockRejectedValue(new Error("timeout waiting for txid"))
+
+    const fns = makeCoreMutationFns(trpc, { awaitTxId: { messages: awaitTxId } })
+    await run(fns)
+
+    expect(mutate).toHaveBeenCalledTimes(1)
+    expect(awaitTxId).toHaveBeenCalledTimes(1)
+  })
+
+  it("skips the handshake when the app supplies no hook", async () => {
+    // Pre-handshake behaviour, still the default for every unwired entity.
+    const { trpc, mutate } = makeTrpc()
+    const fns = makeCoreMutationFns(trpc)
+
+    await expect(run(fns)).resolves.toBeUndefined()
+    expect(mutate).toHaveBeenCalledTimes(1)
+  })
+
+  it("skips the handshake when the server returns no txid", async () => {
+    const { trpc } = makeTrpc({ item: {} })
+    const awaitTxId = vi.fn()
+
+    const fns = makeCoreMutationFns(trpc, { awaitTxId: { messages: awaitTxId } })
+    await run(fns)
+
+    expect(awaitTxId).not.toHaveBeenCalled()
+  })
+
+  it("still surfaces a failed write, and never reaches the handshake", async () => {
+    const mutate = vi.fn().mockRejectedValue(new Error("boom"))
+    const trpc = { messages: { create: { mutate } } } as never
+    const awaitTxId = vi.fn()
+
+    const fns = makeCoreMutationFns(trpc, { awaitTxId: { messages: awaitTxId } })
+
+    await expect(run(fns)).rejects.toThrow("boom")
+    expect(awaitTxId).not.toHaveBeenCalled()
+  })
+})


### PR DESCRIPTION
> **Stacked on #61** (which is stacked on #60). Two independent fixes — happy to split if you'd rather review them separately.

## 1. Hold message sends open until the synced row lands

`createMessage` resolved the moment tRPC returned 200. TanStack DB then dropped the optimistic row, leaving the bubble's existence entirely dependent on the Electric `messages` shape delivering the real row milliseconds later.

That window is normally invisible — but when sync stalls, the row is dropped with **nothing to replace it** and the message silently vanishes, typed text and all, looking exactly like data loss for a write the server has already committed. That is what made #60's bug present as "my message disappeared" rather than "sync is slow".

Every mutation router already calls `generateTxId(tx)` and returns `{ item, txid }`, and Electric stamps the same txid on the rows it streams back. The client was discarding it. `createMessage` now captures it and waits for the shape to deliver it.

**This bounds the failure, it does not cure it.** After `awaitTxId`'s 5s timeout the row still drops. It converts an unbounded, silent, indistinguishable-from-data-loss symptom into a bounded one. Making a send visibly persist as "sending…" needs the pending transaction surfaced in `MessageList` and is separate work.

`sync-core` cannot import either app's collections, so the capability is injected the way `fetchClient` and `retryOnError` already are:

```ts
makeCoreMutationFns(trpc, {
  awaitTxId: { messages: (txid) => messagesCollection.utils.awaitTxId(txid) },
})
```

**It must be an arrow function, not a captured collection** — both apps export collections as `export let` and reassign them on project switch, so a captured value pins a stale instance whose shape is gone. Mirrors the existing `getCollection: () => xCollection` idiom in `actions/*`.

Wired on both apps. Web never showed the vanish, but its projects/build-units/channels have always run this same handshake; leaving messages out would be an asymmetry with nothing behind it.

### The rule to preserve during review

**The await sits OUTSIDE the retriable try/catch.** A timeout carries no `.data.code`, so `wrapTrpcError` would mark it retriable, the executor would re-run the mutation-fn and **re-issue the tRPC write**, forever. That is how the original pilot jammed. `mutation-txid-handshake.test.ts` guards it with "mutate called exactly once" — that assertion looks redundant next to the "doesn't throw" test and is not.

## 2. Sort `resolveMemberScope` ids

The id arrays are interpolated **positionally** by `idSetWhere` into `col = ANY(ARRAY['a','b',…])`, and that string is the Electric shape's identity. `shape-where.ts` states the stakes itself: *"a changed string is a new Electric shape, a new handle, and a full refetch for every client."*

Both `SELECT`s have no `ORDER BY`, and Postgres guarantees no row order without one. A plan flip, an autovacuum relocating tuples, or an `UPDATE` moving a row to a new page reorders them — and every connected client simultaneously refetches messages, tasks, resources and properties.

Not an authorization bug: the *set* is identical either way. It's a thundering-herd refetch triggered by something as mundane as vacuum, and near-impossible to attribute afterwards.

The mobile client already sorts the ids it puts in the shape URL (`collections/init.ts`). This is the server side of the same invariant.

`access-scope-order.test.ts` feeds identical rows back in different orders and asserts the output doesn't move. **Verified to fail without the sort** — the two ordering tests break while de-dup and empty-scope keep passing.

Web 116/116, mobile 38/38, both typechecks clean. No import cycle introduced — `collections/communication` reaches neither app's `infrastructure/offline`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FSFjLZSuenUeHWNcaHMWnx