### PR TITLE
fix(web): serve the storage size, not the DB's, on resource file responses

### DIFF
--- a/web-app/code/src/infrastructure/storage/fileStorage.ts
+++ b/web-app/code/src/infrastructure/storage/fileStorage.ts
@@ -225,12 +225,57 @@ export async function serveResourceFile(
   }
   const raw = rawRecords[0]
 
-  const totalSize = Number(raw.file_size_bytes)
-  const range = parseRangeHeader(request.headers.get("range"), totalSize)
+  // THE SIZE WE SERVE MUST BE THE STORE'S, NOT THE DATABASE'S.
+  //
+  // `resources_raw.file_size_bytes` is a number recorded at upload time; the object
+  // is the thing actually being streamed. They can drift — a row predating the
+  // object-storage migration, a re-upload over the same key (`put` is deliberately
+  // idempotent), a truncated write. When they do and we trust the DB:
+  //   db > real  → we declare a content-length larger than the bytes we send, and an
+  //                HTTP/1.1 client waits forever for a remainder that never comes.
+  //                On mobile that is a socket held open inside OkHttp.
+  //   db < real  → ranges clamp short and seeking past the DB's idea of EOF returns
+  //                416 for bytes that exist. Playback truncates.
+  // Neither is visible while the two agree, which is exactly what makes it a trap.
+  //
+  // Both drivers already stat/getMetadata before opening the stream (local.ts,
+  // gcs.ts), so `obj.size` is authoritative and costs nothing extra.
+  const dbSize = Number(raw.file_size_bytes)
+  const rangeHeader = request.headers.get("range")
+
+  // Provisional parse, against the DB number, for one purpose only: to ask storage
+  // for a slice instead of the whole object. The authoritative parse is below.
+  const provisional = parseRangeHeader(rangeHeader, dbSize)
+  const provisionalRange = provisional === "unsatisfiable" ? null : provisional
+
+  let obj = await getStorage().get(
+    raw.storage_path,
+    provisionalRange ? { range: provisionalRange } : undefined,
+  )
+  if (!obj) {
+    return new Response(JSON.stringify({ error: "File not found on server" }), {
+      status: 404,
+      headers: { "content-type": "application/json" },
+    })
+  }
+
+  const totalSize = obj.size
+  if (totalSize !== dbSize) {
+    // Loud, because it means a row and its object have diverged. Serving is still
+    // correct from here — the store wins — but something upstream needs a look.
+    console.warn(
+      `[storage] size mismatch for resource ${resourceId} (${raw.storage_path}): ` +
+        `db=${dbSize} storage=${totalSize} — serving the storage size`,
+    )
+  }
+
+  // Authoritative parse. Pure function, no I/O, so re-running it is free.
+  const range = parseRangeHeader(rangeHeader, totalSize)
 
   // A range that names bytes outside the file gets 416 + the file's true size, so
   // the client can retry with a valid one (RFC 9110 §15.5.17).
   if (range === "unsatisfiable") {
+    await obj.stream.cancel().catch(() => {})
     return new Response(null, {
       status: 416,
       headers: {
@@ -240,14 +285,26 @@ export async function serveResourceFile(
     })
   }
 
-  // Fetch only the requested slice off storage when a range was asked for — the
-  // player never has to pull the whole file just to seek near the end.
-  const obj = await getStorage().get(raw.storage_path, range ? { range } : undefined)
-  if (!obj) {
-    return new Response(JSON.stringify({ error: "File not found on server" }), {
-      status: 404,
-      headers: { "content-type": "application/json" },
-    })
+  // Only when the two parses disagree — i.e. the sizes really had drifted — is the
+  // slice already in hand the wrong one. Re-fetch with the correct bounds. This
+  // costs a second round trip in the broken case and nothing at all in the normal
+  // one, which is the trade option 2 (a `head` on every request) gets backwards.
+  const sameSlice =
+    (provisionalRange === null && range === null) ||
+    (provisionalRange !== null &&
+      range !== null &&
+      provisionalRange.start === range.start &&
+      provisionalRange.end === range.end)
+  if (!sameSlice) {
+    await obj.stream.cancel().catch(() => {})
+    const corrected = await getStorage().get(raw.storage_path, range ? { range } : undefined)
+    if (!corrected) {
+      return new Response(JSON.stringify({ error: "File not found on server" }), {
+        status: 404,
+        headers: { "content-type": "application/json" },
+      })
+    }
+    obj = corrected
   }
 
   // `attachment` is what the download path relies on; native media players read

--- a/web-app/code/tests/unit/serve-resource-size.test.ts
+++ b/web-app/code/tests/unit/serve-resource-size.test.ts
@@ -1,0 +1,198 @@
+import { describe, it, expect, vi, beforeEach } from "vitest"
+
+// serveResourceFile has two candidate sizes for a file: the number recorded in
+// resources_raw.file_size_bytes at upload time, and the object's real length as
+// reported by the store. It must serve the store's.
+//
+// When it trusted the DB and the two had drifted:
+//   db > real → content-length promised bytes that were never sent, and an
+//               HTTP/1.1 client waits on a body that never completes
+//   db < real → ranges clamped short, and seeks past the DB's idea of EOF
+//               returned 416 for bytes that exist
+// Neither shows up while the two agree, so these tests deliberately drive them
+// apart. `dbSize` and `realSize` differing is the whole point of the fixture.
+
+const state = vi.hoisted(() => ({
+  dbSize: 1000,
+  realSize: 1000,
+  /** Every get() the handler made, in order. */
+  gets: [] as Array<{ range?: { start: number; end: number } }>,
+  /** Streams handed out, so a test can assert an unused one was cancelled. */
+  cancelled: [] as boolean[],
+}))
+
+vi.mock("%/infrastructure/auth/server", () => ({
+  auth: { api: { getSession: async () => ({ user: { id: "u1" } }) } },
+}))
+
+// The handler issues three queries in order: resource, membership, raw record.
+vi.mock("%/infrastructure/database/connection", () => {
+  let call = 0
+  const results = () => [
+    [{ id: "r1", channel_id: "c1", deleted_at: null }],
+    [{ id: "m1" }],
+    [
+      {
+        resource_id: "r1",
+        storage_path: "resources/r1/clip.mp4",
+        file_size_bytes: state.dbSize,
+        mime_type: "video/mp4",
+        original_filename: "clip.mp4",
+      },
+    ],
+  ]
+  return {
+    db: {
+      select: () => ({
+        from: () => ({ where: () => Promise.resolve(results()[call++ % 3]) }),
+      }),
+    },
+  }
+})
+
+vi.mock("%/infrastructure/database/schema/admin-schema", () => ({
+  resourcesTable: { id: "id", channel_id: "channel_id", deleted_at: "deleted_at" },
+  resourcesRawTable: { resource_id: "resource_id" },
+  messagesTable: { id: "id" },
+  membershipTable: { id: "id", user_id: "user_id", channel_id: "channel_id", member_flag: "member_flag" },
+  tasksTable: { id: "id" },
+}))
+
+vi.mock("drizzle-orm", () => ({
+  eq: () => ({}),
+  and: () => ({}),
+  sql: () => ({}),
+}))
+
+vi.mock("%/infrastructure/storage/index", () => ({
+  getStorage: () => ({
+    get: async (_key: string, opts?: { range?: { start: number; end: number } }) => {
+      state.gets.push({ range: opts?.range })
+      const index = state.cancelled.length
+      state.cancelled.push(false)
+      const stream = new ReadableStream({
+        start(controller) {
+          controller.enqueue(new Uint8Array([1, 2, 3]))
+          controller.close()
+        },
+        cancel() {
+          state.cancelled[index] = true
+        },
+      })
+      // Mirrors both drivers: `size` is the FULL object length even for a ranged
+      // read (provider.ts documents this explicitly).
+      return { stream, size: state.realSize }
+    },
+  }),
+}))
+
+const { serveResourceFile } = await import("%/infrastructure/storage/fileStorage")
+
+const serve = (range?: string) =>
+  serveResourceFile(
+    new Request("http://localhost/api/resources/r1/file", {
+      headers: range ? { range } : {},
+    }),
+    { resourceId: "r1" },
+  )
+
+beforeEach(() => {
+  state.dbSize = 1000
+  state.realSize = 1000
+  state.gets = []
+  state.cancelled = []
+  vi.restoreAllMocks()
+})
+
+describe("serveResourceFile size source", () => {
+  it("serves the storage size, not the DB size, on a full response", async () => {
+    // The hang case: the DB claims more bytes than the object holds.
+    state.dbSize = 5000
+    state.realSize = 1000
+
+    const res = await serve()
+
+    expect(res.status).toBe(200)
+    expect(res.headers.get("content-length")).toBe("1000")
+  })
+
+  it("keeps content-length correct when the two agree", async () => {
+    const res = await serve()
+
+    expect(res.status).toBe(200)
+    expect(res.headers.get("content-length")).toBe("1000")
+    expect(res.headers.get("accept-ranges")).toBe("bytes")
+  })
+
+  it("uses the storage size as the content-range denominator", async () => {
+    state.dbSize = 5000
+    state.realSize = 1000
+
+    const res = await serve("bytes=0-99")
+
+    expect(res.status).toBe(206)
+    expect(res.headers.get("content-range")).toBe("bytes 0-99/1000")
+    expect(res.headers.get("content-length")).toBe("100")
+  })
+
+  it("re-fetches the corrected slice when the DB size inflated the range", async () => {
+    // `bytes=900-` resolves to 900-4999 against the DB's 5000 but must be
+    // 900-999 against the real object. Serving the first slice's bounds would
+    // declare 4100 bytes and send 100.
+    state.dbSize = 5000
+    state.realSize = 1000
+
+    const res = await serve("bytes=900-")
+
+    expect(res.status).toBe(206)
+    expect(res.headers.get("content-range")).toBe("bytes 900-999/1000")
+    expect(res.headers.get("content-length")).toBe("100")
+
+    expect(state.gets).toEqual([
+      { range: { start: 900, end: 4999 } }, // provisional, from the DB number
+      { range: { start: 900, end: 999 } }, // corrected, from the store
+    ])
+    expect(state.cancelled[0]).toBe(true) // the wrong slice was not leaked
+  })
+
+  it("416s against the real size when the range is past the true EOF", async () => {
+    state.dbSize = 5000
+    state.realSize = 1000
+
+    const res = await serve("bytes=2000-2999")
+
+    expect(res.status).toBe(416)
+    expect(res.headers.get("content-range")).toBe("bytes */1000")
+    expect(state.cancelled[0]).toBe(true)
+  })
+
+  it("serves bytes the DB would have wrongly called unsatisfiable", async () => {
+    // The opposite drift: the object is bigger than the row claims. The old code
+    // 416'd here without ever asking storage.
+    state.dbSize = 500
+    state.realSize = 2000
+
+    const res = await serve("bytes=1500-1599")
+
+    expect(res.status).toBe(206)
+    expect(res.headers.get("content-range")).toBe("bytes 1500-1599/2000")
+    expect(res.headers.get("content-length")).toBe("100")
+  })
+
+  it("makes exactly one storage call when the sizes agree", async () => {
+    // The correction path must not cost a second round trip on the happy path.
+    await serve("bytes=0-99")
+
+    expect(state.gets).toEqual([{ range: { start: 0, end: 99 } }])
+  })
+
+  it("warns when the row and the object disagree", async () => {
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {})
+    state.dbSize = 5000
+    state.realSize = 1000
+
+    await serve()
+
+    expect(warn).toHaveBeenCalledWith(expect.stringContaining("size mismatch"))
+  })
+})


### PR DESCRIPTION
> **Stacked on #61** (which is stacked on #60). Sibling of #62 — they touch disjoint files and can merge in either order.

## The bug

`serveResourceFile` has two candidate sizes for a file and uses the wrong one. `resources_raw.file_size_bytes` is a number recorded at upload time; the object is what actually gets streamed. Both drivers already return the object's true length as `obj.size`, and the handler discarded it.

`totalSize` drove **four** things: the `416` `content-range`, the `206` `content-range` denominator, the `206` `content-length` (via `range.end`), and the `200` `content-length`.

While the two agree this is invisible, which is what makes it a trap. When they drift:

| | Effect |
|---|---|
| **db > real** | `content-length` promises bytes that are never sent. An HTTP/1.1 client waits on a body that never completes; on mobile that is a socket held open inside OkHttp. |
| **db < real** | Ranges clamp short, and a seek past the DB's idea of EOF returns `416` for bytes that exist. Playback truncates. |

They can drift from a row predating the object-storage migration, a re-upload over the same key (`put` is deliberately idempotent — *"overwriting the same key is fine"*), or a truncated write.

## The approach, and why not the obvious one

**The happy path keeps a single storage round trip.** The range header is parsed twice: provisionally against the DB number, purely to ask for a slice rather than the whole object, then authoritatively against `obj.size` once storage has answered. Re-parsing is a pure function, so it costs nothing.

Only when the two parses disagree — i.e. the sizes really had drifted — is a corrected fetch issued, and the unused stream is `cancel()`ed rather than leaked.

The obvious alternative, adding `head`/`stat` to `StorageProvider` and learning the true size up front, pays that cost on *every* request to fix the rare broken one. It's also unnecessary: both drivers already `stat`/`getMetadata` before opening the stream (`local.ts:38`, `gcs.ts:48`), so `obj.size` is free.

A mismatch is logged loudly. Serving is correct from there on, but a row and its object having diverged means something upstream needs looking at.

## Tests

`serve-resource-size.test.ts` drives `dbSize` and `realSize` apart in **both** directions — including the case the old code got wrong in the opposite way, where the object is larger than the row claims and a valid seek was 416'd without storage ever being asked. Covers the 200, 206, 416, corrected-refetch and stream-cancel paths, and pins that the happy path makes exactly one storage call.

**Verified against the old implementation: 6 of the 8 fail**, and the 2 that pass are the two that shouldn't discriminate (sizes agree).

Web 114/114, typecheck clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FSFjLZSuenUeHWNcaHMWnx