### PR TITLE
fix(deploy): roll back on any failure, and prune superseded images

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -156,6 +156,13 @@ jobs:
       - name: Quality ratchet (typecheck + lint vs baseline)
         run: bash .github/scripts/ratchet.sh
 
+      # deploy.sh is the one script whose failure mode is a wedged production
+      # box, and it is the only thing here CI never otherwise exercises — the
+      # deploy job runs it on the VM, where a bug has already cost a release.
+      # Fully stubbed: no registry, database or VM is touched.
+      - name: Deploy script failure-handling tests
+        run: bash deploy/deploy.test.sh
+
   # ---------------------------------------------------------------------------
   # Deploy — main only, and only when every gate above is green.
   #

--- a/deploy/deploy.sh
+++ b/deploy/deploy.sh
@@ -13,10 +13,21 @@
 #   4. up -d     — Compose recreates only changed services, leaving Electric's
 #                  replication slot alone (verified §12)
 #   5. smoke     — and roll back the tag if it fails
+#   6. prune     — evict superseded images; the boot disk is finite (see below)
 #
+# Failure handling is a single EXIT trap, NOT per-step cleanup. Step 1 rewrites
+# compose.env before anything else runs, so ANY later failure used to leave the
+# file pointing at a tag that may not even be on the box — while the rollback
+# lived only inside the smoke-test branch and so never ran for an earlier
+# failure. That is exactly what happened when a full disk killed the pull: the
+# containers kept serving the old image (correct), but compose.env named the new
+# one, so the next `compose up` or a reboot would have tried to start a tag that
+# was never fully pulled.
 set -euo pipefail
 
-APP_DIR=/opt/buildinlime
+# Overridable only so deploy.test.sh can point it at a scratch directory. In
+# production CI always leaves it unset, and the default is what runs.
+APP_DIR="${APP_DIR:-/opt/buildinlime}"
 IMAGE_TAG="${IMAGE_TAG:?set IMAGE_TAG}"
 REGION="${REGION:-asia-south1}"
 PROJECT="${PROJECT:-buildinlime}"
@@ -29,23 +40,69 @@ COMPOSE=(docker compose --env-file compose.env --env-file .env -f docker-compose
 
 step() { printf '\n\033[1;36m▸ %s\033[0m\n' "$*"; }
 
-# Remember the current tag so a failed smoke test can roll back.
+# Remember the current tag so any failure can roll back to it.
 PREV_TAG=$(grep -oP '(?<=/app:).*' compose.env || echo "")
 step "deploying ${IMAGE_TAG} (previous: ${PREV_TAG:-none})"
 
-step "1/5 point compose at the new tag"
-sed -i "s|/app:.*|/app:${IMAGE_TAG}|" compose.env
-sed -i "s|/tools:.*|/tools:${IMAGE_TAG}|" compose.env
+# Set once the smoke test has passed; tells the trap there is nothing to undo.
+DEPLOY_OK=false
+# Set the moment `up -d` has run. Before that point the containers are still on
+# PREV_TAG and rolling back means editing compose.env and NOTHING ELSE — calling
+# `up -d` there would recreate containers this deploy never touched.
+CONTAINERS_RECREATED=false
+
+point_compose_at() {
+  sed -i "s|/app:.*|/app:${1}|" compose.env
+  sed -i "s|/tools:.*|/tools:${1}|" compose.env
+}
+
+on_exit() {
+  local rc=$?
+  trap - EXIT
+  # Explicit `if`, not `$DEPLOY_OK && exit 0`: the && form leans on set -e's
+  # exemption for non-final commands in a list, which is exactly the kind of
+  # subtlety that should not decide whether production rolls back.
+  if $DEPLOY_OK; then
+    exit 0
+  fi
+
+  printf '\n\033[1;31m✗ deploy FAILED (exit %s)\033[0m\n' "$rc"
+
+  if [[ -z "$PREV_TAG" ]]; then
+    # First-ever deploy, or compose.env had no tag to read. Nothing to go back
+    # to, so say so loudly rather than pretending we recovered.
+    echo "  no previous tag recorded — compose.env still names ${IMAGE_TAG}."
+    echo "  Fix the cause, then re-run; do not 'compose up' until you do."
+    exit "$rc"
+  fi
+
+  echo "  restoring compose.env to ${PREV_TAG}"
+  point_compose_at "$PREV_TAG"
+
+  if $CONTAINERS_RECREATED; then
+    echo "  containers were already recreated — bringing ${PREV_TAG} back up"
+    "${COMPOSE[@]}" up -d 2>&1 | tail -3 || true
+    echo "  rolled back. NOTE: migrations are NOT reverted — if this deploy applied"
+    echo "  a schema change, the previous image may not be compatible with it."
+  else
+    echo "  containers were never recreated; they are still serving ${PREV_TAG}."
+  fi
+  exit "$rc"
+}
+trap on_exit EXIT
+
+step "1/6 point compose at the new tag"
+point_compose_at "$IMAGE_TAG"
 grep -E '^(APP|TOOLS)_IMAGE=' compose.env
 
-step "2/5 pull"
+step "2/6 pull"
 "${COMPOSE[@]}" pull -q app 2>&1 | tail -2
 "${COMPOSE[@]}" --profile tools pull -q app-tools 2>&1 | tail -2
 
-step "3/5 migrate"
+step "3/6 migrate"
 "${COMPOSE[@]}" --profile tools run --rm app-tools pnpm migrate 2>&1 | tail -5
 
-step "4/5 electric ownership sweep"
+step "4/6 electric ownership sweep"
 # MUST run after every migration. drizzle-kit runs as the app role, so any table
 # a migration creates is owned by `app` and Electric cannot add it to its
 # publication or set REPLICA IDENTITY FULL on it. Electric configures tables
@@ -54,8 +111,10 @@ step "4/5 electric ownership sweep"
 DB_URL=$(grep -oP '(?<=^DATABASE_URL=).*' .env)
 psql "$DB_URL" -v ON_ERROR_STOP=1 -q -f "${APP_DIR}/sql/02-electric-own-tables.sql"
 
-step "5/5 restart"
+step "5/6 restart"
 "${COMPOSE[@]}" up -d 2>&1 | tail -5
+# From here on a rollback means more than editing compose.env.
+CONTAINERS_RECREATED=true
 "${COMPOSE[@]}" ps --format 'table {{.Service}}\t{{.Status}}'
 
 step "smoke test"
@@ -100,15 +159,45 @@ fi
 
 if ! $ok; then
   printf '\n\033[1;31m✗ smoke test FAILED\033[0m\n'
-  if [[ -n "$PREV_TAG" ]]; then
-    echo "  rolling back to ${PREV_TAG}"
-    sed -i "s|/app:.*|/app:${PREV_TAG}|" compose.env
-    sed -i "s|/tools:.*|/tools:${PREV_TAG}|" compose.env
-    "${COMPOSE[@]}" up -d 2>&1 | tail -3
-    echo "  rolled back. NOTE: migrations are NOT reverted — if this deploy applied"
-    echo "  a schema change, the previous image may not be compatible with it."
-  fi
+  # The rollback itself lives in the EXIT trap, so this path and an earlier
+  # failure recover identically. Keeping a second copy here is how the pull
+  # failure ended up with no rollback at all.
   exit 1
 fi
 
+# ---------------------------------------------------------------------------
+step "6/6 prune superseded images"
+# The boot disk is 30 GB and shared with the OS (deploymentPlan.md §4.6.2), while
+# every merge to main pulls TWO new images (app + tools). Nothing used to evict
+# the old ones, so the disk filled and a deploy died mid-`pull` with
+# "no space left on device" — after compose.env had already been rewritten.
+#
+# Deliberately NOT `docker image prune -a`: that would take PREV_TAG's images
+# with it, and PREV_TAG is exactly what the trap above rolls back to. Keep the
+# tag being deployed, the one before it, and `latest`; drop the rest of this
+# repo's tags. Anything still referenced by a running container is refused by
+# `docker rmi` anyway, so this cannot pull the floor out from under the app.
+#
+# Never fatal: a deploy that worked must not be reported as failed because a
+# cleanup did not.
+KEEP="${IMAGE_TAG}|latest"
+if [[ -n "$PREV_TAG" ]]; then
+  KEEP="${KEEP}|${PREV_TAG}"
+fi
+STALE=$(docker images --format '{{.Repository}}:{{.Tag}}' \
+  | grep -E "^${REGISTRY}/(app|tools):" \
+  | grep -vE ":(${KEEP})$" || true)
+if [[ -n "$STALE" ]]; then
+  echo "  keeping: ${IMAGE_TAG}, ${PREV_TAG:-none}, latest"
+  echo "$STALE" | sed 's/^/  removing /'
+  echo "$STALE" | xargs -r docker rmi >/dev/null 2>&1 || true
+else
+  echo "  nothing to remove"
+fi
+# Dangling layers left behind by `docker build`/failed pulls. Safe by definition:
+# untagged and unreferenced.
+docker image prune -f >/dev/null 2>&1 || true
+df -h / | awk 'NR==2 {printf "  boot disk: %s used of %s (%s)\n", $3, $2, $5}'
+
+DEPLOY_OK=true
 printf '\n\033[1;32m✓ deployed %s\033[0m\n' "$IMAGE_TAG"

--- a/deploy/deploy.test.sh
+++ b/deploy/deploy.test.sh
@@ -1,0 +1,186 @@
+#!/usr/bin/env bash
+#
+# Tests for deploy/deploy.sh's failure handling and image pruning.
+#
+#   bash deploy/deploy.test.sh
+#
+# WHY THIS EXISTS. deploy.sh rewrites compose.env in step 1, before anything
+# else runs. For a long time the rollback lived only inside the smoke-test
+# branch, so any EARLIER failure left compose.env naming a tag that might not be
+# on the box. That is not theoretical: a full boot disk killed the `pull` in
+# step 2, and production was left one `compose up` away from trying to start a
+# half-pulled image. These tests pin the three recovery paths so that cannot
+# regress:
+#
+#   1. fail BEFORE `up -d`  -> restore compose.env, do NOT touch containers
+#   2. fail AFTER  `up -d`  -> restore compose.env AND bring the old tag back up
+#   3. no previous tag      -> restore nothing, say so loudly, still fail
+#
+# Everything the script shells out to (docker, psql, curl) is stubbed on PATH.
+# Nothing here touches a real registry, database or VM.
+
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+DEPLOY_SH="${SCRIPT_DIR}/deploy.sh"
+
+PASS=0
+FAIL=0
+
+pass() { printf '  \033[1;32m✓\033[0m %s\n' "$1"; PASS=$((PASS + 1)); }
+fail() { printf '  \033[1;31m✗\033[0m %s\n     %s\n' "$1" "$2"; FAIL=$((FAIL + 1)); }
+
+check() { # check <label> <expected> <actual>
+  if [[ "$2" == "$3" ]]; then pass "$1"; else fail "$1" "expected [$2], got [$3]"; fi
+}
+check_contains() { # check_contains <label> <needle> <haystack>
+  if [[ "$3" == *"$2"* ]]; then pass "$1"; else fail "$1" "expected to contain [$2]"; fi
+}
+check_absent() {
+  if [[ "$3" != *"$2"* ]]; then pass "$1"; else fail "$1" "expected NOT to contain [$2]"; fi
+}
+
+# ---------------------------------------------------------------------------
+# Harness
+# ---------------------------------------------------------------------------
+
+# Builds a scratch APP_DIR plus stub docker/psql/curl, runs deploy.sh, and
+# leaves the results in RUN_OUT / RUN_RC / the stub call log.
+#
+#   FAIL_PULL=1   docker compose pull exits 1   (the disk-full case)
+#   FAIL_SMOKE=1  curl never returns 200        (bad image case)
+#   PREV=<tag>    starting tag in compose.env; empty for a first-ever deploy
+setup_and_run() {
+  local prev="$1" fail_pull="${2:-0}" fail_smoke="${3:-0}"
+
+  WORK="$(mktemp -d)"
+  BIN="${WORK}/bin"
+  mkdir -p "$BIN" "${WORK}/app/sql"
+  CALLS="${WORK}/calls.log"
+  : >"$CALLS"
+
+  local app_dir="${WORK}/app"
+  if [[ -n "$prev" ]]; then
+    cat >"${app_dir}/compose.env" <<EOF
+APP_IMAGE=asia-south1-docker.pkg.dev/buildinlime/buildinlime/app:${prev}
+TOOLS_IMAGE=asia-south1-docker.pkg.dev/buildinlime/buildinlime/tools:${prev}
+PUBLIC_DOMAIN=example.test
+EOF
+  else
+    # No tag at all — grep -oP finds nothing, PREV_TAG ends up empty.
+    cat >"${app_dir}/compose.env" <<EOF
+PUBLIC_DOMAIN=example.test
+EOF
+  fi
+  echo "DATABASE_URL=postgres://stub" >"${app_dir}/.env"
+  : >"${app_dir}/docker-compose.prod.yaml"
+  : >"${app_dir}/sql/02-electric-own-tables.sql"
+
+  # --- stubs -------------------------------------------------------------
+  cat >"${BIN}/docker" <<EOF
+#!/usr/bin/env bash
+echo "docker \$*" >>"${CALLS}"
+case "\$1" in
+  compose)
+    for a in "\$@"; do
+      if [[ "\$a" == pull ]]; then [[ "${fail_pull}" == 1 ]] && exit 1; fi
+    done
+    exit 0
+    ;;
+  images)
+    # Two live tags plus three superseded ones, across app and tools.
+    R=asia-south1-docker.pkg.dev/buildinlime/buildinlime
+    echo "\$R/app:newtag"
+    echo "\$R/app:${prev:-none}"
+    echo "\$R/app:latest"
+    echo "\$R/app:oldaaa"
+    echo "\$R/tools:oldaaa"
+    echo "\$R/app:oldbbb"
+    echo "postgres:16"
+    exit 0
+    ;;
+  *) exit 0 ;;
+esac
+EOF
+
+  cat >"${BIN}/psql" <<EOF
+#!/usr/bin/env bash
+echo "psql \$*" >>"${CALLS}"
+exit 0
+EOF
+
+  cat >"${BIN}/curl" <<EOF
+#!/usr/bin/env bash
+echo "curl \$*" >>"${CALLS}"
+if [[ "${fail_smoke}" == 1 ]]; then echo 000; exit 0; fi
+for a in "\$@"; do
+  case "\$a" in
+    *"/api/users")   echo 401; exit 0 ;;
+    *"/api/.env")    echo 404; exit 0 ;;
+  esac
+done
+echo 200
+EOF
+
+  # `sleep` is stubbed out so the 20x3s smoke retry loop does not make the
+  # failure tests take a minute each.
+  cat >"${BIN}/sleep" <<'EOF'
+#!/usr/bin/env bash
+exit 0
+EOF
+
+  chmod +x "${BIN}"/*
+
+  RUN_OUT="$(PATH="${BIN}:${PATH}" APP_DIR="${app_dir}" IMAGE_TAG=newtag \
+    bash "$DEPLOY_SH" 2>&1)"
+  RUN_RC=$?
+  COMPOSE_ENV="$(cat "${app_dir}/compose.env")"
+  CALL_LOG="$(cat "$CALLS")"
+  rm -rf "$WORK"
+}
+
+# ---------------------------------------------------------------------------
+
+echo
+echo "1. failure BEFORE up -d (the disk-full pull)"
+setup_and_run "oldtag" 1 0
+check "exits non-zero" "1" "$RUN_RC"
+check_contains "compose.env restored to the previous tag" "/app:oldtag" "$COMPOSE_ENV"
+check_absent "compose.env no longer names the new tag" "/app:newtag" "$COMPOSE_ENV"
+check_absent "containers were NOT recreated" "compose up -d" "${CALL_LOG//compose --env-file/compose}"
+check_contains "says the containers are untouched" "still serving oldtag" "$RUN_OUT"
+
+echo
+echo "2. failure AFTER up -d (smoke test fails)"
+setup_and_run "oldtag" 0 1
+check "exits non-zero" "1" "$RUN_RC"
+check_contains "compose.env restored to the previous tag" "/app:oldtag" "$COMPOSE_ENV"
+check_contains "rolls the containers back too" "bringing oldtag back up" "$RUN_OUT"
+check_contains "warns migrations are not reverted" "migrations are NOT reverted" "$RUN_OUT"
+
+echo
+echo "3. no previous tag recorded"
+setup_and_run "" 1 0
+check "exits non-zero" "1" "$RUN_RC"
+check_contains "says there is nothing to roll back to" "no previous tag recorded" "$RUN_OUT"
+check_contains "warns against compose up" "do not 'compose up'" "$RUN_OUT"
+
+echo
+echo "4. success prunes superseded images only"
+setup_and_run "oldtag" 0 0
+check "exits zero" "0" "$RUN_RC"
+check_contains "compose.env left on the new tag" "/app:newtag" "$COMPOSE_ENV"
+check_contains "reports success" "deployed newtag" "$RUN_OUT"
+check_contains "removes a superseded app image" "removing asia-south1-docker.pkg.dev/buildinlime/buildinlime/app:oldaaa" "$RUN_OUT"
+check_contains "removes a superseded tools image" "removing asia-south1-docker.pkg.dev/buildinlime/buildinlime/tools:oldaaa" "$RUN_OUT"
+# The three that must survive: the tag just deployed, the rollback target, and
+# latest. Losing PREV_TAG here would silently disarm the rollback in test 2.
+check_absent "keeps the tag just deployed" "removing asia-south1-docker.pkg.dev/buildinlime/buildinlime/app:newtag" "$RUN_OUT"
+check_absent "keeps the rollback target" "removing asia-south1-docker.pkg.dev/buildinlime/buildinlime/app:oldtag" "$RUN_OUT"
+check_absent "keeps latest" "removing asia-south1-docker.pkg.dev/buildinlime/buildinlime/app:latest" "$RUN_OUT"
+# Unrelated images (postgres, electric, caddy) are not ours to delete.
+check_absent "leaves third-party images alone" "removing postgres:16" "$RUN_OUT"
+
+echo
+printf '\n%s passed, %s failed\n\n' "$PASS" "$FAIL"
+[[ "$FAIL" -eq 0 ]]

--- a/web-app/code/agentGuides/deploymentPlan.md
+++ b/web-app/code/agentGuides/deploymentPlan.md
@@ -556,6 +556,26 @@ the OS, and so it can be snapshotted and resized independently.
 much storage you need is highly application dependent. We encourage you to test with
 your own workload."* 50 GB is a guess; measure it.
 
+**And alarm the BOOT disk too — that is the one that has actually filled.** Every merge
+to main pulls two new images (`app` + `tools`, tagged by SHA) onto the 30 GB boot disk,
+which is also the OS disk. Nothing evicted the old ones, so on 2026-07-22 a deploy died
+mid-`pull` with:
+
+```
+failed to extract layer … to overlayfs:
+write /var/lib/containerd/…/snapshots/192/fs/…: no space left on device
+```
+
+`deploy.sh` step 6/6 now prunes superseded tags after a successful deploy. It
+deliberately does **not** use `docker image prune -a`: that would take `PREV_TAG`'s
+images with it, and `PREV_TAG` is precisely what the script's rollback restores. It
+keeps the tag being deployed, the one before it, and `latest`.
+
+Note this failure mode is masked if the Electric disk is not mounted — `vm-bootstrap.sh`
+uses `nofail` by design, and `docker-compose.prod.yaml` warns that otherwise "shape logs
+land on the boot disk". When `/` fills, check `df -h / /var/lib/electric` before assuming
+it is images.
+
 #### 4.6.4 Firewall
 
 ```bash


### PR DESCRIPTION
Fixes the two problems behind the failed deploy of #60 (run `29899030483`). Both were latent since the pipeline was written; #60 was just the release that happened to be standing there.

## 1. The boot disk had no eviction

Every merge to main pulls **two** new images (`app` + `tools`, tagged by SHA) onto the **30 GB** boot disk, which is also the OS disk. Nothing ever removed the old ones. That's arithmetic, not bad luck — the next deploy would have hit it regardless of which one got there first:

```
failed to extract layer … to overlayfs:
write /var/lib/containerd/…/snapshots/192/fs/out/node_modules/open/index.js:
no space left on device
```

`deploy.sh` gains **step 6/6**, after the smoke test passes.

It deliberately does **not** use `docker image prune -a`. That would take `PREV_TAG`'s images with it — and `PREV_TAG` is exactly what the rollback restores, so a blind prune would silently disarm the recovery path this same PR is fixing. It keeps the tag being deployed, the one before it, and `latest`, and drops the rest of this repo's tags. Images still referenced by a running container are refused by `docker rmi` anyway, so it can't pull the floor out from under the app.

Never fatal: a deploy that worked must not be reported as failed because a cleanup didn't.

## 2. The rollback only covered the smoke test

This is the more dangerous half. Step 1 rewrites `compose.env` before anything else runs:

```sh
point_compose_at "$IMAGE_TAG"   # step 1 — done
"${COMPOSE[@]}" pull -q app     # step 2 — died here
```

…but the rollback lived inside the smoke-test branch, so it **never ran for an earlier failure**. The pull failure left `compose.env` naming a tag that was never fully pulled. The running containers were fine, but the box was one `compose up` or one reboot away from trying to start it.

Replaced with a single `EXIT` trap covering every path, distinguishing the two cases that genuinely need different handling:

| Failure point | Recovery |
|---|---|
| **before `up -d`** | restore `compose.env`, and **do not** call `up -d` — that would recreate containers this deploy never touched |
| **after `up -d`** | restore `compose.env` **and** bring the old tag back up (the previous behaviour) |
| **no `PREV_TAG`** | say so loudly rather than pretending we recovered |

## Tests

`deploy/deploy.test.sh` — 21 assertions, stubbing `docker`, `psql` and `curl` on `PATH`. No registry, database or VM is touched. Covers all four paths above, including that prune keeps the rollback target and leaves third-party images (`postgres:16`) alone.

Wired into the `quality` job. `deploy.sh` is the one script whose failure mode is a wedged production box, and CI never otherwise executes it — the deploy job runs it on the VM, where a bug has already cost a release.

**Mutation-checked rather than assumed:**
- removing `PREV_TAG` from the prune keep-list → fails exactly `keeps the rollback target`
- removing the `trap` → fails all eight recovery assertions

`APP_DIR` is now overridable solely so the tests can point at a scratch dir; CI leaves it unset and the default is what runs.

## Before merging

This fixes the *cause*, but the VM is still full — the prune only runs at the end of a **successful** deploy, and a deploy can't succeed until there's room. One-off to unblock:

```
gcloud compute ssh buildinlime-app --zone asia-south1-a --tunnel-through-iap \
  --command "df -h / /var/lib/electric; sudo docker system df"
```

If `/var/lib/electric` is **not** its own filesystem, the pd-ssd is unmounted and Electric has been filling `/` with shape logs — `vm-bootstrap.sh` mounts it `nofail` by design, so that fails silently. Pruning images would only buy days.

Otherwise:

```
gcloud compute ssh buildinlime-app --zone asia-south1-a --tunnel-through-iap \
  --command "sudo docker image prune -af --filter 'until=72h' && df -h /"
```

Also note `compose.env` on the VM currently names `bc1a8ad` with only a partial image behind it. Re-running the deploy fixes that; the new trap prevents it recurring.

## Not covered

A boot-disk usage alarm. §4.6.3 specifies one for the Electric disk only, and I've documented the gap there rather than guessing at your monitoring setup.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FSFjLZSuenUeHWNcaHMWnx