### PR TITLE
fix(mobile): recover collections stranded empty by the fresh-login hydration race

### DIFF
--- a/mobile-app/app/(tabs)/_layout.tsx
+++ b/mobile-app/app/(tabs)/_layout.tsx
@@ -8,6 +8,8 @@ import {
   initProjectCollections,
   membershipSetsChanged,
   resyncProjectCollections,
+  hasStrandedProjectCollections,
+  recoverStrandedProjectCollections,
 } from "@/src/application/collections/init"
 import { membershipsCollection } from "@/src/application/collections/organization"
 import { waitForLiveQueryRelease } from "@/src/application/collections/live-query-release"
@@ -32,6 +34,14 @@ export default function DrawerLayout() {
   // the Drawer so remounted live queries read the freshly-built collections.
   const [resyncing, setResyncing] = useState(false)
   const [dataVersion, setDataVersion] = useState(0)
+
+  // Fresh-login recovery (persistence hydration race). When a rebuild is requested
+  // because collections synced empty rather than because the scope changed,
+  // recoverRef routes the shared resync effect down the recovery rebuild instead of
+  // resyncProjectCollections. recoverAttempts caps retries so a genuinely-empty
+  // state can never loop. See hasStrandedProjectCollections.
+  const recoverRef = useRef(false)
+  const recoverAttempts = useRef(0)
 
   // Phase 1: Bootstrap collections (memberships + projects + users)
   //
@@ -128,6 +138,52 @@ export default function DrawerLayout() {
     }
   }, [projectReady, projectId])
 
+  // Backstop for the persistence hydration race: after project collections are
+  // ready, poll for an owner-escape ORG collection that Electric marked up-to-date
+  // (isReady) yet left empty despite the membership scope proving it must hold rows.
+  //
+  // isReady() only flips true AFTER Electric commits its snapshot batch (deferred
+  // behind persistence hydration), so in a healthy load `size` is already non-zero
+  // by the time isReady() is true — isReady() && empty is NOT a normal mid-load
+  // state. The remaining ways to be isReady() && empty are the stranded-hydration
+  // bug (permanent) and a shape error just before its retry delivers (transient).
+  // To ignore the transient we require the condition to hold on TWO consecutive
+  // polls (~600ms apart); the stranded state holds forever and trips it at once,
+  // while an error window clears when the retry lands. When confirmed, route the
+  // shared resync effect through the recovery rebuild. Re-runs after each rebuild
+  // (dataVersion) so a recovery that itself raced is caught, bounded by
+  // recoverAttempts. See recoverStrandedProjectCollections.
+  useEffect(() => {
+    if (!projectReady || !projectId || resyncing) return
+    if (recoverAttempts.current >= 2) return
+    let cancelled = false
+    let timer: ReturnType<typeof setTimeout> | null = null
+    let checks = 0
+    let consecutive = 0
+    const tick = () => {
+      if (cancelled) return
+      checks++
+      if (hasStrandedProjectCollections(projectId)) {
+        consecutive++
+        if (consecutive >= 2) {
+          if (__DEV__) console.log("[layout] Stranded-empty collections confirmed — recovering")
+          recoverRef.current = true
+          recoverAttempts.current += 1
+          setResyncing(true)
+          return
+        }
+      } else {
+        consecutive = 0
+      }
+      if (checks < 12) timer = setTimeout(tick, 600)
+    }
+    timer = setTimeout(tick, 600)
+    return () => {
+      cancelled = true
+      if (timer) clearTimeout(timer)
+    }
+  }, [projectReady, projectId, resyncing, dataVersion])
+
   // Run the resync only AFTER the content has unmounted (resyncing=true renders
   // the spinner), so cleanup() never runs against collections a mounted live
   // query still references. Rebind the offline executor to the freshly-built
@@ -145,7 +201,13 @@ export default function DrawerLayout() {
         // ("… cleaned up while live query depends on it"). Same guard sign-out uses.
         await waitForLiveQueryRelease()
         if (cancelled) return
-        const changed = await resyncProjectCollections(projectId)
+        // recoverRef routes this rebuild: a stranded-empty recovery (fresh-login
+        // hydration race) rebuilds the whole scope; otherwise a scope-change resync.
+        const recovering = recoverRef.current
+        recoverRef.current = false
+        const changed = recovering
+          ? await recoverStrandedProjectCollections(projectId)
+          : await resyncProjectCollections(projectId)
         if (cancelled) return
         if (changed) {
           resetAllOfflineActions()

--- a/mobile-app/src/application/collections/init.ts
+++ b/mobile-app/src/application/collections/init.ts
@@ -247,6 +247,27 @@ export async function initProjectCollections(projectId: string): Promise<void> {
 
   if (__DEV__) {
     console.log(`[collections] Project collections ready in ${Date.now() - t0}ms (project=${projectId})`)
+    // DIAGNOSTIC (dev-only): startSyncImmediate() above only KICKS OFF the shape
+    // long-polls — the rows arrive over the network afterward. Log the derived
+    // scope, then snapshot the row counts as they land so an empty build-units/
+    // channels view can be pinned to "server delivered nothing" vs "delivered but
+    // not rendered". Remove with the rest of the wipe/stale-offset diagnostics.
+    console.log(
+      `[rows] scope for project=${projectId}: memberships=${memberships.length} ` +
+        `memberBuildunitIds=[${memberBuildunitIds.join(",")}] memberChannelIds=[${memberChannelIds.join(",")}]`,
+    )
+    const probe = (label: string) =>
+      console.log(
+        `[rows] ${label}: build_units=${buildUnitsCollection?.size ?? `null`} ` +
+          `channels=${channelsCollection?.size ?? `null`} ` +
+          `channel_members=${channelMembersCollection?.size ?? `null`} ` +
+          `tasks=${tasksCollection?.size ?? `null`} messages=${messagesCollection?.size ?? `null`}`,
+      )
+    probe(`t+0ms`)
+    setTimeout(() => probe(`t+500ms`), 500)
+    setTimeout(() => probe(`t+2s`), 2000)
+    setTimeout(() => probe(`t+5s`), 5000)
+    setTimeout(() => probe(`t+10s`), 10000)
   }
 }
 
@@ -335,6 +356,129 @@ export async function resyncProjectCollections(projectId: string | null): Promis
 
   _appliedSets = sets
   return true
+}
+
+// ---------------------------------------------------------------------------
+// Fresh-login recovery — rebuild collections that synced empty because of the
+// persistence-layer hydration race.
+//
+// On a fresh login the server delivers the rows and Electric marks the shape
+// up-to-date, yet the in-memory collection can stay at size 0: a sync transaction
+// whose `begin` landed while the collection was still hydrating from SQLite, but
+// whose `commit` landed after the persistence wrapper's one-shot post-hydration
+// buffer flush, is stranded — never applied, never persisted, offset never
+// advanced (see @tanstack/db-sqlite-persistence-core persisted.js, and the
+// fresh-login no-data investigation). It is intermittent (~2/5) and hits a random
+// subset of the collections that all startSyncImmediate() at once in Phase 2.
+//
+// A relaunch fixes it because the offset was never persisted, so Electric refetches
+// from -1 and usually wins the race the second time. This backstop does the same
+// thing WITHOUT a relaunch: detect the stranded collections and rebuild them, which
+// starts a fresh sync from -1.
+// ---------------------------------------------------------------------------
+
+// A collection Electric has marked up-to-date (isReady) that nonetheless holds no
+// rows. On its own that is also the legitimate "you have nothing" state, so callers
+// pair it with a membership signal that says the collection MUST be non-empty.
+function isReadyEmpty(
+  c: { isReady: () => boolean; size: number } | null,
+): boolean {
+  return !!c && c.isReady() && c.size === 0
+}
+
+// True when an owner-escape ORG collection synced empty despite the membership
+// scope proving it must hold rows. These three are the only collections whose
+// emptiness is a RELIABLE stranded signal: being a member of a channel guarantees
+// that channel, its build unit, and its roster (you) come back — via the id set or
+// the server's owner_id escape. Channel-scoped comm collections (tasks/messages/…)
+// are deliberately NOT probed: a brand-new channel legitimately has zero of them,
+// so their emptiness is not diagnostic.
+//
+// LIMITATION: a pure owner with no memberships has empty member id sets, so a
+// stranding of their OWNED build-units/channels is not detectable here — the
+// upstream persistence fix is the complete cure. For every member (the reported
+// case) this fires correctly.
+export function hasStrandedProjectCollections(projectId: string | null): boolean {
+  if (!projectId || !_appliedSets) return false
+  const sets = deriveMembershipSets(projectId)
+  return (
+    (sets.memberBuildunitIds.length > 0 && isReadyEmpty(buildUnitsCollection)) ||
+    (sets.memberChannelIds.length > 0 && isReadyEmpty(channelsCollection)) ||
+    (sets.memberChannelIds.length > 0 && isReadyEmpty(channelMembersCollection))
+  )
+}
+
+// Rebuild ONLY the owner-escape ORG collections that are actually stranded
+// (isReady + empty). Each rebuild cleanup()s the stranded instance (releasing its
+// Electric shape + SQLite handle) before recreating it, and the fresh sync starts
+// from offset -1 — which is what the stranded collection never got.
+//
+// Two scoping choices, both learned on device (see the fresh-login investigation):
+//
+//   - Rebuild ONLY org collections, never the channel-scoped comm collections
+//     (tasks/messages/resources/…) or properties. Those are usually NOT stranded —
+//     they synced fine — and tearing down a collection whose deferred markReady is
+//     still in flight throws "Invalid collection status transition from cleaned-up
+//     to ready" (an uncaught rejection from the persistence wrapper) AND needlessly
+//     refetches good data. The org collections rebuilt here have ALREADY fired
+//     markReady — that is how hasStranded (via isReady) detected them — so cleaning
+//     them up is safe.
+//   - Guard each rebuild on its own isReadyEmpty, so a still-loading org collection
+//     is never cleaned up mid-startup.
+//
+// LIMITATION: a co-stranded comm collection is not repaired here — only the upstream
+// persistence fix covers every collection. In practice the reported symptom is the
+// empty build-units / channels / roster, which this restores.
+//
+// MUST run while the authenticated content is unmounted and AFTER
+// waitForLiveQueryRelease() — same constraint as resyncProjectCollections — so
+// cleanup() never tears a source out from under a mounted live query. Returns true
+// if anything was rebuilt.
+export async function recoverStrandedProjectCollections(
+  projectId: string | null,
+): Promise<boolean> {
+  if (!projectId || !_appliedSets) return false
+  const sets = deriveMembershipSets(projectId)
+
+  const strandedBuildUnits =
+    sets.memberBuildunitIds.length > 0 && isReadyEmpty(buildUnitsCollection)
+  const strandedChannels =
+    sets.memberChannelIds.length > 0 && isReadyEmpty(channelsCollection)
+  const strandedRoster =
+    sets.memberChannelIds.length > 0 && isReadyEmpty(channelMembersCollection)
+
+  if (__DEV__) {
+    console.log(
+      `[collections] Recovering stranded ORG collections (project=${projectId}): ` +
+        `build_units=${strandedBuildUnits} channels=${strandedChannels} channel_members=${strandedRoster}`,
+    )
+  }
+
+  // build_units + channels share one rebuild helper, so rebuild the pair only when
+  // NEITHER is still mid-startup (both isReady) — cleaning up a collection whose
+  // deferred markReady is still pending is exactly what throws the cleaned-up→ready
+  // error. A stranded collection is isReady by definition; this guards the PARTNER.
+  // If the partner is still loading, defer — the detection poll re-fires once it
+  // settles.
+  const buReady = !!buildUnitsCollection && buildUnitsCollection.isReady()
+  const chReady = !!channelsCollection && channelsCollection.isReady()
+  const rebuiltPair = (strandedBuildUnits || strandedChannels) && buReady && chReady
+  if (rebuiltPair) {
+    reinitializeScopedOrganizationCollections({
+      memberBuildunitIds: sets.memberBuildunitIds,
+      memberChannelIds: sets.memberChannelIds,
+    })
+    buildUnitsCollection.startSyncImmediate()
+    channelsCollection.startSyncImmediate()
+  }
+
+  if (strandedRoster) {
+    initializeChannelMembersCollection(sets.memberChannelIds)
+    channelMembersCollection.startSyncImmediate()
+  }
+
+  _appliedSets = sets
+  return rebuiltPair || strandedRoster
 }
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Problem

On a fresh mobile login an owner intermittently (~2 of 5 relogins) sees an **empty build-units / channels / roster** view that only an app relaunch clears. On-device logs settled the cause:

- the login syncs from `offset=-1` and the server **delivers** the rows (the `[body]` probe shows them on the wire), yet the collection `.size` stays `0` for a **random subset** of the collections that all `startSyncImmediate()` at once in Phase 2 (one login lost `channels` only; another lost `build_units + channels + channel_members` while `tasks`/`messages` applied fine). Random victim set ⇒ a **race**, not a scope/auth/schema fault.

## Root cause (upstream)

In `@tanstack/db-sqlite-persistence-core` (`persisted.js`): the wrapper latches `queuedBecauseHydrating` at a sync transaction's `begin` and drains the buffer **once**, at the end of `hydrateSubsetUnsafe`. A transaction whose `begin` lands mid-hydration but whose `commit` lands **after** that single drain is queued and never applied — never persisted, offset never advanced. A relaunch recovers only because the offset was never persisted, so Electric refetches from `-1` and usually wins the race the second time.

This is **still present in the latest published `0.2.8`** and is not among the defects enumerated in TanStack/db RFC #1659 (the maintainers' active hardening of this exact stack). An upstream issue will be filed separately. It is distinct from the empty-membership-set path (already handled) — here memberships load fine and the derived scope is correct.

## Fix (app-level backstop — the real cure is upstream)

After project collections are ready, poll for an **owner-escape ORG collection** (`build_units` / `channels` / `channel_members`) that `isReady()` yet holds `0` rows **while the membership scope proves it must hold rows** — a reliable stranded signal (membership in a channel guarantees that channel, its build unit, and its roster come back). When confirmed, rebuild **only the stranded org collections** through the existing resync machinery (unmount → `waitForLiveQueryRelease` → rebuild → rebind executor → re-key Drawer), which restarts sync from `-1`, exactly as a relaunch would.

Design points, all validated on device:

- **`isReady()`-gated** so a still-loading collection is never mistaken for stranded (verified in the library: `markReady` fires only after the snapshot `commit`, deferred behind hydration).
- **Two consecutive polls** required, so a transient `isReady && empty` window (e.g. a shape error just before its retry delivers) can't trip it; a permanent stranding trips it immediately.
- **Surgical**: rebuilds only the stranded org collections, never the channel-scoped comm collections — tearing down a comm collection whose deferred `markReady` is still in flight throws `CollectionStateError: "cleaned-up" → "ready"` and needlessly refetches good data (observed and fixed). The `build_units` + `channels` pair additionally requires both `isReady()` so a mid-startup partner is never cleaned up.
- **Bounded** at 2 recovery attempts so a genuinely-empty state can never loop.

Known limit: a pure owner with no memberships has empty member id sets, so a stranding of their *owned* rows isn't detectable here — only the upstream fix closes that. For members (the reported case) it's covered.

## Validation

Reproduced on device and confirmed recovery: `[layout] Stranded-empty collections confirmed — recovering` fires and `build_units`/`channels`/`channel_members` go `0 → 1`; user sees a brief spinner then data. Typecheck + lint clean.

## Note

Carries a dev-only `[rows]` probe in `initProjectCollections` (the log line that visibly confirms recovery); it is `__DEV__`-gated and flagged for removal when the fresh-login diagnostics are stripped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
