### PR TITLE
Mobile sync/UI fixes + task links & linkified messages (mobile + web)

### DIFF
--- a/mobile-app/app.json
+++ b/mobile-app/app.json
@@ -57,7 +57,8 @@
       "@react-native-community/datetimepicker",
       "expo-sqlite",
       "./plugins/withOkHttpDispatcher",
-      "expo-video"
+      "expo-video",
+      "expo-image"
     ],
     "experiments": {
       "typedRoutes": true

--- a/mobile-app/app/(tabs)/_layout.tsx
+++ b/mobile-app/app/(tabs)/_layout.tsx
@@ -139,8 +139,10 @@ export default function DrawerLayout() {
   }, [projectReady, projectId])
 
   // Backstop for the persistence hydration race: after project collections are
-  // ready, poll for an owner-escape ORG collection that Electric marked up-to-date
-  // (isReady) yet left empty despite the membership scope proving it must hold rows.
+  // ready, poll for a project collection (build-units / channels / roster, or
+  // properties) that Electric marked up-to-date (isReady) yet left empty despite the
+  // membership scope proving it should hold rows. Comm collections are repaired as
+  // recovery targets but never polled on — see hasStrandedProjectCollections.
   //
   // isReady() only flips true AFTER Electric commits its snapshot batch (deferred
   // behind persistence hydration), so in a healthy load `size` is already non-zero

--- a/mobile-app/app/_layout.tsx
+++ b/mobile-app/app/_layout.tsx
@@ -31,6 +31,7 @@ import { GestureHandlerRootView } from "react-native-gesture-handler"
 import "react-native-reanimated"
 
 import { useSession, signOutAndDispose, clearAuthCookies } from "@/src/infrastructure/auth/client"
+import { clearResourceFileCache } from "@/src/infrastructure/resources/resource-file-cache"
 import { ProjectProvider, useProjectContext } from "@/src/application/context/ProjectContext"
 import { waitForLiveQueryRelease } from "@/src/application/collections/live-query-release"
 import { colors } from "@/src/presentation/shared/colors"
@@ -114,6 +115,9 @@ function AuthGuard() {
   useEffect(() => {
     if (!isSigningOut) return
     let cancelled = false
+    // Wipe the on-disk resource cache so the next user doesn't inherit this one's
+    // media. Fire-and-forget — it has no ordering dependency on the sync teardown.
+    void clearResourceFileCache()
     void (async () => {
       await clearProject()
       if (cancelled) return

--- a/mobile-app/package.json
+++ b/mobile-app/package.json
@@ -41,6 +41,7 @@
     "expo-document-picker": "~55.0.13",
     "expo-file-system": "~55.0.16",
     "expo-font": "~55.0.6",
+    "expo-image": "~55.0.11",
     "expo-image-picker": "~55.0.18",
     "expo-linking": "~55.0.13",
     "expo-router": "~55.0.12",

--- a/mobile-app/src/application/actions/resources.ts
+++ b/mobile-app/src/application/actions/resources.ts
@@ -1,11 +1,30 @@
-import { makeResourceActions } from "@buildinlime/sync-core"
+import { makeResourceActions, type DeleteResourceInput } from "@buildinlime/sync-core"
 import { resourcesCollection } from "../collections/communication"
 import { getOfflineExecutor } from "../../infrastructure/offline/executor"
+import { evictResource } from "../../infrastructure/resources/resource-file-cache"
 
-const { deleteResourceAction, resetResourceActions } = makeResourceActions({
-  getExecutor: getOfflineExecutor,
-  getCollection: () => resourcesCollection,
-})
+const { deleteResourceAction: _deleteResourceAction, resetResourceActions } =
+  makeResourceActions({
+    getExecutor: getOfflineExecutor,
+    getCollection: () => resourcesCollection,
+  })
 
-export { deleteResourceAction, resetResourceActions }
-export type { DeleteResourceInput } from "@buildinlime/sync-core"
+// Deleting a resource is a soft delete: the server flips deleted_at and thereafter
+// 404s the file route so the bytes are unreachable "for everyone". Purge this
+// device's cached copy too, or the local file would keep the deleted bytes readable
+// until sign-out (they wouldn't render — the row leaves resourcesCollection — but
+// they would still sit on disk). Fire-and-forget: eviction has no bearing on the
+// mutation, and if the delete later rolls back the file simply re-downloads on view.
+//
+// This covers the delete initiated ON THIS device. A delete performed by ANOTHER
+// member arrives as a row-removal from Electric; it is intentionally NOT chased with
+// a persistent collection subscription, because that would keep the IDLE_GC
+// resources collection hydrated all session (GC only runs at zero subscribers) — so
+// remotely-deleted bytes are cleared at sign-out instead.
+export function deleteResourceAction(input: DeleteResourceInput) {
+  void evictResource(input.id)
+  return _deleteResourceAction(input)
+}
+
+export { resetResourceActions }
+export type { DeleteResourceInput }

--- a/mobile-app/src/application/collections/init.ts
+++ b/mobile-app/src/application/collections/init.ts
@@ -386,13 +386,31 @@ function isReadyEmpty(
   return !!c && c.isReady() && c.size === 0
 }
 
-// True when an owner-escape ORG collection synced empty despite the membership
-// scope proving it must hold rows. These three are the only collections whose
-// emptiness is a RELIABLE stranded signal: being a member of a channel guarantees
-// that channel, its build unit, and its roster (you) come back — via the id set or
-// the server's owner_id escape. Channel-scoped comm collections (tasks/messages/…)
-// are deliberately NOT probed: a brand-new channel legitimately has zero of them,
-// so their emptiness is not diagnostic.
+// True when a collection synced empty despite the membership scope proving it
+// should hold rows. Four TRIGGERS, in descending order of how reliable "empty ==
+// stranded" is:
+//
+//   build_units / channels / channel_members — RELIABLE. Being a member of a
+//     channel guarantees that channel, its build unit, and its roster (you) come
+//     back, via the id set or the server's owner_id escape. Empty-when-ready here
+//     is unambiguously the race.
+//
+//   properties — WEAKER, but the reported symptom (build units render, their
+//     property pills are missing). A build unit CAN legitimately carry zero
+//     properties (they are created by explicit user action, not auto-seeded), so
+//     an empty properties collection is not a proof of stranding the way an empty
+//     build_units collection is. It is included anyway because it is the failure
+//     users actually hit, and the cost of a false positive is bounded: recovery
+//     runs at most `recoverAttempts` times (see the layout poll), so a genuinely
+//     property-less project pays a couple of extra login-time refetches, never a
+//     loop. Gated on memberBuildunitIds so a brand-new project with nothing at all
+//     never trips it.
+//
+// Channel-scoped comm collections (tasks / messages / resources) are deliberately
+// NOT triggers: a brand-new channel legitimately has zero of any of them, so their
+// emptiness is far too commonly legitimate to poll on without flashing a spinner on
+// nearly every login. They are still REPAIRED — as conservative recovery targets,
+// only when the whole batch stranded together — see recoverStrandedProjectCollections.
 //
 // LIMITATION: a pure owner with no memberships has empty member id sets, so a
 // stranding of their OWNED build-units/channels is not detectable here — the
@@ -404,31 +422,41 @@ export function hasStrandedProjectCollections(projectId: string | null): boolean
   return (
     (sets.memberBuildunitIds.length > 0 && isReadyEmpty(buildUnitsCollection)) ||
     (sets.memberChannelIds.length > 0 && isReadyEmpty(channelsCollection)) ||
-    (sets.memberChannelIds.length > 0 && isReadyEmpty(channelMembersCollection))
+    (sets.memberChannelIds.length > 0 && isReadyEmpty(channelMembersCollection)) ||
+    (sets.memberBuildunitIds.length > 0 && isReadyEmpty(propertiesCollection))
   )
 }
 
-// Rebuild ONLY the owner-escape ORG collections that are actually stranded
-// (isReady + empty). Each rebuild cleanup()s the stranded instance (releasing its
-// Electric shape + SQLite handle) before recreating it, and the fresh sync starts
-// from offset -1 — which is what the stranded collection never got.
+// Rebuild the collections that are actually stranded (isReady + empty). Each
+// rebuild cleanup()s the stranded instance (releasing its Electric shape + SQLite
+// handle) before recreating it, and the fresh sync starts from offset -1 — which is
+// what the stranded collection never got.
 //
-// Two scoping choices, both learned on device (see the fresh-login investigation):
+// Safety rule for EVERY rebuild here: only cleanup() a collection that is already
+// isReady(). Tearing down a collection whose deferred markReady is still in flight
+// throws "Invalid collection status transition from cleaned-up to ready" (an
+// uncaught rejection from the persistence wrapper). A stranded collection is isReady
+// by definition (that is how it was detected), so its own teardown is safe; the care
+// below is all about NOT tearing down a still-loading PARTNER in a shared rebuild.
 //
-//   - Rebuild ONLY org collections, never the channel-scoped comm collections
-//     (tasks/messages/resources/…) or properties. Those are usually NOT stranded —
-//     they synced fine — and tearing down a collection whose deferred markReady is
-//     still in flight throws "Invalid collection status transition from cleaned-up
-//     to ready" (an uncaught rejection from the persistence wrapper) AND needlessly
-//     refetches good data. The org collections rebuilt here have ALREADY fired
-//     markReady — that is how hasStranded (via isReady) detected them — so cleaning
-//     them up is safe.
-//   - Guard each rebuild on its own isReadyEmpty, so a still-loading org collection
-//     is never cleaned up mid-startup.
+// What gets repaired, and why the scoping differs:
+//   - build_units + channels — reliable stranded signal; rebuild the pair when
+//     BOTH are isReady (guard the partner).
+//   - channel_members (roster) — reliable; own rebuild helper.
+//   - properties — the reported symptom. Own rebuild helper, so it is repaired in
+//     isolation without disturbing anything else. isReadyEmpty guarantees isReady,
+//     so its cleanup is safe.
+//   - comm batch (tasks/messages/resources + the inbox/my-tasks badge slices) —
+//     a CONSERVATIVE target, never a trigger. Repaired only when the WHOLE batch is
+//     isReady+empty: a partial mix (say messages loaded, resources empty) is far
+//     more likely a legitimately-empty channel than a race, and the batch shares one
+//     initializer, so rebuilding on a partial would needlessly refetch the members
+//     that DID load. All-empty-and-ready is the recognisable co-stranding shape.
 //
-// LIMITATION: a co-stranded comm collection is not repaired here — only the upstream
-// persistence fix covers every collection. In practice the reported symptom is the
-// empty build-units / channels / roster, which this restores.
+// LIMITATION: a comm collection stranded ALONE (build_units/channels/properties all
+// fine) is not repaired — its emptiness is indistinguishable from a new empty
+// channel, so polling on it would flash a spinner every login. The upstream
+// persistence fix is the only complete cure; a relaunch remains the fallback there.
 //
 // MUST run while the authenticated content is unmounted and AFTER
 // waitForLiveQueryRelease() — same constraint as resyncProjectCollections — so
@@ -446,11 +474,23 @@ export async function recoverStrandedProjectCollections(
     sets.memberChannelIds.length > 0 && isReadyEmpty(channelsCollection)
   const strandedRoster =
     sets.memberChannelIds.length > 0 && isReadyEmpty(channelMembersCollection)
+  const strandedProperties =
+    sets.memberBuildunitIds.length > 0 && isReadyEmpty(propertiesCollection)
+
+  // Comm batch is stranded only when ALL of tasks/messages/resources are isReady+
+  // empty — see the header for why a partial mix is left alone.
+  const strandedCommBatch =
+    sets.memberChannelIds.length > 0 &&
+    isReadyEmpty(tasksCollection) &&
+    isReadyEmpty(messagesCollection) &&
+    isReadyEmpty(resourcesCollection)
 
   if (__DEV__) {
     console.log(
-      `[collections] Recovering stranded ORG collections (project=${projectId}): ` +
-        `build_units=${strandedBuildUnits} channels=${strandedChannels} channel_members=${strandedRoster}`,
+      `[collections] Recovering stranded collections (project=${projectId}): ` +
+        `build_units=${strandedBuildUnits} channels=${strandedChannels} ` +
+        `channel_members=${strandedRoster} properties=${strandedProperties} ` +
+        `comm_batch=${strandedCommBatch}`,
     )
   }
 
@@ -477,8 +517,41 @@ export async function recoverStrandedProjectCollections(
     channelMembersCollection.startSyncImmediate()
   }
 
+  // Properties rebuild in isolation (own initializer) — the reported symptom.
+  let rebuiltProperties = false
+  if (strandedProperties) {
+    initializePropertiesCollection({
+      memberProjectIds: [projectId],
+      memberBuildunitIds: sets.memberBuildunitIds,
+      memberChannelIds: sets.memberChannelIds,
+    })
+    propertiesCollection.startSyncImmediate()
+    rebuiltProperties = true
+  }
+
+  // Comm batch: initializeCommunicationCollections tears down and rebuilds all five
+  // channel-scoped collections together, so guard on EVERY one being isReady — the
+  // badge slices (inbox/my-tasks) are rebuilt alongside the three probed above but
+  // are not part of strandedCommBatch, so confirm their readiness explicitly.
+  const commAllReady =
+    !!tasksCollection && tasksCollection.isReady() &&
+    !!messagesCollection && messagesCollection.isReady() &&
+    !!resourcesCollection && resourcesCollection.isReady() &&
+    !!inboxMentionsCollection && inboxMentionsCollection.isReady() &&
+    !!myTasksCollection && myTasksCollection.isReady()
+  let rebuiltComm = false
+  if (strandedCommBatch && commAllReady) {
+    initializeCommunicationCollections({ memberChannelIds: sets.memberChannelIds })
+    tasksCollection.startSyncImmediate()
+    messagesCollection.startSyncImmediate()
+    resourcesCollection.startSyncImmediate()
+    inboxMentionsCollection.startSyncImmediate()
+    myTasksCollection.startSyncImmediate()
+    rebuiltComm = true
+  }
+
   _appliedSets = sets
-  return rebuiltPair || strandedRoster
+  return rebuiltPair || strandedRoster || rebuiltProperties || rebuiltComm
 }
 
 // ---------------------------------------------------------------------------

--- a/mobile-app/src/infrastructure/resources/resource-file-cache.ts
+++ b/mobile-app/src/infrastructure/resources/resource-file-cache.ts
@@ -1,0 +1,193 @@
+import * as FileSystem from "expo-file-system/legacy"
+import * as VideoThumbnails from "expo-video-thumbnails"
+import { getAuthHeaders } from "@/src/infrastructure/auth/cookie-fetch"
+
+// Persistent on-device cache for resource file bytes and video posters.
+//
+// Resource files are IMMUTABLE — a resource id maps to fixed bytes (the server's
+// object PUT is idempotent, and a deleted resource drops out of sync so it is never
+// re-requested), so once a file is on disk it never has to be fetched again. The
+// media components used to render straight from the session-guarded remote route
+// with per-mount auth headers, which meant every reopen re-hit the network (RN's
+// core <Image> does not reliably keep header-bearing responses cached) and every
+// video poster was re-decoded from scratch. This module downloads each file ONCE,
+// keyed by its immutable resource id, so every component can render from a local
+// file:// uri thereafter — no network, no auth gate, no re-decode.
+//
+// Layer note: the stateful cache lives in infrastructure (not presentation) so the
+// application layer can evict a deleted resource without an upward import. The React
+// hooks over these functions live in presentation/resources/lib/resource-cache.
+//
+// Scope note: only fully-materialised media go through here — thumbnails, inline
+// images, posters, and small audio clips. Video PLAYBACK deliberately keeps
+// streaming from the remote route (progressive), so a large clip starts on the first
+// second rather than after a full download.
+
+const FILE_DIR = `${FileSystem.cacheDirectory}resource-files/`
+const POSTER_DIR = `${FileSystem.cacheDirectory}resource-posters/`
+
+// In-session memo: remoteUrl -> local uri, so a re-mount resolves synchronously
+// instead of paying even a getInfoAsync stat. Cleared with the on-disk cache.
+const resolvedFiles = new Map<string, string>()
+const resolvedPosters = new Map<string, string>()
+
+// De-dupe concurrent requests for the same file/poster — a list mounts N rows at
+// once, so the first caller kicks the work and the rest await the same promise.
+const inFlightFiles = new Map<string, Promise<string>>()
+const inFlightPosters = new Map<string, Promise<string>>()
+
+let dirsEnsured: Promise<void> | null = null
+function ensureDirs(): Promise<void> {
+  if (!dirsEnsured) {
+    dirsEnsured = (async () => {
+      await FileSystem.makeDirectoryAsync(FILE_DIR, { intermediates: true }).catch(() => {})
+      await FileSystem.makeDirectoryAsync(POSTER_DIR, { intermediates: true }).catch(() => {})
+    })()
+  }
+  return dirsEnsured
+}
+
+// Stable, filesystem-safe key from a resource URL. The URL is always
+// `${API_URL}/api/resources/<id>/file`, so the id is the natural key — which also
+// lets evictResource(id) find every cache entry for a deleted resource. A djb2 hash
+// is the fallback for anything that does not match that shape.
+function keyFor(remoteUrl: string): string {
+  const m = remoteUrl.match(/resources\/([^/]+)\/file/)
+  if (m) return m[1]
+  let h = 5381
+  for (let i = 0; i < remoteUrl.length; i++) h = ((h << 5) + h + remoteUrl.charCodeAt(i)) | 0
+  return (h >>> 0).toString(36)
+}
+
+const EXT_BY_MIME: Record<string, string> = {
+  "image/jpeg": "jpg", "image/png": "png", "image/heic": "heic", "image/webp": "webp",
+  "image/gif": "gif", "video/mp4": "mp4", "video/quicktime": "mov",
+  "audio/mpeg": "mp3", "audio/mp4": "m4a", "audio/m4a": "m4a", "application/pdf": "pdf",
+}
+function extFor(mimeType?: string): string {
+  if (mimeType && EXT_BY_MIME[mimeType]) return EXT_BY_MIME[mimeType]
+  const sub = mimeType?.split("/")[1]
+  return sub && /^[a-z0-9]+$/i.test(sub) ? sub : "bin"
+}
+
+/** Synchronous peek of the in-session memo — lets a hook resolve without a stat. */
+export function peekCachedFile(remoteUrl: string): string | null {
+  return resolvedFiles.get(remoteUrl) ?? null
+}
+export function peekCachedPoster(remoteUrl: string): string | null {
+  return resolvedPosters.get(remoteUrl) ?? null
+}
+
+/**
+ * Ensure the resource file is on disk and return its local file:// uri. Downloads
+ * once (deduped); returns the cached uri on every later call.
+ */
+export async function ensureCachedFile(remoteUrl: string, mimeType?: string): Promise<string> {
+  const memo = resolvedFiles.get(remoteUrl)
+  if (memo) return memo
+  const existing = inFlightFiles.get(remoteUrl)
+  if (existing) return existing
+
+  const work = (async () => {
+    await ensureDirs()
+    const dest = `${FILE_DIR}${keyFor(remoteUrl)}.${extFor(mimeType)}`
+    const info = await FileSystem.getInfoAsync(dest)
+    if (info.exists && info.size > 0) {
+      resolvedFiles.set(remoteUrl, dest)
+      return dest
+    }
+    // Download to a temp path first so an interrupted transfer can't leave a
+    // truncated file that a later mount would read as "already cached".
+    const tmp = `${dest}.tmp`
+    const headers = await getAuthHeaders()
+    const { status } = await FileSystem.downloadAsync(remoteUrl, tmp, { headers })
+    if (status !== 200) {
+      await FileSystem.deleteAsync(tmp, { idempotent: true }).catch(() => {})
+      throw new Error(`resource download failed: ${status}`)
+    }
+    await FileSystem.moveAsync({ from: tmp, to: dest })
+    resolvedFiles.set(remoteUrl, dest)
+    return dest
+  })().finally(() => inFlightFiles.delete(remoteUrl))
+
+  inFlightFiles.set(remoteUrl, work)
+  return work
+}
+
+/**
+ * Ensure a poster (first-frame thumbnail) for a video resource is on disk and
+ * return its local uri. Decoded ONCE, straight from the remote route — which streams
+ * only the bytes it needs for the frame rather than pulling the whole clip down — and
+ * the resulting jpg is cached, so every reopen is instant without re-decoding or ever
+ * downloading the full video (playback streams separately). Poster is keyed by the
+ * resource id alone, so it is shared by the sheet thumbnail and the inline bubble.
+ */
+export async function ensureCachedPoster(remoteUrl: string): Promise<string> {
+  const memo = resolvedPosters.get(remoteUrl)
+  if (memo) return memo
+  const existing = inFlightPosters.get(remoteUrl)
+  if (existing) return existing
+
+  const work = (async () => {
+    await ensureDirs()
+    const dest = `${POSTER_DIR}${keyFor(remoteUrl)}.jpg`
+    const info = await FileSystem.getInfoAsync(dest)
+    if (info.exists && info.size > 0) {
+      resolvedPosters.set(remoteUrl, dest)
+      return dest
+    }
+    const headers = await getAuthHeaders()
+    const { uri: thumb } = await VideoThumbnails.getThumbnailAsync(remoteUrl, { time: 1000, headers })
+    await FileSystem.copyAsync({ from: thumb, to: dest })
+    resolvedPosters.set(remoteUrl, dest)
+    return dest
+  })().finally(() => inFlightPosters.delete(remoteUrl))
+
+  inFlightPosters.set(remoteUrl, work)
+  return work
+}
+
+// Remove every cache entry (memo, in-flight, and on-disk file/poster) for one
+// resource id — the id is the on-disk filename prefix, so a delete needs no ext.
+async function deleteByPrefix(dir: string, prefix: string): Promise<void> {
+  try {
+    const entries = await FileSystem.readDirectoryAsync(dir)
+    await Promise.all(
+      entries
+        .filter((name) => name.startsWith(prefix))
+        .map((name) => FileSystem.deleteAsync(`${dir}${name}`, { idempotent: true }).catch(() => {})),
+    )
+  } catch {
+    // dir may not exist yet — nothing cached for this id, nothing to evict.
+  }
+}
+
+/**
+ * Purge the cached bytes + poster for a deleted resource, so the server's
+ * "soft-deleted files return 404" guarantee is honoured on-device too rather than
+ * leaving the local copy readable until sign-out. Called when a resource is deleted.
+ */
+export async function evictResource(resourceId: string): Promise<void> {
+  for (const url of [...resolvedFiles.keys()]) if (keyFor(url) === resourceId) resolvedFiles.delete(url)
+  for (const url of [...resolvedPosters.keys()]) if (keyFor(url) === resourceId) resolvedPosters.delete(url)
+  for (const url of [...inFlightFiles.keys()]) if (keyFor(url) === resourceId) inFlightFiles.delete(url)
+  for (const url of [...inFlightPosters.keys()]) if (keyFor(url) === resourceId) inFlightPosters.delete(url)
+  await Promise.all([
+    deleteByPrefix(FILE_DIR, `${resourceId}.`),
+    deleteByPrefix(POSTER_DIR, `${resourceId}.`),
+  ])
+}
+
+/**
+ * Wipe the on-disk resource cache. Called at sign-out (fire-and-forget) so the next
+ * user on the device never inherits the previous one's cached media.
+ */
+export async function clearResourceFileCache(): Promise<void> {
+  resolvedFiles.clear()
+  resolvedPosters.clear()
+  inFlightFiles.clear()
+  inFlightPosters.clear()
+  dirsEnsured = null
+  await FileSystem.deleteAsync(FILE_DIR, { idempotent: true }).catch(() => {})
+  await FileSystem.deleteAsync(POSTER_DIR, { idempotent: true }).catch(() => {})
+}

--- a/mobile-app/src/presentation/messages/components/MessageItem.tsx
+++ b/mobile-app/src/presentation/messages/components/MessageItem.tsx
@@ -1,7 +1,9 @@
 import { useState } from "react"
 import { View, Text, TouchableOpacity, StyleSheet, Alert } from "react-native"
-import { MessageCircle, ChevronDown, ChevronRight, Trash2 } from "lucide-react-native"
+import { useRouter } from "expo-router"
+import { MessageCircle, ChevronDown, ChevronRight, Trash2, ListTodo } from "lucide-react-native"
 import { MessageAttachments } from "@/src/presentation/resources/components/MessageAttachments"
+import { LinkifiedText } from "@/src/presentation/shared/components/LinkifiedText"
 import { deleteMessageAction } from "@/src/application/actions/messages"
 import { formatDateTime } from "@/src/presentation/shared/lib/datetime"
 import { colors } from "@/src/presentation/shared/colors"
@@ -41,6 +43,7 @@ export function MessageItem({
   highlightId,
 }: MessageItemProps) {
   const [showReplies, setShowReplies] = useState(true)
+  const router = useRouter()
 
   const replies = repliesByParent.get(message.id) ?? EMPTY_MESSAGES
   const senderName = usersMap[message.createdby_id] ?? "Unknown"
@@ -84,8 +87,27 @@ export function MessageItem({
             // There is nothing to hide here: the server already cleared the text.
             <Text style={styles.deletedText}>This message was deleted</Text>
           ) : message.text?.trim() ? (
-            <Text style={styles.text}>{message.text}</Text>
+            <LinkifiedText style={styles.text}>{message.text}</LinkifiedText>
           ) : null}
+
+          {/* Status-change notes carry the task they describe (Message.task_id) —
+              surface a jump straight to it. */}
+          {!isDeleted && message.task_id && (
+            <TouchableOpacity
+              style={styles.taskLink}
+              onPress={() =>
+                router.push(
+                  `/(tabs)/project/${message.project_id}/${message.buildunit_id}/${message.channel_id}/${message.task_id}` as never,
+                )
+              }
+              hitSlop={{ top: 6, bottom: 6, left: 6, right: 6 }}
+              activeOpacity={0.6}
+            >
+              <ListTodo size={12} color={colors.primary} strokeWidth={2} />
+              <Text style={styles.taskLinkText}>View task</Text>
+              <ChevronRight size={12} color={colors.primary} strokeWidth={2} />
+            </TouchableOpacity>
+          )}
 
           {!isDeleted && (
             <MessageAttachments
@@ -235,6 +257,22 @@ const styles = StyleSheet.create({
     fontFamily: "InstrumentSans_400Regular",
     color: colors.foreground,
     lineHeight: 19,
+  },
+  taskLink: {
+    flexDirection: "row",
+    alignItems: "center",
+    gap: 4,
+    alignSelf: "flex-start",
+    marginTop: 5,
+    paddingVertical: 4,
+    paddingHorizontal: 8,
+    backgroundColor: colors.iconChip,
+    borderRadius: 8,
+  },
+  taskLinkText: {
+    fontSize: 11,
+    fontFamily: "InstrumentSans_600SemiBold",
+    color: colors.primary,
   },
   actions: {
     flexDirection: "row",

--- a/mobile-app/src/presentation/resources/components/AudioPlayer.tsx
+++ b/mobile-app/src/presentation/resources/components/AudioPlayer.tsx
@@ -4,7 +4,7 @@ import { useAudioPlayer, useAudioPlayerStatus } from "expo-audio"
 import { Play, Pause } from "lucide-react-native"
 import { colors } from "@/src/presentation/shared/colors"
 import { formatDuration } from "@/src/presentation/resources/lib/attachment-format"
-import { useAuthHeaders } from "@/src/presentation/resources/lib/media-source"
+import { useCachedResourceFile } from "@/src/presentation/resources/lib/resource-cache"
 
 // A voice/audio clip rendered INSIDE a message bubble: play/pause, a scrubbable
 // progress bar, and elapsed/total time. `remoteUrl` is the session-guarded file
@@ -19,6 +19,7 @@ import { useAuthHeaders } from "@/src/presentation/resources/lib/media-source"
 interface AudioPlayerProps {
   remoteUrl?: string
   localUri?: string
+  mimeType?: string
   /** Flip the palette so the control stays legible on a dark own-bubble. */
   isOwn: boolean
 }
@@ -31,10 +32,10 @@ function palette(isOwn: boolean) {
   }
 }
 
-export function AudioPlayer({ remoteUrl, localUri, isOwn }: AudioPlayerProps) {
+export function AudioPlayer({ remoteUrl, localUri, mimeType, isOwn }: AudioPlayerProps) {
   const [activated, setActivated] = useState(false)
   if (activated) {
-    return <ActiveAudioPlayer remoteUrl={remoteUrl} localUri={localUri} isOwn={isOwn} />
+    return <ActiveAudioPlayer remoteUrl={remoteUrl} localUri={localUri} mimeType={mimeType} isOwn={isOwn} />
   }
   return <IdleAudioPlayer isOwn={isOwn} onActivate={() => setActivated(true)} />
 }
@@ -64,17 +65,15 @@ function IdleAudioPlayer({ isOwn, onActivate }: { isOwn: boolean; onActivate: ()
 
 // Playing state: holds the one live player for this clip. Auto-starts on mount
 // (the user tapped play to get here) and thereafter play/pause/seek in place.
-function ActiveAudioPlayer({ remoteUrl, localUri, isOwn }: AudioPlayerProps) {
-  const headers = useAuthHeaders()
-  const uri = localUri ?? remoteUrl ?? null
-  const needsAuth = !localUri && !!remoteUrl
-  // Hold the source until headers arrive so the remote request doesn't 401.
-  // Memoized so its identity is stable across renders — otherwise the play-once
-  // effect and the player would rebuild on every render.
-  const source = useMemo(
-    () => (uri && (!needsAuth || headers) ? { uri, headers: needsAuth ? headers! : undefined } : null),
-    [uri, needsAuth, headers]
-  )
+function ActiveAudioPlayer({ remoteUrl, localUri, mimeType, isOwn }: AudioPlayerProps) {
+  // Voice clips are small, so caching the whole file to disk on first play is cheap
+  // and makes every replay instant (no auth, no re-fetch). Local uploads play direct.
+  const cached = useCachedResourceFile(localUri ? undefined : remoteUrl, mimeType)
+  const uri = localUri ?? cached.uri
+  // Hold the source until the local file resolves. Memoized so its identity is
+  // stable across renders — otherwise the play-once effect and the player would
+  // rebuild on every render.
+  const source = useMemo(() => (uri ? { uri } : null), [uri])
 
   const player = useAudioPlayer(source)
   const status = useAudioPlayerStatus(player)

--- a/mobile-app/src/presentation/resources/components/ImageViewerModal.tsx
+++ b/mobile-app/src/presentation/resources/components/ImageViewerModal.tsx
@@ -1,28 +1,25 @@
-import { Modal, Image, TouchableOpacity, Text, StyleSheet } from "react-native"
+import { Modal, TouchableOpacity, Text, StyleSheet } from "react-native"
+import { Image } from "expo-image"
 import { useSafeAreaInsets } from "react-native-safe-area-context"
 
 // Full-screen viewer for a tapped inline image. A plain contained image on a
-// black backdrop — tap anywhere (or the ✕) to dismiss. Source carries the same
-// { uri, headers } the inline thumbnail used, so no second auth round-trip.
+// black backdrop — tap anywhere (or the ✕) to dismiss. `uri` is the local cached
+// file the inline thumbnail already resolved, so opening full-screen is instant and
+// needs no auth round-trip.
 
 interface ImageViewerModalProps {
   visible: boolean
   uri: string | null
-  headers?: Record<string, string>
   onClose: () => void
 }
 
-export function ImageViewerModal({ visible, uri, headers, onClose }: ImageViewerModalProps) {
+export function ImageViewerModal({ visible, uri, onClose }: ImageViewerModalProps) {
   const { top } = useSafeAreaInsets()
   return (
     <Modal visible={visible} transparent animationType="fade" onRequestClose={onClose}>
       <TouchableOpacity style={styles.backdrop} activeOpacity={1} onPress={onClose}>
         {uri ? (
-          <Image
-            source={headers ? { uri, headers } : { uri }}
-            style={styles.image}
-            resizeMode="contain"
-          />
+          <Image source={{ uri }} style={styles.image} contentFit="contain" cachePolicy="memory-disk" />
         ) : null}
         <TouchableOpacity
           style={[styles.close, { top: top + 8 }]}

--- a/mobile-app/src/presentation/resources/components/InlineImage.tsx
+++ b/mobile-app/src/presentation/resources/components/InlineImage.tsx
@@ -1,16 +1,19 @@
 import { useState } from "react"
-import { View, Image, TouchableOpacity, ActivityIndicator, StyleSheet } from "react-native"
+import { View, TouchableOpacity, ActivityIndicator, StyleSheet } from "react-native"
+import { Image, type ImageLoadEventData } from "expo-image"
 import { colors } from "@/src/presentation/shared/colors"
-import { useAuthHeaders } from "@/src/presentation/resources/lib/media-source"
+import { useCachedResourceFile } from "@/src/presentation/resources/lib/resource-cache"
 import { ImageViewerModal } from "./ImageViewerModal"
 
 // An image rendered INSIDE a message bubble (not a download chip). Tap to open
-// full-screen. `remoteUrl` is the session-guarded file route (needs auth
-// headers); `localUri` is a not-yet-uploaded file on the device (no auth).
+// full-screen. `remoteUrl` is the session-guarded file route — cached to a local
+// file on first view (see resource-cache), so reopening the thread is instant and
+// needs no auth headers; `localUri` is a not-yet-uploaded file already on the device.
 
 interface InlineImageProps {
   remoteUrl?: string
   localUri?: string
+  mimeType?: string
 }
 
 // Cap on the bubble media so a tall portrait shot doesn't take over the thread.
@@ -18,23 +21,21 @@ const MAX_W = 240
 const MAX_H = 280
 const DEFAULT_RATIO = 4 / 3
 
-export function InlineImage({ remoteUrl, localUri }: InlineImageProps) {
-  const headers = useAuthHeaders()
+export function InlineImage({ remoteUrl, localUri, mimeType }: InlineImageProps) {
   const [ratio, setRatio] = useState(DEFAULT_RATIO)
   const [failed, setFailed] = useState(false)
   const [viewerOpen, setViewerOpen] = useState(false)
 
-  const uri = localUri ?? remoteUrl ?? null
-  // Local files are already on disk; only the remote route needs the cookie.
-  const needsAuth = !localUri && !!remoteUrl
-  const source = uri ? (needsAuth && headers ? { uri, headers } : { uri }) : null
-  const waitingForAuth = needsAuth && !headers
+  // Local files are already on disk; the remote route is cached to one on first view.
+  const cached = useCachedResourceFile(localUri ? undefined : remoteUrl, mimeType)
+  const uri = localUri ?? cached.uri
+  const loadFailed = failed || cached.failed
 
   // Fit within the box while preserving aspect ratio.
   const width = Math.min(MAX_W, MAX_H * ratio)
   const height = width / ratio
 
-  if (!uri || failed) {
+  if (loadFailed || (!uri && !remoteUrl && !localUri)) {
     return (
       <View style={[styles.frame, styles.fallback, { width: MAX_W, height: 160 }]}>
         <ActivityIndicator size="small" color={colors.primary} />
@@ -46,13 +47,14 @@ export function InlineImage({ remoteUrl, localUri }: InlineImageProps) {
     <>
       <TouchableOpacity activeOpacity={0.85} onPress={() => setViewerOpen(true)}>
         <View style={[styles.frame, { width, height: Math.min(height, MAX_H) }]}>
-          {source && !waitingForAuth ? (
+          {uri ? (
             <Image
-              source={source}
+              source={{ uri }}
               style={styles.image}
-              resizeMode="cover"
-              onLoad={(e) => {
-                const { width: w, height: h } = e.nativeEvent.source
+              contentFit="cover"
+              cachePolicy="memory-disk"
+              onLoad={(e: ImageLoadEventData) => {
+                const { width: w, height: h } = e.source
                 if (w > 0 && h > 0) setRatio(w / h)
               }}
               onError={() => setFailed(true)}
@@ -63,12 +65,7 @@ export function InlineImage({ remoteUrl, localUri }: InlineImageProps) {
         </View>
       </TouchableOpacity>
 
-      <ImageViewerModal
-        visible={viewerOpen}
-        uri={uri}
-        headers={needsAuth ? (headers ?? undefined) : undefined}
-        onClose={() => setViewerOpen(false)}
-      />
+      <ImageViewerModal visible={viewerOpen} uri={uri} onClose={() => setViewerOpen(false)} />
     </>
   )
 }

--- a/mobile-app/src/presentation/resources/components/InlineVideo.tsx
+++ b/mobile-app/src/presentation/resources/components/InlineVideo.tsx
@@ -1,16 +1,19 @@
 import { useEffect, useState } from "react"
-import { View, Image, TouchableOpacity, ActivityIndicator, StyleSheet } from "react-native"
+import { View, TouchableOpacity, ActivityIndicator, StyleSheet } from "react-native"
+import { Image } from "expo-image"
 import * as VideoThumbnails from "expo-video-thumbnails"
 import { Play } from "lucide-react-native"
-import { useAuthHeaders } from "@/src/presentation/resources/lib/media-source"
+import { useCachedVideoPoster } from "@/src/presentation/resources/lib/resource-cache"
 import { VideoPlayerModal } from "./VideoPlayerModal"
 
 // A video INSIDE a message bubble, rendered as a still POSTER (its first frame)
 // with a play button. Tapping opens VideoPlayerModal, which is the only place a
 // live expo-video player is mounted — the list itself never holds one, so it
 // can't churn expo-video's shared objects or exhaust the device's decoders.
-// Extracting the poster is a one-shot native call (expo-video-thumbnails), not a
-// live player, so N of them in a list is safe.
+//
+// The poster for a synced video is decoded ONCE from the cached file and reused on
+// every reopen (see resource-cache); a still-uploading video (localUri) decodes its
+// own frame directly, since it has no resource id to cache under yet.
 
 interface InlineVideoProps {
   remoteUrl?: string
@@ -21,41 +24,35 @@ const WIDTH = 240
 const HEIGHT = (WIDTH * 9) / 16
 
 export function InlineVideo({ remoteUrl, localUri }: InlineVideoProps) {
-  const headers = useAuthHeaders()
-  const [poster, setPoster] = useState<string | null>(null)
   const [open, setOpen] = useState(false)
 
-  const uri = localUri ?? remoteUrl ?? null
-  const needsAuth = !localUri && !!remoteUrl
-
+  // Synced video: cached poster, keyed by resource id. Pending upload: decode the
+  // local frame directly (transient, no id to cache under).
+  const remotePoster = useCachedVideoPoster(localUri ? undefined : remoteUrl)
+  const [localPoster, setLocalPoster] = useState<string | null>(null)
   useEffect(() => {
-    if (!uri) return
-    // Remote frames need the session cookie; wait for it. Local files don't.
-    if (needsAuth && !headers) return
+    if (!localUri) return
     let cancelled = false
-    void (async () => {
-      try {
-        const { uri: thumb } = await VideoThumbnails.getThumbnailAsync(uri, {
-          time: 1000,
-          ...(needsAuth && headers ? { headers } : {}),
-        })
-        if (!cancelled) setPoster(thumb)
-      } catch {
-        // Extraction failed (codec/network) — the play button on a dark frame is
-        // still a perfectly usable affordance, so just leave the poster empty.
-      }
-    })()
+    void VideoThumbnails.getThumbnailAsync(localUri, { time: 1000 })
+      .then(({ uri }) => {
+        if (!cancelled) setLocalPoster(uri)
+      })
+      .catch(() => {
+        // Extraction failed — the play button on a dark frame is still usable.
+      })
     return () => {
       cancelled = true
     }
-  }, [uri, needsAuth, headers])
+  }, [localUri])
+
+  const poster = localUri ? localPoster : remotePoster.uri
 
   return (
     <>
       <TouchableOpacity activeOpacity={0.85} onPress={() => setOpen(true)}>
         <View style={styles.frame}>
           {poster ? (
-            <Image source={{ uri: poster }} style={styles.poster} resizeMode="cover" />
+            <Image source={{ uri: poster }} style={styles.poster} contentFit="cover" cachePolicy="memory-disk" />
           ) : (
             <ActivityIndicator size="small" color="#fff" />
           )}

--- a/mobile-app/src/presentation/resources/components/MessageAttachments.tsx
+++ b/mobile-app/src/presentation/resources/components/MessageAttachments.tsx
@@ -45,16 +45,19 @@ function InlineMedia({
   kind,
   remoteUrl,
   localUri,
+  mimeType,
   isOwn,
 }: {
   kind: "image" | "video" | "audio"
   remoteUrl?: string
   localUri?: string
+  mimeType?: string
   isOwn: boolean
 }) {
-  if (kind === "image") return <InlineImage remoteUrl={remoteUrl} localUri={localUri} />
+  if (kind === "image") return <InlineImage remoteUrl={remoteUrl} localUri={localUri} mimeType={mimeType} />
+  // Video posters are keyed by resource id alone, so the video path needs no mime.
   if (kind === "video") return <InlineVideo remoteUrl={remoteUrl} localUri={localUri} />
-  return <AudioPlayer remoteUrl={remoteUrl} localUri={localUri} isOwn={isOwn} />
+  return <AudioPlayer remoteUrl={remoteUrl} localUri={localUri} mimeType={mimeType} isOwn={isOwn} />
 }
 
 // ── Non-media: the existing download / status chips ─────────────────────────
@@ -111,7 +114,7 @@ function PendingMedia({ upload, isOwn }: { upload: PendingUpload; isOwn: boolean
   const kind = mediaKind(upload.mimeType)!
   return (
     <View style={styles.pendingMedia}>
-      <InlineMedia kind={kind} localUri={upload.uri} isOwn={isOwn} />
+      <InlineMedia kind={kind} localUri={upload.uri} mimeType={upload.mimeType} isOwn={isOwn} />
       {upload.status !== "synced" && (
         <Text
           style={[
@@ -148,7 +151,7 @@ export function MessageAttachments({ resources, pendingUploads, isOwn }: Message
       {resources.map((r) => {
         const kind = mediaKind(r.mime_type)
         return kind ? (
-          <InlineMedia key={r.id} kind={kind} remoteUrl={resourceUrl(r.file_location)} isOwn={isOwn} />
+          <InlineMedia key={r.id} kind={kind} remoteUrl={resourceUrl(r.file_location)} mimeType={r.mime_type} isOwn={isOwn} />
         ) : (
           <SyncedAttachment key={r.id} resource={r} isOwn={isOwn} />
         )

--- a/mobile-app/src/presentation/resources/components/RenameFileModal.tsx
+++ b/mobile-app/src/presentation/resources/components/RenameFileModal.tsx
@@ -1,4 +1,4 @@
-import { useState } from "react"
+import { useRef, useState } from "react"
 import {
   View,
   Text,
@@ -29,16 +29,24 @@ export function RenameFileModal({
 }: RenameFileModalProps) {
   const [baseName, extension] = splitExtension(fileName)
   const [draft, setDraft] = useState(baseName)
+  const inputRef = useRef<TextInput>(null)
 
   const trimmed = draft.trim()
   const valid = trimmed.length > 0
 
   return (
-    <CenteredModal visible={visible} onRequestClose={onCancel}>
+    <CenteredModal
+      visible={visible}
+      onRequestClose={onCancel}
+      // Focus AFTER the modal is presented — see CenteredModal.onShow. The small
+      // delay lets the fade animation settle so the soft keyboard reliably rises.
+      onShow={() => setTimeout(() => inputRef.current?.focus(), 50)}
+    >
       <Text style={styles.title}>Rename file</Text>
 
       <View style={styles.nameRow}>
         <TextInput
+          ref={inputRef}
           style={styles.nameInput}
           value={draft}
           onChangeText={setDraft}
@@ -46,7 +54,6 @@ export function RenameFileModal({
           placeholderTextColor={colors.mutedForeground}
           autoCapitalize="none"
           autoCorrect={false}
-          autoFocus
           selectTextOnFocus
           returnKeyType="done"
           onSubmitEditing={() => valid && onSave(`${trimmed}${extension}`)}

--- a/mobile-app/src/presentation/resources/components/ResourceThumbnail.tsx
+++ b/mobile-app/src/presentation/resources/components/ResourceThumbnail.tsx
@@ -1,41 +1,28 @@
-import { useEffect, useState } from "react"
-import { View, Image, ActivityIndicator, StyleSheet } from "react-native"
-import * as VideoThumbnails from "expo-video-thumbnails"
+import { View, ActivityIndicator, StyleSheet } from "react-native"
+import { Image } from "expo-image"
 import { File, FileText, Music, Play } from "lucide-react-native"
 import { colors } from "@/src/presentation/shared/colors"
-import { API_URL, useAuthHeaders } from "@/src/presentation/resources/lib/media-source"
+import { API_URL } from "@/src/presentation/resources/lib/media-source"
+import {
+  useCachedResourceFile,
+  useCachedVideoPoster,
+} from "@/src/presentation/resources/lib/resource-cache"
 
-/** First frame of the video, pulled from the actual uploaded file. */
+// Every thumbnail renders from a LOCAL file:// uri (see resource-cache): the file
+// is downloaded once, keyed by its immutable resource id, so reopening the sheet is
+// instant instead of re-fetching over the network. expo-image adds a memory cache
+// on top, which keeps scrolling smooth.
+
+/** First frame of the video — decoded once, then cached (keyed by resource id). */
 function VideoThumb({ url, size }: { url: string; size: number }) {
-  const headers = useAuthHeaders()
-  const [uri, setUri] = useState<string | null>(null)
-  const [failed, setFailed] = useState(false)
-
-  useEffect(() => {
-    if (!headers) return
-    let cancelled = false
-    void (async () => {
-      try {
-        const { uri: thumb } = await VideoThumbnails.getThumbnailAsync(url, {
-          time: 1000,
-          headers,
-        })
-        if (!cancelled) setUri(thumb)
-      } catch {
-        if (!cancelled) setFailed(true)
-      }
-    })()
-    return () => {
-      cancelled = true
-    }
-  }, [url, headers])
+  const { uri, failed } = useCachedVideoPoster(url)
 
   if (failed) return <IconThumb mimeType="video/" size={size} />
 
   return (
     <View style={[styles.thumb, { width: size, height: size }]}>
       {uri ? (
-        <Image source={{ uri }} style={styles.image} resizeMode="cover" />
+        <Image source={{ uri }} style={styles.image} contentFit="cover" cachePolicy="memory-disk" />
       ) : (
         <ActivityIndicator size="small" color={colors.primary} />
       )}
@@ -49,21 +36,15 @@ function VideoThumb({ url, size }: { url: string; size: number }) {
   )
 }
 
-function ImageThumb({ url, size }: { url: string; size: number }) {
-  const headers = useAuthHeaders()
-  const [failed, setFailed] = useState(false)
+function ImageThumb({ url, mimeType, size }: { url: string; mimeType: string; size: number }) {
+  const { uri, failed } = useCachedResourceFile(url, mimeType)
 
   if (failed) return <IconThumb mimeType="image/" size={size} />
 
   return (
     <View style={[styles.thumb, { width: size, height: size }]}>
-      {headers ? (
-        <Image
-          source={{ uri: url, headers }}
-          style={styles.image}
-          resizeMode="cover"
-          onError={() => setFailed(true)}
-        />
+      {uri ? (
+        <Image source={{ uri }} style={styles.image} contentFit="cover" cachePolicy="memory-disk" />
       ) : (
         <ActivityIndicator size="small" color={colors.primary} />
       )}
@@ -103,11 +84,11 @@ export function ResourceThumbnail({
   mimeType,
   size = 40,
 }: ResourceThumbnailProps) {
-  // A pending upload still lives on the device — no auth, no network needed.
+  // A pending upload still lives on the device — no auth, no network, no cache.
   if (localUri && mimeType.startsWith("image/")) {
     return (
       <View style={[styles.thumb, { width: size, height: size }]}>
-        <Image source={{ uri: localUri }} style={styles.image} resizeMode="cover" />
+        <Image source={{ uri: localUri }} style={styles.image} contentFit="cover" />
       </View>
     )
   }
@@ -115,7 +96,7 @@ export function ResourceThumbnail({
   if (!fileLocation) return <IconThumb mimeType={mimeType} size={size} />
 
   const url = `${API_URL}${fileLocation}`
-  if (mimeType.startsWith("image/")) return <ImageThumb url={url} size={size} />
+  if (mimeType.startsWith("image/")) return <ImageThumb url={url} mimeType={mimeType} size={size} />
   if (mimeType.startsWith("video/")) return <VideoThumb url={url} size={size} />
   return <IconThumb mimeType={mimeType} size={size} />
 }

--- a/mobile-app/src/presentation/resources/components/UploadScheduleModal.tsx
+++ b/mobile-app/src/presentation/resources/components/UploadScheduleModal.tsx
@@ -1,4 +1,4 @@
-import { useState } from "react"
+import { useRef, useState } from "react"
 import {
   View,
   Text,
@@ -48,6 +48,7 @@ export function UploadScheduleModal({
 
   const [baseName, extension] = splitExtension(fileName)
   const [draftName, setDraftName] = useState(baseName)
+  const nameInputRef = useRef<TextInput>(null)
 
   const trimmed = draftName.trim()
   const nameValid = trimmed.length > 0
@@ -86,6 +87,8 @@ export function UploadScheduleModal({
         reset()
         onCancel()
       }}
+      // Focus AFTER present so the soft keyboard rises — see CenteredModal.onShow.
+      onShow={() => setTimeout(() => nameInputRef.current?.focus(), 50)}
     >
       <Text style={styles.title}>Upload file</Text>
 
@@ -93,6 +96,7 @@ export function UploadScheduleModal({
       <Text style={styles.fieldLabel}>File name</Text>
       <View style={styles.nameRow}>
         <TextInput
+          ref={nameInputRef}
           style={styles.nameInput}
           value={draftName}
           onChangeText={setDraftName}

--- a/mobile-app/src/presentation/resources/lib/resource-cache.ts
+++ b/mobile-app/src/presentation/resources/lib/resource-cache.ts
@@ -1,0 +1,95 @@
+import { useEffect, useState } from "react"
+import {
+  ensureCachedFile,
+  ensureCachedPoster,
+  peekCachedFile,
+  peekCachedPoster,
+} from "@/src/infrastructure/resources/resource-file-cache"
+
+// React hooks over the resource file cache (the stateful cache itself lives in
+// infrastructure/resources/resource-file-cache so the application layer can evict a
+// deleted resource without importing presentation). Each hook returns a local
+// file:// uri once the resource is on disk, resolving synchronously from the memo on
+// a re-mount so reopening a thread or sheet is instant.
+
+export interface CachedState {
+  /** Local file:// uri once resolved; null while loading or on failure. */
+  uri: string | null
+  loading: boolean
+  failed: boolean
+}
+
+/** Local file:// uri for a resource file, downloading + caching on first use. */
+export function useCachedResourceFile(
+  remoteUrl: string | null | undefined,
+  mimeType?: string,
+): CachedState {
+  const [uri, setUri] = useState<string | null>(() =>
+    remoteUrl ? peekCachedFile(remoteUrl) : null,
+  )
+  const [failed, setFailed] = useState(false)
+
+  useEffect(() => {
+    if (!remoteUrl) {
+      setUri(null)
+      return
+    }
+    const cached = peekCachedFile(remoteUrl)
+    if (cached) {
+      setUri(cached)
+      setFailed(false)
+      return
+    }
+    let cancelled = false
+    setUri(null)
+    setFailed(false)
+    void ensureCachedFile(remoteUrl, mimeType)
+      .then((local) => {
+        if (!cancelled) setUri(local)
+      })
+      .catch(() => {
+        if (!cancelled) setFailed(true)
+      })
+    return () => {
+      cancelled = true
+    }
+  }, [remoteUrl, mimeType])
+
+  return { uri, loading: !!remoteUrl && !uri && !failed, failed }
+}
+
+/** Local file:// uri for a video's poster frame, generated + cached on first use. */
+export function useCachedVideoPoster(remoteUrl: string | null | undefined): CachedState {
+  const [uri, setUri] = useState<string | null>(() =>
+    remoteUrl ? peekCachedPoster(remoteUrl) : null,
+  )
+  const [failed, setFailed] = useState(false)
+
+  useEffect(() => {
+    if (!remoteUrl) {
+      setUri(null)
+      return
+    }
+    const cached = peekCachedPoster(remoteUrl)
+    if (cached) {
+      setUri(cached)
+      setFailed(false)
+      return
+    }
+    let cancelled = false
+    setUri(null)
+    setFailed(false)
+    void ensureCachedPoster(remoteUrl)
+      .then((local) => {
+        if (!cancelled) setUri(local)
+      })
+      .catch(() => {
+        if (!cancelled) setFailed(true)
+      })
+    return () => {
+      cancelled = true
+    }
+  }, [remoteUrl])
+
+  return { uri, loading: !!remoteUrl && !uri && !failed, failed }
+}

--- a/mobile-app/src/presentation/shared/components/CenteredModal.tsx
+++ b/mobile-app/src/presentation/shared/components/CenteredModal.tsx
@@ -7,6 +7,10 @@ interface CenteredModalProps {
   /** Hardware back / system dismiss. The backdrop is not tap-to-dismiss —
       neither of the dialogs this was lifted from dismissed on an outside tap. */
   onRequestClose: () => void
+  /** Fires once the modal is fully presented. The reliable place to focus a
+      TextInput: `autoFocus` runs before the modal window attaches on Android, so
+      it grabs focus programmatically but never raises the soft keyboard. */
+  onShow?: () => void
   children: ReactNode
 }
 
@@ -20,9 +24,15 @@ interface CenteredModalProps {
  * children. The bottom sheets (TasksSheet, ResourcesSheet) are a different
  * shape — slide up, tap-to-dismiss — and are not this.
  */
-export function CenteredModal({ visible, onRequestClose, children }: CenteredModalProps) {
+export function CenteredModal({ visible, onRequestClose, onShow, children }: CenteredModalProps) {
   return (
-    <Modal visible={visible} transparent animationType="fade" onRequestClose={onRequestClose}>
+    <Modal
+      visible={visible}
+      transparent
+      animationType="fade"
+      onRequestClose={onRequestClose}
+      onShow={onShow}
+    >
       <View style={styles.backdrop}>
         <View style={styles.sheet}>{children}</View>
       </View>

--- a/mobile-app/src/presentation/shared/components/LinkifiedText.tsx
+++ b/mobile-app/src/presentation/shared/components/LinkifiedText.tsx
@@ -1,0 +1,48 @@
+import { Text, Linking, type StyleProp, type TextStyle } from "react-native"
+import { colors } from "@/src/presentation/shared/colors"
+
+// Renders a string with any URLs turned into tappable spans — so a pasted map
+// link (Google/Apple Maps, or a bare `geo:` link) opens the maps app, and any
+// other link opens the browser. Message text was previously a plain <Text>, so
+// links were dead. Nested <Text> keeps everything on one flowing paragraph.
+
+// One capturing group, so String.split keeps the URLs as their own array slots.
+// Matches http(s), a bare `www.` host, and `geo:` (lat,long) links.
+const URL_SPLIT = /((?:https?:\/\/|geo:|www\.)[^\s]+)/gi
+const URL_HEAD = /^(?:https?:\/\/|geo:|www\.)/i
+
+function openUrl(raw: string): void {
+  // Trailing sentence punctuation is almost never part of the URL — "…maps.app/x)."
+  const cleaned = raw.replace(/[.,;:!?)\]]+$/, "")
+  const url = /^www\./i.test(cleaned) ? `https://${cleaned}` : cleaned
+  void Linking.openURL(url).catch(() => {})
+}
+
+interface LinkifiedTextProps {
+  children: string
+  style?: StyleProp<TextStyle>
+  /** Overrides the default link appearance (primary + underline). */
+  linkStyle?: StyleProp<TextStyle>
+}
+
+export function LinkifiedText({ children, style, linkStyle }: LinkifiedTextProps) {
+  const parts = children.split(URL_SPLIT)
+  return (
+    <Text style={style}>
+      {parts.map((part, i) =>
+        part && URL_HEAD.test(part) ? (
+          <Text
+            key={i}
+            style={[{ color: colors.primary, textDecorationLine: "underline" }, linkStyle]}
+            onPress={() => openUrl(part)}
+            suppressHighlighting
+          >
+            {part}
+          </Text>
+        ) : (
+          part
+        ),
+      )}
+    </Text>
+  )
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -89,6 +89,9 @@ importers:
       expo-font:
         specifier: ~55.0.6
         version: 55.0.6(expo@55.0.15)(react-native@0.83.4(@babel/core@7.29.0)(@types/react@19.2.14)(react@19.1.0))(react@19.1.0)
+      expo-image:
+        specifier: ~55.0.11
+        version: 55.0.11(expo@55.0.15)(react-native-web@0.21.2(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(react-native@0.83.4(@babel/core@7.29.0)(@types/react@19.2.14)(react@19.1.0))(react@19.1.0)
       expo-image-picker:
         specifier: ~55.0.18
         version: 55.0.18(expo@55.0.15)
@@ -5212,8 +5215,8 @@ packages:
     peerDependencies:
       expo: '*'
 
-  expo-image@55.0.8:
-    resolution: {integrity: sha512-fNdvdYVcGn3g1x6o5AXHKzk4xX8U6rg2W9vFdE1pQO80kWCNReh003ypqSrGy4dD+zA8FtZjrNF3oMDGnPpIGQ==}
+  expo-image@55.0.11:
+    resolution: {integrity: sha512-PVIBYQJW/h1f6Zb9xnoWlgfqyOPVm2yb6eo6ZogaKbvMrhb/Q/fiERbagi4oqmR6IPljWPEpkXXQyFBUh7TjpQ==}
     peerDependencies:
       expo: '*'
       react: 19.1.0
@@ -13233,6 +13236,11 @@ snapshots:
       shebang-command: 2.0.0
       which: 2.0.2
 
+  crossws@0.4.4(srvx@0.11.12):
+    optionalDependencies:
+      srvx: 0.11.12
+    optional: true
+
   crossws@0.4.4(srvx@0.9.8):
     optionalDependencies:
       srvx: 0.9.8
@@ -14086,7 +14094,7 @@ snapshots:
       expo: 55.0.15(@babel/core@7.29.0)(@expo/dom-webview@55.0.5)(@expo/metro-runtime@55.0.9)(expo-router@55.0.12)(react-dom@19.1.0(react@19.1.0))(react-native-worklets@0.7.2(@babel/core@7.29.0)(react-native@0.83.4(@babel/core@7.29.0)(@types/react@19.2.14)(react@19.1.0))(react@19.1.0))(react-native@0.83.4(@babel/core@7.29.0)(@types/react@19.2.14)(react@19.1.0))(react@19.1.0)(typescript@5.9.3)
       expo-image-loader: 55.0.0(expo@55.0.15)
 
-  expo-image@55.0.8(expo@55.0.15)(react-native-web@0.21.2(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(react-native@0.83.4(@babel/core@7.29.0)(@types/react@19.2.14)(react@19.1.0))(react@19.1.0):
+  expo-image@55.0.11(expo@55.0.15)(react-native-web@0.21.2(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(react-native@0.83.4(@babel/core@7.29.0)(@types/react@19.2.14)(react@19.1.0))(react@19.1.0):
     dependencies:
       expo: 55.0.15(@babel/core@7.29.0)(@expo/dom-webview@55.0.5)(@expo/metro-runtime@55.0.9)(expo-router@55.0.12)(react-dom@19.1.0(react@19.1.0))(react-native-worklets@0.7.2(@babel/core@7.29.0)(react-native@0.83.4(@babel/core@7.29.0)(@types/react@19.2.14)(react@19.1.0))(react@19.1.0))(react-native@0.83.4(@babel/core@7.29.0)(@types/react@19.2.14)(react@19.1.0))(react@19.1.0)(typescript@5.9.3)
       react: 19.1.0
@@ -14145,7 +14153,7 @@ snapshots:
       expo: 55.0.15(@babel/core@7.29.0)(@expo/dom-webview@55.0.5)(@expo/metro-runtime@55.0.9)(expo-router@55.0.12)(react-dom@19.1.0(react@19.1.0))(react-native-worklets@0.7.2(@babel/core@7.29.0)(react-native@0.83.4(@babel/core@7.29.0)(@types/react@19.2.14)(react@19.1.0))(react@19.1.0))(react-native@0.83.4(@babel/core@7.29.0)(@types/react@19.2.14)(react@19.1.0))(react@19.1.0)(typescript@5.9.3)
       expo-constants: 55.0.14(expo@55.0.15)(react-native@0.83.4(@babel/core@7.29.0)(@types/react@19.2.14)(react@19.1.0))(typescript@5.9.3)
       expo-glass-effect: 55.0.10(expo@55.0.15)(react-native@0.83.4(@babel/core@7.29.0)(@types/react@19.2.14)(react@19.1.0))(react@19.1.0)
-      expo-image: 55.0.8(expo@55.0.15)(react-native-web@0.21.2(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(react-native@0.83.4(@babel/core@7.29.0)(@types/react@19.2.14)(react@19.1.0))(react@19.1.0)
+      expo-image: 55.0.11(expo@55.0.15)(react-native-web@0.21.2(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(react-native@0.83.4(@babel/core@7.29.0)(@types/react@19.2.14)(react@19.1.0))(react@19.1.0)
       expo-linking: 55.0.13(expo@55.0.15)(react-native@0.83.4(@babel/core@7.29.0)(@types/react@19.2.14)(react@19.1.0))(react@19.1.0)(typescript@5.9.3)
       expo-server: 55.0.7
       expo-symbols: 55.0.7(expo-font@55.0.6)(expo@55.0.15)(react-native@0.83.4(@babel/core@7.29.0)(@types/react@19.2.14)(react@19.1.0))(react@19.1.0)
@@ -14654,7 +14662,7 @@ snapshots:
       rou3: 0.8.1
       srvx: 0.11.12
     optionalDependencies:
-      crossws: 0.4.4(srvx@0.9.8)
+      crossws: 0.4.4(srvx@0.11.12)
 
   h3@2.0.1-rc.5(crossws@0.4.4(srvx@0.11.12)):
     dependencies:

--- a/web-app/code/src/presentation/components/buildInlime/communication/CommentsSection.tsx
+++ b/web-app/code/src/presentation/components/buildInlime/communication/CommentsSection.tsx
@@ -41,9 +41,14 @@ export function CommentsSection({
   const users = (allUsers ?? []).filter((u) => memberIds.includes(u.id))
 
   // task_id -> name, so a status-change note can link to its task. The task route
-  // is name-based, and the note only carries the id.
+  // is name-based, and the note only carries the id. The `| undefined` cast is
+  // load-bearing: useLiveQuery types data as a plain array, but it is undefined on
+  // the first render before the query resolves — so the `?? []` is necessary, not
+  // lint noise. Mirrors ResourceDisplay's pattern in this folder.
   const { data: allTasks } = useLiveQuery((q) => q.from({ tasksCollection }), [])
-  const taskNameById = new Map((allTasks ?? []).map((t) => [t.id, t.name]))
+  const taskNameById = new Map(
+    ((allTasks as { id: string; name: string }[] | undefined) ?? []).map((t) => [t.id, t.name]),
+  )
 
   const { messagePending, addPending, scheduleUpload, retryUpload } = usePendingResources(channelId)
 

--- a/web-app/code/src/presentation/components/buildInlime/communication/CommentsSection.tsx
+++ b/web-app/code/src/presentation/components/buildInlime/communication/CommentsSection.tsx
@@ -3,6 +3,7 @@ import { useLiveQuery } from "@tanstack/react-db"
 import {
   messagesCollection,
   usersCollection,
+  tasksCollection,
 } from "%/infrastructure/database/tanstack-db-electric/admincollections"
 import { createMessageAction } from "%/application/actions/messages"
 import { usePendingResources } from "%/application/hooks/use-pending-resources"
@@ -17,6 +18,9 @@ export interface CommentsSectionProps {
   projectId: string
   currentUserId: string
   memberIds: string[]
+  /** Route names for this channel, so a status-note can link to its task. */
+  buildUnitName: string
+  channelName: string
   /** ?messageId= from the Inbox — scroll to and briefly highlight this message. */
   focusMessageId?: string
 }
@@ -27,12 +31,19 @@ export function CommentsSection({
   projectId,
   currentUserId,
   memberIds,
+  buildUnitName,
+  channelName,
   focusMessageId,
 }: CommentsSectionProps) {
   const { data: allMessages } = useLiveQuery((q) => q.from({ messagesCollection }), [channelId])
 
   const { data: allUsers } = useLiveQuery((q) => q.from({ usersCollection }), [])
   const users = (allUsers ?? []).filter((u) => memberIds.includes(u.id))
+
+  // task_id -> name, so a status-change note can link to its task. The task route
+  // is name-based, and the note only carries the id.
+  const { data: allTasks } = useLiveQuery((q) => q.from({ tasksCollection }), [])
+  const taskNameById = new Map((allTasks ?? []).map((t) => [t.id, t.name]))
 
   const { messagePending, addPending, scheduleUpload, retryUpload } = usePendingResources(channelId)
 
@@ -125,6 +136,9 @@ export function CommentsSection({
               onRetryUpload={retryUpload}
               focusMessageId={focusMessageId}
               currentUserId={currentUserId}
+              buildUnitName={buildUnitName}
+              channelName={channelName}
+              taskNameById={taskNameById}
             />
           ))}
         </div>

--- a/web-app/code/src/presentation/components/buildInlime/communication/LinkifiedText.tsx
+++ b/web-app/code/src/presentation/components/buildInlime/communication/LinkifiedText.tsx
@@ -1,0 +1,45 @@
+// Renders a string with any URLs turned into anchor tags — so a pasted map link
+// (Google/Apple Maps, or a bare `geo:` link) or any other URL in a message is
+// clickable. Message text was previously a plain <p>, so links were dead.
+// Mirrors the mobile LinkifiedText.
+
+// One capturing group, so String.split keeps the URLs as their own array slots.
+// Matches http(s), a bare `www.` host, and `geo:` (lat,long) links.
+const URL_SPLIT = /((?:https?:\/\/|geo:|www\.)[^\s]+)/gi
+const URL_HEAD = /^(?:https?:\/\/|geo:|www\.)/i
+
+function hrefFor(raw: string): string {
+  // Trailing sentence punctuation is almost never part of the URL.
+  const cleaned = raw.replace(/[.,;:!?)\]]+$/, "")
+  return /^www\./i.test(cleaned) ? `https://${cleaned}` : cleaned
+}
+
+interface LinkifiedTextProps {
+  text: string
+  className?: string
+}
+
+export function LinkifiedText({ text, className }: LinkifiedTextProps) {
+  const parts = text.split(URL_SPLIT)
+  return (
+    <p className={className}>
+      {parts.map((part, i) =>
+        part && URL_HEAD.test(part) ? (
+          <a
+            key={i}
+            href={hrefFor(part)}
+            target="_blank"
+            rel="noopener noreferrer"
+            // Don't let a link tap bubble to any row-level handler (e.g. focus/scroll).
+            onClick={(e) => e.stopPropagation()}
+            className="text-primary underline break-all"
+          >
+            {part}
+          </a>
+        ) : (
+          part
+        ),
+      )}
+    </p>
+  )
+}

--- a/web-app/code/src/presentation/components/buildInlime/communication/MessageItem.tsx
+++ b/web-app/code/src/presentation/components/buildInlime/communication/MessageItem.tsx
@@ -1,6 +1,8 @@
 import { useState } from "react"
-import { MessageCircle, ChevronDown, ChevronRight, Send, X, Trash2 } from "lucide-react"
+import { Link } from "@tanstack/react-router"
+import { MessageCircle, ChevronDown, ChevronRight, Send, X, Trash2, ListTodo } from "lucide-react"
 import { deleteMessageAction } from "%/application/actions/messages"
+import { LinkifiedText } from "./LinkifiedText"
 import type { PendingResource } from "%/application/hooks/use-pending-resources"
 import { useMentions  } from "./use-mentions"
 import type {MentionUser} from "./use-mentions";
@@ -37,6 +39,11 @@ export interface MessageItemProps {
   depth?: number
   focusMessageId?: string
   currentUserId: string
+  /** Current channel's route names, so a status-note can link to its task. */
+  buildUnitName: string
+  channelName: string
+  /** task_id -> task name, for the "View task" link on status-change notes. */
+  taskNameById: Map<string, string>
 }
 
 export function MessageItem({
@@ -49,10 +56,16 @@ export function MessageItem({
   depth = 0,
   focusMessageId,
   currentUserId,
+  buildUnitName,
+  channelName,
+  taskNameById,
 }: MessageItemProps) {
   const isFocused = focusMessageId === message.id
   const isDeleted = !!message.deleted_at
   const isOwn = message.createdby_id === currentUserId
+  // Status-change notes carry the task they describe (Message.task_id); resolve
+  // its name so we can link to the name-based task route.
+  const taskName = message.task_id ? taskNameById.get(message.task_id) : undefined
 
   const confirmDelete = () => {
     if (
@@ -122,9 +135,28 @@ export function MessageItem({
                Nothing to hide: the server already cleared the text. */
             <p className="text-xs italic text-muted-foreground">This message was deleted</p>
           ) : (
-            <p className="text-xs text-foreground whitespace-pre-wrap break-words">
-              {message.text}
-            </p>
+            <LinkifiedText
+              className="text-xs text-foreground whitespace-pre-wrap break-words"
+              text={message.text}
+            />
+          )}
+
+          {/* Status-change note → jump straight to the task it describes. */}
+          {!isDeleted && taskName && (
+            <Link
+              to="/projects/$projectId/$buildUnitName/$channelName/$taskName"
+              params={{
+                projectId: message.project_id,
+                buildUnitName,
+                channelName,
+                taskName,
+              }}
+              className="mt-1 inline-flex items-center gap-1 rounded bg-card-border/40 px-1.5 py-0.5 text-xs font-medium text-primary hover:bg-card-border/70 transition-colors"
+            >
+              <ListTodo className="w-3 h-3" />
+              View task
+              <ChevronRight className="w-3 h-3" />
+            </Link>
           )}
 
           {/* Pending uploads for this message */}
@@ -229,6 +261,9 @@ export function MessageItem({
             depth={depth + 1}
             focusMessageId={focusMessageId}
             currentUserId={currentUserId}
+            buildUnitName={buildUnitName}
+            channelName={channelName}
+            taskNameById={taskNameById}
           />
         ))}
     </div>

--- a/web-app/code/src/presentation/pages/ChannelPage.tsx
+++ b/web-app/code/src/presentation/pages/ChannelPage.tsx
@@ -182,6 +182,8 @@ export function ChannelPage({
                 projectId={projectId}
                 currentUserId={currentUserId}
                 memberIds={channelMembers.map(u => u.id)}
+                buildUnitName={buildUnitName}
+                channelName={channelName}
                 focusMessageId={focusMessageId}
               />
             </div>


### PR DESCRIPTION
Mobile sync/UI fixes plus two features shared across mobile and web.

## Mobile

**Hydration-race recovery (`4216ef1`)** — extends the fresh-login stranded-collection
backstop to **properties** (a build unit whose property pills came back empty) and the
comm batch, on top of the existing build-units/channels/roster recovery. Properties are
a trigger; comm collections are conservative repair targets (whole-batch-empty only), so
a legitimately-empty channel never flashes a recovery spinner.

**Resource file cache (`d11a8ee`)** — resource files are immutable, so they're downloaded
once (keyed by resource id) and rendered from a local `file://` uri via **expo-image**;
video posters are decoded once and cached. Fixes the "every reopen re-hits the network"
slowness. Includes `evictResource` on delete (honours the server's soft-delete 404
on-device) and a sign-out cache wipe. Video *playback* still streams (no full-download
gate on large clips).

**Channel-page UI (`4d750d8`)**
- **Rename keyboard fix** — a `<Modal>` TextInput focused via `autoFocus` never raised the
  soft keyboard on Android; now focused from `onShow`.
- **"View task" link** on status-change notes (messages carrying `task_id`).
- **Linkified messages** — URLs incl. Google/Apple Maps + `geo:` links are tappable.

## Web (`c0ea519`)

The same **task link** and **linkified messages**, ported to the comments section. The web
task route is name-based, so `CommentsSection` resolves `task_id → name` and `ChannelPage`
threads the channel's route names through.

## Verification
- Mobile: typecheck clean, 38 tests pass; the preview build was verified end-to-end on a
  device (prod API, sync, dispatcher latency), and these changes were tested on device.
- Web: typecheck clean; tested in browser.
- Dependency versions deliberately held (Electric + TanStack DB coupling) — no version
  alignment in this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EByTFmVj3m2iovCTz4c7kv
