### PR TITLE
feat(web): privacy/support/contact pages + account-deletion request flow

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -53,6 +53,9 @@ Thumbs.db
 # TypeScript
 *.tsbuildinfo
 
+# Generated documents (rendered from app content, not source)
+*.pdf
+
 # Database
 *.db
 *.db-shm

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -280,6 +280,10 @@ The tradeoff is documented candidly in `infrastructure/auth/server.ts` and is ac
 
 **Mobile has no cookie jar.** React Native's `fetch` neither persists cookies nor sends an `Origin` header (which Better Auth's CSRF protection requires). `infrastructure/auth/cookie-fetch.ts` supplies both: it stores session cookies in `expo-secure-store` and wraps `fetch` to attach `Cookie` + `Origin` on every request and to persist `Set-Cookie` from every response. `getAuthHeaders()` is exported as the single header-builder so the native file-transfer paths (`FileSystem.downloadAsync` / `uploadAsync`, which do their own networking and cannot use the wrapped fetch) cannot drift out of sync with it.
 
+**Account & data deletion is an email-request flow, not an automated purge.** The Account page (`presentation/pages/AccountPage.tsx`, at `/account`) links, below the user's name/email, to `/delete-account` (`presentation/pages/DeleteAccountPage.tsx`), a page that shows the signed-in email, offers two deletion modes — account-only, or account plus removal of the user's data from the Mozilla Data Collective — and a free-text reason. This satisfies the Play Store / privacy-policy requirement for a discoverable account-deletion path. Submitting calls `account.requestDeletion` (an **authed** tRPC procedure — the email/id come from the server session, never client input) which emails the request to **support@buildinlime.com** via Resend for **manual** action; the client also downloads a small JSON snapshot of the account (id/name/email). What is still missing is the automated backend: **no server-side purge** (no Better Auth `deleteUser`, no cascade over the user's rows), **no real data export** (the download is an account stub, not the user's messages/tasks/files), and **no Mozilla Data Collective integration**. The published privacy policy commits to deleting within 30 days of a request; honouring that is a manual operation until the purge script exists. Wiring those up is future work (§12.11).
+
+**Public transactional endpoints.** Two unauthenticated procedures back the marketing pages: `contact.send` (the `/contact` form → email to Barefoot Programmers) and, authed, `account.requestDeletion` above. Both are **web-only and deliberately not mirrored in `@buildinlime/contracts`** — mobile never calls them, and the parity test (§12.4) asserts only contract ⊆ server. Both send through Resend via lazily-constructed clients (`sendContactEmail.ts` / `sendDeletionRequestEmail.ts`), so importing the `appRouter` — as the parity test does without a mail key — has no construction side effect.
+
 ---
 
 ## 10. Web ↔ mobile: shared, parallel, divergent
@@ -416,6 +420,19 @@ These are the things to fix before this stops being a POC. Every one of them is 
 
     **Mobile only, deliberately.** Web has nothing equivalent to reclaim: it uploads straight through `FormData` with no queue, its resource previews are in-memory `URL.createObjectURL` blobs released on unload, and the service worker does not runtime-cache `/api/*`. Web's only device-side store is the OPFS replica, and clearing that forces a full re-sync and breaks offline use — a different feature with a real cost, not a cleanup. A "free up space" button on web would always reclaim zero bytes, so there deliberately isn't one.
 
+11. **Account deletion is a manual email flow; the automated backend is not built (§9).** The `/delete-account` page now files a real request — `account.requestDeletion` emails support@buildinlime.com for a human to action — and downloads a three-field JSON stub (id/name/email). But nothing is deleted *automatically*: the actual purge is a manual operation, and the "download" is not a real export. The published privacy policy promises deletion within 30 days of a request, so until the two pieces below exist, meeting that window depends on someone reading the mailbox and running the deletion by hand. Two backend pieces are future work.
+
+    **A real data-export script.** The download must return the user's *actual* data, not an account stub — their messages, tasks, resources, properties, seen-state, memberships, teams, and uploaded files — assembled server-side from Postgres (and the file store for resource bytes) into a downloadable archive, gated to the requesting session. This is the read side of the same authorization surface the shapes enforce (§4): the export must be scoped to what the user is entitled to, so it should reuse `resolveMemberScope()` rather than inventing a second access rule.
+
+    **A real deletion script.** A tRPC procedure (or a server-side job it enqueues) that actually removes the account and its data. This is where the system's own invariants make it hard, and none of it is decided yet:
+
+    - **Soft-delete semantics are non-uniform (§4).** Tasks and resources filter `deleted_at IS NULL` out of shapes and vanish; messages are redacted-in-place so replies are not orphaned. A deletion routine has to honour both, and decide whether a departing user's messages are hard-deleted (orphaning others' replies) or tombstoned like a normal message delete.
+    - **Membership is the authorization primitive (§1).** Deleting a user who is the `owner_id` of a project/build-unit/channel — the owner-escape hatch other members' access hangs off — can strand or expose data. Ownership transfer or cascade rules must be defined before anything is deleted.
+    - **Resource bytes need the purge path (§12.9), not a parallel one.** Files must be released through the existing `deleted_at` → `scripts/purge-resources.ts` mechanism so the retention/orphan-grace logic still applies; the deletion routine should stamp, not `unlink`.
+    - **The Mozilla Data Collective removal** (the second radio option) has no integration at all — no client, no endpoint, no defined contract. It is a named intent only.
+
+    Until this exists, the page must not imply completed deletion beyond what it does; the confirmation copy is deliberately phrased as a received *request*.
+
 ---
 
 ## Appendix — where things live
@@ -431,6 +448,9 @@ These are the things to fix before this stops being a POC. Every one of them is 
 | tRPC routers (write authorization) | `web-app/code/src/infrastructure/trpc/routers/` |
 | Electric proxy | `web-app/code/src/infrastructure/database/electric-proxy.ts` |
 | Auth config | `web-app/code/src/infrastructure/auth/server.ts` |
+| Account-deletion request page (email flow, §12.11) | `web-app/code/src/presentation/pages/DeleteAccountPage.tsx`, `routes/_authenticated/delete-account.tsx` |
+| Deletion-request / contact procedures + email senders | `web-app/code/src/infrastructure/trpc/routers/{account,contact}.ts`, `infrastructure/lib/utils/send{DeletionRequest,Contact}Email.ts` |
+| Marketing pages (privacy / support / contact) | `web-app/code/src/presentation/pages/{Privacy,Support,Contact}Page.tsx`, `content/privacy.ts` |
 | File storage | `web-app/code/src/infrastructure/storage/fileStorage.ts` |
 | Bootstrap / resync | `web-app/code/src/presentation/routes/_authenticated.tsx` |
 | Collection definitions (web / mobile, still per-app) | `*/src/application/collections/*.ts` |

--- a/mobile-app/PRIVACY_POLICY_INPUTS.md
+++ b/mobile-app/PRIVACY_POLICY_INPUTS.md
@@ -1,0 +1,39 @@
+# Privacy Policy — intake / inputs
+
+Fill in the **"Your input / edit"** column and the **Open questions** at the bottom, then
+hand this back and I'll generate `PRIVACY_POLICY.md` from it. Rows marked 🔲 need your
+answer; rows marked ✅ are pre-filled from the app source — just confirm or correct them.
+
+| # | Section | Proposed content (from the code / data-safety doc) | Your input / edit |
+|---|---|---|---|
+| 1 | **Who (data controller)** | App name: **BuildInLime**. | 🔲 Legal/entity name + country to name as controller |
+| 2 | **Contact** | For privacy & deletion requests. | 🔲 Contact email (e.g. privacy@buildinlime.com) |
+| 3 | **What you collect** | Email address; photos & videos; documents/files; voice recordings; text messages. On-device: session cookie (secure-store) + local SQLite cache. | ✅ confirm, or add/remove |
+| 4 | **Name / profile** | A name/profile exists on the server account (better-auth). | 🔲 Which profile fields exist? Is name required at signup? |
+| 5 | **Why (purposes)** | Provide the app (project collaboration: channels, tasks, messages, attachments) and account management/auth. **Not** for advertising; **not** sold. | ✅ confirm "no ads / no selling" |
+| 6 | **Who it's shared with (processors)** | Your own server/infra; the OTP **email-delivery provider**; the **file/object storage** provider. No sharing for advertising. | 🔲 Name the providers: hosting =? , email sender =? , object storage =? (e.g. Google Cloud Storage) |
+| 7 | **Retention** | How long data is kept. | 🔲 e.g. "kept until the user deletes their account; backups purged after N days" |
+| 8 | **Security** | Encrypted in transit (TLS to app.buildinlime.com); access limited to members of a channel; session token in the device secure store. | 🔲 Encrypted at rest? (confirm yes/no) |
+| 9 | **User rights & deletion** | How a user accesses, corrects, or deletes their data. | 🔲 Deletion method: in-app "delete account", or email request to whom? Any access/export path? |
+| 10 | **Children** | Age policy. | 🔲 Minimum age? Is it "not directed to children under 13/16"? |
+| 11 | **Where data is processed** | Server/storage location (matters for GDPR transfers). | 🔲 Hosting region/country |
+| 12 | **Permissions rationale** | Microphone → record voice messages (user-initiated); Camera/Photos → attach images/videos to messages & tasks. | ✅ confirm |
+| 13 | **Governing law / audience** | Which region's users, to pick GDPR / CCPA / general wording. | 🔲 Primary user region (e.g. India / EU / US / global) |
+| 14 | **Effective date** | Date shown on the policy. | 🔲 Date (or "on publish") |
+
+## Open questions (the free-text ones — write as much as you like)
+
+1. **Account deletion** — exactly how can a user delete their account and data today?
+   (In-app button? Email to X? Not yet supported → we should state an email request path.)
+
+2. **Data retention** — how long is content (messages, files) and account data kept after
+   deletion or inactivity? Any backup retention window?
+
+3. **Sub-processors** — the concrete third parties that touch user data, so we can name
+   them: hosting provider, transactional-email provider (OTP codes), object/file storage.
+
+4. **Entity + contact** — the name to publish as the data controller, a contact email, and
+   (if you have one) a mailing address/jurisdiction.
+
+5. **Anything else** you want stated (e.g. no third-party analytics/ads — already true today;
+   note that crash reporting via Sentry is currently OFF and will be declared if enabled).

--- a/web-app/code/src/infrastructure/lib/utils/sendContactEmail.ts
+++ b/web-app/code/src/infrastructure/lib/utils/sendContactEmail.ts
@@ -1,0 +1,78 @@
+import { Resend } from "resend";
+
+// Constructed lazily inside the sender rather than at module load: the Resend
+// constructor throws when RESEND_API_KEY is unset, and this module is pulled in
+// by the appRouter (and thus by tests that import it without a mail key).
+let resend: Resend | null = null;
+function getResend(): Resend {
+  if (!resend) resend = new Resend(process.env.RESEND_API_KEY);
+  return resend;
+}
+
+/** Where contact-form submissions are delivered. */
+const CONTACT_TO = "parthasarathi.edupally@barefootprogrammers.in";
+
+interface SendContactEmailOptions {
+  /** Submitter's name */
+  name: string;
+  /** Submitter's email — used as reply-to so a reply goes straight back to them */
+  email: string;
+  /** The message body */
+  message: string;
+}
+
+function escapeHtml(s: string): string {
+  return s
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/"/g, "&quot;")
+    .replace(/'/g, "&#39;");
+}
+
+/**
+ * Delivers a contact-form submission to the BuildInLime maintainers via Resend.
+ * `replyTo` is the submitter so a reply from the inbox reaches them directly,
+ * while `from` stays on the verified sending domain.
+ */
+export async function sendContactEmail({
+  name,
+  email,
+  message,
+}: SendContactEmailOptions): Promise<{ success: boolean; error?: string }> {
+  try {
+    const { error } = await getResend().emails.send({
+      from: process.env.EMAIL_FROM || "BuildInLime <contact@buildinlime.com>",
+      to: CONTACT_TO,
+      replyTo: email,
+      subject: `New contact-form message from ${name}`,
+      html: `
+        <!DOCTYPE html>
+        <html>
+          <body style="font-family: sans-serif; padding: 20px; background-color: #f5f5f5;">
+            <div style="max-width: 520px; margin: 0 auto; background: white; padding: 30px; border-radius: 8px;">
+              <h2 style="color: #333; margin-bottom: 20px;">New contact-form message</h2>
+              <p style="color: #666; margin: 0 0 8px;"><strong>Name:</strong> ${escapeHtml(name)}</p>
+              <p style="color: #666; margin: 0 0 20px;"><strong>Email:</strong> ${escapeHtml(email)}</p>
+              <div style="background: #f0f0f0; padding: 15px; border-radius: 4px; color: #333; white-space: pre-wrap;">${escapeHtml(message)}</div>
+            </div>
+          </body>
+        </html>
+      `,
+    });
+
+    if (error) {
+      console.error("Resend error (contact):", error);
+      return { success: false, error: error.message };
+    }
+
+    console.log(`Contact email delivered to ${CONTACT_TO} (from ${email})`);
+    return { success: true };
+  } catch (err) {
+    console.error("Failed to send contact email:", err);
+    return {
+      success: false,
+      error: err instanceof Error ? err.message : "Unknown error",
+    };
+  }
+}

--- a/web-app/code/src/infrastructure/lib/utils/sendDeletionRequestEmail.ts
+++ b/web-app/code/src/infrastructure/lib/utils/sendDeletionRequestEmail.ts
@@ -1,0 +1,96 @@
+import { Resend } from "resend";
+
+// Lazily constructed — the Resend constructor throws when RESEND_API_KEY is
+// unset, and this module is reachable from the appRouter (and its tests).
+let resend: Resend | null = null;
+function getResend(): Resend {
+  if (!resend) resend = new Resend(process.env.RESEND_API_KEY);
+  return resend;
+}
+
+/** Where account-deletion requests are delivered for manual processing. */
+const DELETION_TO = "support@buildinlime.com";
+
+export type DeletionMode = "account-only" | "account-and-collective";
+
+interface SendDeletionRequestEmailOptions {
+  /** The requesting user's id (from the server session) */
+  userId: string;
+  /** The requesting user's email (from the server session) */
+  email: string;
+  /** The requesting user's name, if any */
+  name?: string | null;
+  /** Whether to also remove data from the Mozilla Data Collective */
+  mode: DeletionMode;
+  /** The free-text reason the user gave (may be empty) */
+  reason: string;
+}
+
+function escapeHtml(s: string): string {
+  return s
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/"/g, "&quot;")
+    .replace(/'/g, "&#39;");
+}
+
+/**
+ * Delivers an account-deletion request to support@buildinlime.com so it can be
+ * actioned manually. There is no automated backend purge yet (ARCHITECTURE.md
+ * §12.11); this email IS the deletion pipeline for now.
+ */
+export async function sendDeletionRequestEmail({
+  userId,
+  email,
+  name,
+  mode,
+  reason,
+}: SendDeletionRequestEmailOptions): Promise<{ success: boolean; error?: string }> {
+  const modeLabel =
+    mode === "account-and-collective"
+      ? "Delete account + remove data from the Mozilla Data Collective"
+      : "Delete account only";
+
+  try {
+    const { error } = await getResend().emails.send({
+      from: process.env.EMAIL_FROM || "BuildInLime <contact@buildinlime.com>",
+      to: DELETION_TO,
+      replyTo: email,
+      subject: `Account deletion request — ${email}`,
+      html: `
+        <!DOCTYPE html>
+        <html>
+          <body style="font-family: sans-serif; padding: 20px; background-color: #f5f5f5;">
+            <div style="max-width: 520px; margin: 0 auto; background: white; padding: 30px; border-radius: 8px;">
+              <h2 style="color: #333; margin-bottom: 20px;">Account deletion request</h2>
+              <p style="color: #666; margin: 0 0 8px;"><strong>User:</strong> ${escapeHtml(name || "—")}</p>
+              <p style="color: #666; margin: 0 0 8px;"><strong>Email:</strong> ${escapeHtml(email)}</p>
+              <p style="color: #666; margin: 0 0 8px;"><strong>User ID:</strong> ${escapeHtml(userId)}</p>
+              <p style="color: #666; margin: 0 0 16px;"><strong>Request:</strong> ${escapeHtml(modeLabel)}</p>
+              <p style="color: #666; margin: 0 0 8px;"><strong>Reason:</strong></p>
+              <div style="background: #f0f0f0; padding: 15px; border-radius: 4px; color: #333; white-space: pre-wrap;">${escapeHtml(reason || "(none given)")}</div>
+              <p style="color: #999; font-size: 12px; margin-top: 20px;">
+                Action manually: delete this user's account and data from the backend within 30 days.
+              </p>
+            </div>
+          </body>
+        </html>
+      `,
+    });
+
+    if (error) {
+      console.error("Resend error (deletion request):", error);
+      return { success: false, error: error.message };
+    }
+
+    console.log(`Deletion request delivered to ${DELETION_TO} for ${email}`);
+    return { success: true };
+  } catch (err) {
+    console.error("Failed to send deletion request:", err);
+    return {
+      success: false,
+      error: err instanceof Error ? err.message : "Unknown error",
+    };
+  }
+}

--- a/web-app/code/src/infrastructure/trpc/routers/account.ts
+++ b/web-app/code/src/infrastructure/trpc/routers/account.ts
@@ -1,0 +1,36 @@
+import { z } from "zod"
+import { TRPCError } from "@trpc/server"
+import { router, authedProcedure } from "../lib/trpc"
+import { sendDeletionRequestEmail } from "../../lib/utils/sendDeletionRequestEmail"
+
+// Web-only, so deliberately not mirrored in @buildinlime/contracts (the parity
+// test only asserts contract ⊆ server). The email/id come from the server
+// session, never from client input, so a request cannot be filed for someone
+// else. There is no automated purge yet (ARCHITECTURE.md §12.11) — this routes
+// the request to support@buildinlime.com for manual action.
+export const accountRouter = router({
+  requestDeletion: authedProcedure
+    .input(
+      z.object({
+        mode: z.enum(["account-only", "account-and-collective"]),
+        reason: z.string().trim().max(5000).default(""),
+      })
+    )
+    .mutation(async ({ ctx, input }) => {
+      const user = ctx.session.user
+      const { success, error } = await sendDeletionRequestEmail({
+        userId: user.id,
+        email: user.email,
+        name: user.name,
+        mode: input.mode,
+        reason: input.reason,
+      })
+      if (!success) {
+        throw new TRPCError({
+          code: "INTERNAL_SERVER_ERROR",
+          message: error || "Failed to submit your deletion request. Please try again.",
+        })
+      }
+      return { success: true }
+    }),
+})

--- a/web-app/code/src/infrastructure/trpc/routers/contact.ts
+++ b/web-app/code/src/infrastructure/trpc/routers/contact.ts
@@ -1,0 +1,28 @@
+import { z } from "zod"
+import { TRPCError } from "@trpc/server"
+import { router, procedure } from "../lib/trpc"
+import { sendContactEmail } from "../../lib/utils/sendContactEmail"
+
+// Public: the contact form lives on the unauthenticated landing page. Web-only,
+// so it is deliberately NOT mirrored in @buildinlime/contracts (mobile never
+// calls it); the parity test only asserts contract ⊆ server.
+export const contactRouter = router({
+  send: procedure
+    .input(
+      z.object({
+        name: z.string().trim().min(1).max(200),
+        email: z.string().trim().email().max(320),
+        message: z.string().trim().min(1).max(5000),
+      })
+    )
+    .mutation(async ({ input }) => {
+      const { success, error } = await sendContactEmail(input)
+      if (!success) {
+        throw new TRPCError({
+          code: "INTERNAL_SERVER_ERROR",
+          message: error || "Failed to send your message. Please try again.",
+        })
+      }
+      return { success: true }
+    }),
+})

--- a/web-app/code/src/infrastructure/trpc/routers/index.ts
+++ b/web-app/code/src/infrastructure/trpc/routers/index.ts
@@ -10,6 +10,8 @@ import { messagesRouter } from "%/infrastructure/trpc/routers/messages"
 import { teamsRouter } from "%/infrastructure/trpc/routers/teams"
 import { readsRouter } from "%/infrastructure/trpc/routers/reads"
 import { seenRouter } from "%/infrastructure/trpc/routers/seen"
+import { contactRouter } from "%/infrastructure/trpc/routers/contact"
+import { accountRouter } from "%/infrastructure/trpc/routers/account"
 
 // Composed here, outside the TanStack route file, so tests can import the real
 // router (e.g. the contract-name parity spec) without dragging in createFileRoute.
@@ -26,6 +28,8 @@ export const appRouter = router({
   teams: teamsRouter,
   reads: readsRouter,
   seen: seenRouter,
+  contact: contactRouter,
+  account: accountRouter,
 })
 
 export type AppRouter = typeof appRouter

--- a/web-app/code/src/presentation/components/buildInlime/Footer.tsx
+++ b/web-app/code/src/presentation/components/buildInlime/Footer.tsx
@@ -84,13 +84,13 @@ export function Footer({ compact = false }: { compact?: boolean } = {}) {
               </Link>
             </li>
             <li>
-              <a
-                href="#support"
+              <Link
+                to="/support"
                 className="font-['Instrument_Sans',sans-serif] text-[14px] leading-[20px] text-black hover:text-primary transition-colors"
                 style={{ fontVariationSettings: "'wdth' 100" }}
               >
                 Support
-              </a>
+              </Link>
             </li>
           </ul>
         </div>
@@ -114,22 +114,34 @@ export function Footer({ compact = false }: { compact?: boolean } = {}) {
               </Link>
             </li>
             <li>
-              <a
-                href="#careers"
-                className="font-['Instrument_Sans',sans-serif] text-[14px] leading-[20px] text-black hover:text-primary transition-colors"
-                style={{ fontVariationSettings: "'wdth' 100" }}
-              >
-                Careers
-              </a>
-            </li>
-            <li>
-              <a
-                href="#contact"
+              <Link
+                to="/contact"
                 className="font-['Instrument_Sans',sans-serif] text-[14px] leading-[20px] text-black hover:text-primary transition-colors"
                 style={{ fontVariationSettings: "'wdth' 100" }}
               >
                 Contact
-              </a>
+              </Link>
+            </li>
+          </ul>
+        </div>
+
+        {/* Legal */}
+        <div className="flex flex-col gap-[16px] w-[284.15px]">
+          <h3
+            className="font-['Instrument_Sans',sans-serif] font-medium text-[16px] leading-[24px] text-black"
+            style={{ fontVariationSettings: "'wdth' 100" }}
+          >
+            Legal
+          </h3>
+          <ul className="flex flex-col gap-[8px]">
+            <li>
+              <Link
+                to="/privacy"
+                className="font-['Instrument_Sans',sans-serif] text-[14px] leading-[20px] text-black hover:text-primary transition-colors"
+                style={{ fontVariationSettings: "'wdth' 100" }}
+              >
+                Privacy
+              </Link>
             </li>
           </ul>
         </div>

--- a/web-app/code/src/presentation/content/privacy.ts
+++ b/web-app/code/src/presentation/content/privacy.ts
@@ -1,0 +1,87 @@
+/**
+ * Privacy policy copy for /privacy.
+ *
+ * Kept in sync with the Play Data Safety declaration (mobile-app/PLAY_DATA_SAFETY.md):
+ * every data category stated here must also be declared there, and vice versa.
+ * The account-deletion path described under "Your rights and data deletion"
+ * matches the in-app flow at /delete-account.
+ */
+
+export type PrivacySection = {
+  title: string;
+  paragraphs: string[];
+};
+
+export const PRIVACY_EFFECTIVE_DATE = "25 July 2026";
+
+export const PRIVACY_INTRO =
+  "This policy explains what BuildInLime collects, why, and the choices you have. BuildInLime is operated by DataConscientious LLP and built by Barefoot Programmers (barefootprogrammers.in).";
+
+export const PRIVACY_SECTIONS: PrivacySection[] = [
+  {
+    title: "Who we are",
+    paragraphs: [
+      "BuildInLime is a construction project-management application operated by DataConscientious LLP, registered with the Registrar of Companies (RoC), Vijayawada, India. The application is built by Barefoot Programmers (barefootprogrammers.in).",
+      "DataConscientious LLP is the data controller. For any privacy or data-deletion request, contact us at support@buildinlime.com.",
+    ],
+  },
+  {
+    title: "What we collect",
+    paragraphs: [
+      "Account information: your email address, and a name/profile associated with your account.",
+      "Content you create or upload: text messages, tasks, photos and videos, documents and files, and voice recordings — all as part of using the app to collaborate on projects.",
+      "On your device: a session cookie held in secure storage to keep you signed in, and a local database cache that holds a copy of the data you are allowed to see so the app works offline.",
+    ],
+  },
+  {
+    title: "Why we use it",
+    paragraphs: [
+      "To provide the app — project collaboration through channels, tasks, messages and attachments — and to manage your account and sign you in.",
+      "We do not use your data for advertising, and we do not sell it.",
+    ],
+  },
+  {
+    title: "Who it is shared with",
+    paragraphs: [
+      "Your data is processed on our own server infrastructure. We use a transactional email provider to deliver sign-in codes and messages, and a file-storage provider to hold uploaded files. These providers process data only to provide their service to us.",
+      "We do not share your data with anyone for advertising.",
+    ],
+  },
+  {
+    title: "Security",
+    paragraphs: [
+      "Data is encrypted in transit using TLS. Access to the content in a channel is limited to the members of that channel, enforced on the server for every request. Your session token is held in your device's secure store.",
+    ],
+  },
+  {
+    title: "Your rights and data deletion",
+    paragraphs: [
+      "You can request deletion of your account and its data from the Account page in the app, which also lets you download a copy of your data as part of the request. When you submit the request, it is sent to our team at support@buildinlime.com and processed manually.",
+      "Your account and its associated data are deleted from our systems within 30 days of the request. You can also reach us at support@buildinlime.com to access, correct, or delete your data.",
+    ],
+  },
+  {
+    title: "Data retention",
+    paragraphs: [
+      "We keep your data for as long as your account is active. After you request deletion, your data is retained for up to 30 days and then removed from our systems.",
+    ],
+  },
+  {
+    title: "Data sovereignty",
+    paragraphs: [
+      "We believe the information a community generates belongs to that community. In support of this, we are members of the Mozilla Data Collective, and you can request removal of your data from the collective as part of your deletion request.",
+    ],
+  },
+  {
+    title: "Permissions",
+    paragraphs: [
+      "The app requests the microphone only to record voice messages you choose to send, and the camera and photo library only to attach images and videos to your messages and tasks. These are used only when you initiate the action.",
+    ],
+  },
+  {
+    title: "Governing law and contact",
+    paragraphs: [
+      "This policy and the operation of BuildInLime are governed by the laws of India, with DataConscientious LLP registered under the Registrar of Companies (RoC), Vijayawada. For any question about this policy or your data, contact support@buildinlime.com.",
+    ],
+  },
+];

--- a/web-app/code/src/presentation/pages/AccountPage.tsx
+++ b/web-app/code/src/presentation/pages/AccountPage.tsx
@@ -1,4 +1,5 @@
-import { ArrowLeft } from "lucide-react";
+import { ArrowLeft, Trash2 } from "lucide-react";
+import { Link } from "@tanstack/react-router";
 import { Sidebar } from "../components/buildInlime";
 import { useSession } from "%/infrastructure/auth/client";
 
@@ -42,6 +43,24 @@ export function AccountPage() {
             <div className="max-w-2xl">
               <DetailRow label="Name" value={user.name || "—"} />
               <DetailRow label="Email" value={user.email || "—"} />
+
+              {/* Delete account & data — entry point to the deletion request flow */}
+              <div className="mt-8">
+                <h2 className="text-sm font-medium text-foreground mb-1">
+                  Delete account &amp; data
+                </h2>
+                <p className="text-xs text-muted-foreground mb-3">
+                  Request deletion of your account and the data associated with
+                  it. You'll get a copy of your data as part of the request.
+                </p>
+                <Link
+                  to="/delete-account"
+                  className="inline-flex items-center gap-2 rounded-md border border-destructive/40 px-4 py-2 text-sm font-medium text-destructive hover:bg-destructive/5 transition-colors"
+                >
+                  <Trash2 className="w-4 h-4" />
+                  Delete account &amp; data
+                </Link>
+              </div>
             </div>
           )}
         </div>

--- a/web-app/code/src/presentation/pages/ContactPage.tsx
+++ b/web-app/code/src/presentation/pages/ContactPage.tsx
@@ -1,0 +1,163 @@
+import { useState } from "react";
+import { Loader2 } from "lucide-react";
+import { Header, HeaderLoggedIn, Footer, PageHeading } from "../components/buildInlime";
+import { trpc } from "../../infrastructure/trpc/lib/trpc-client";
+import { signOutAndDispose, useRequireAuth } from "../../infrastructure/auth/client";
+
+const inputClass =
+  "w-full bg-input-background border border-border rounded-[10px] px-4 py-3 font-['Instrument_Sans',sans-serif] text-[16px] text-foreground placeholder:text-muted-foreground focus:outline-none focus:ring-2 focus:ring-ring";
+
+export default function ContactPage() {
+  const { user } = useRequireAuth();
+  const loggedIn = !!user;
+
+  const [name, setName] = useState("");
+  const [email, setEmail] = useState("");
+  const [message, setMessage] = useState("");
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState("");
+  const [sent, setSent] = useState(false);
+
+  const handleSignOut = async () => {
+    await signOutAndDispose();
+    window.location.href = "/";
+  };
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    setError("");
+    if (!navigator.onLine) {
+      setError("You're offline. Connect to the internet to send your message.");
+      return;
+    }
+    setLoading(true);
+    try {
+      await trpc.contact.send.mutate({
+        name: name.trim(),
+        email: email.trim(),
+        message: message.trim(),
+      });
+      setSent(true);
+    } catch (err) {
+      console.error("Failed to send contact message:", err);
+      setError("Something went wrong sending your message. Please try again.");
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  return (
+    <div className="bg-white flex flex-col items-start min-h-screen">
+      {loggedIn ? <HeaderLoggedIn onSignOut={handleSignOut} /> : <Header />}
+
+      <PageHeading
+        title="Contact us"
+        description="Have a question or want to work with us? Send us a message and we'll be in touch."
+      />
+
+      <section className="w-full px-[120px] py-[20px]">
+        <div className="max-w-[788px] mx-auto flex flex-col gap-[16px]">
+          <p
+            className="font-['Instrument_Sans',sans-serif] text-[16px] leading-[26px] text-black"
+            style={{ fontVariationSettings: "'wdth' 100" }}
+          >
+            BuildInLime is built by{" "}
+            <a
+              href="https://barefootprogrammers.in"
+              target="_blank"
+              rel="noreferrer"
+              className="text-primary hover:underline"
+            >
+              barefootprogrammers.in
+            </a>
+            . Use the form below to send us a query.
+          </p>
+
+          {sent ? (
+            <div className="p-4 bg-green-50 border border-green-200 rounded-[10px]">
+              <p className="font-['Instrument_Sans',sans-serif] text-[15px] text-green-700">
+                Thanks for reaching out — your message has been sent. We'll get
+                back to you soon.
+              </p>
+            </div>
+          ) : (
+            <form onSubmit={handleSubmit} className="flex flex-col gap-[20px] max-w-[520px]">
+              {error && (
+                <div className="p-3 bg-red-50 border border-red-200 rounded-[10px]">
+                  <p className="font-['Instrument_Sans',sans-serif] text-[14px] text-red-600">
+                    {error}
+                  </p>
+                </div>
+              )}
+
+              <div className="flex flex-col gap-[8px]">
+                <label
+                  className="font-['Instrument_Sans',sans-serif] font-medium text-[14px] text-black"
+                  style={{ fontVariationSettings: "'wdth' 100" }}
+                >
+                  Name <span className="text-red-500">*</span>
+                </label>
+                <input
+                  type="text"
+                  value={name}
+                  onChange={(e) => setName(e.target.value)}
+                  placeholder="Your name"
+                  required
+                  className={inputClass}
+                  style={{ fontVariationSettings: "'wdth' 100" }}
+                />
+              </div>
+
+              <div className="flex flex-col gap-[8px]">
+                <label
+                  className="font-['Instrument_Sans',sans-serif] font-medium text-[14px] text-black"
+                  style={{ fontVariationSettings: "'wdth' 100" }}
+                >
+                  Email <span className="text-red-500">*</span>
+                </label>
+                <input
+                  type="email"
+                  value={email}
+                  onChange={(e) => setEmail(e.target.value)}
+                  placeholder="you@example.com"
+                  required
+                  className={inputClass}
+                  style={{ fontVariationSettings: "'wdth' 100" }}
+                />
+              </div>
+
+              <div className="flex flex-col gap-[8px]">
+                <label
+                  className="font-['Instrument_Sans',sans-serif] font-medium text-[14px] text-black"
+                  style={{ fontVariationSettings: "'wdth' 100" }}
+                >
+                  Message <span className="text-red-500">*</span>
+                </label>
+                <textarea
+                  value={message}
+                  onChange={(e) => setMessage(e.target.value)}
+                  placeholder="How can we help?"
+                  required
+                  rows={5}
+                  className={inputClass}
+                  style={{ fontVariationSettings: "'wdth' 100" }}
+                />
+              </div>
+
+              <button
+                type="submit"
+                disabled={loading}
+                className="w-full bg-primary hover:bg-primary-hover disabled:bg-primary-disabled text-white rounded-[10px] h-[48px] font-['Instrument_Sans',sans-serif] font-medium text-[16px] flex items-center justify-center gap-2 transition-colors max-w-[520px]"
+                style={{ fontVariationSettings: "'wdth' 100" }}
+              >
+                {loading ? <Loader2 className="w-4 h-4 animate-spin" /> : "Send message"}
+              </button>
+            </form>
+          )}
+        </div>
+      </section>
+
+      <Footer compact />
+    </div>
+  );
+}

--- a/web-app/code/src/presentation/pages/DeleteAccountPage.tsx
+++ b/web-app/code/src/presentation/pages/DeleteAccountPage.tsx
@@ -1,0 +1,229 @@
+import { useState } from "react";
+import { ArrowLeft, Download, Trash2, Loader2 } from "lucide-react";
+import { Sidebar } from "../components/buildInlime";
+import { useSession } from "%/infrastructure/auth/client";
+import { trpc } from "../../infrastructure/trpc/lib/trpc-client";
+
+type DeletionMode = "account-only" | "account-and-collective";
+
+/** Downloads a JSON snapshot of the signed-in user's account details. */
+function downloadAccountData(user: { id: string; name?: string; email?: string }) {
+  const payload = {
+    exportedAt: new Date().toISOString(),
+    account: {
+      id: user.id,
+      name: user.name ?? null,
+      email: user.email ?? null,
+    },
+  };
+  const blob = new Blob([JSON.stringify(payload, null, 2)], {
+    type: "application/json",
+  });
+  const url = URL.createObjectURL(blob);
+  const a = document.createElement("a");
+  a.href = url;
+  a.download = `buildinlime-data-${user.id}.json`;
+  document.body.appendChild(a);
+  a.click();
+  a.remove();
+  URL.revokeObjectURL(url);
+}
+
+export function DeleteAccountPage() {
+  const { data: session, isPending } = useSession();
+  const user = session?.user;
+
+  const [mode, setMode] = useState<DeletionMode>("account-only");
+  const [reason, setReason] = useState("");
+  const [submitted, setSubmitted] = useState(false);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState("");
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    if (!user) return;
+    setError("");
+    if (!navigator.onLine) {
+      setError("You're offline. Connect to the internet to submit your request.");
+      return;
+    }
+    setLoading(true);
+    try {
+      // There is no automated backend purge yet (ARCHITECTURE.md §12.11): this
+      // files the request by email to support@buildinlime.com, where it is
+      // actioned manually. Both options export the user's data first.
+      await trpc.account.requestDeletion.mutate({ mode, reason: reason.trim() });
+      downloadAccountData(user);
+      setSubmitted(true);
+    } catch (err) {
+      console.error("Failed to submit deletion request:", err);
+      setError("Something went wrong submitting your request. Please try again.");
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  return (
+    <div className="flex h-screen bg-white font-['Instrument_Sans',sans-serif]">
+      <Sidebar />
+
+      <main className="flex-1 flex flex-col overflow-hidden">
+        {/* Top nav */}
+        <header className="h-12 bg-white border-b border-card-border flex items-center gap-3 px-6">
+          <button
+            onClick={() => window.history.back()}
+            className="p-1 text-muted-foreground hover:text-foreground hover:bg-icon-chip rounded transition-colors"
+          >
+            <ArrowLeft className="w-4 h-4" />
+          </button>
+          <h1 className="font-semibold text-[16px] text-foreground">
+            Delete account &amp; data
+          </h1>
+        </header>
+
+        {/* Content */}
+        <div className="flex-1 overflow-y-auto px-8 py-6">
+          {isPending ? (
+            <p className="text-sm text-muted-foreground">Loading…</p>
+          ) : !user ? (
+            <p className="text-sm text-muted-foreground">Not signed in.</p>
+          ) : submitted ? (
+            <div className="max-w-2xl">
+              <div className="rounded-lg border border-card-border bg-icon-chip p-4">
+                <p className="text-sm font-medium text-foreground mb-1">
+                  Deletion request received
+                </p>
+                <p className="text-sm text-muted-foreground">
+                  A copy of your data has been downloaded and your request has
+                  been sent to our team at support@buildinlime.com. Your account
+                  and relevant data
+                  {mode === "account-and-collective"
+                    ? ", including data held in the Mozilla Data Collective,"
+                    : ""}{" "}
+                  will be deleted from our systems within 30 days. We'll process
+                  the request manually and email you at {user.email} if we need
+                  anything.
+                </p>
+              </div>
+            </div>
+          ) : (
+            <form onSubmit={handleSubmit} className="max-w-2xl space-y-8">
+              <p className="text-sm text-muted-foreground">
+                Request deletion of your BuildInLime account and the data
+                associated with it. You will get a copy of your data as part of
+                this request, and your account and data will be deleted within
+                30 days. This action cannot be undone.
+              </p>
+
+              {error && (
+                <div className="rounded-lg border border-red-200 bg-red-50 p-3">
+                  <p className="text-sm text-red-600">{error}</p>
+                </div>
+              )}
+
+              {/* Email */}
+              <div className="flex flex-col gap-1">
+                <span className="text-xs text-muted-foreground">Email</span>
+                <span className="text-sm text-foreground break-words">
+                  {user.email || "—"}
+                </span>
+              </div>
+
+              {/* Deletion mode */}
+              <fieldset className="space-y-3">
+                <legend className="text-sm font-medium text-foreground mb-2">
+                  What would you like to do?
+                </legend>
+
+                <label className="flex items-start gap-3 rounded-lg border border-card-border p-3 cursor-pointer hover:bg-icon-chip transition-colors">
+                  <input
+                    type="radio"
+                    name="deletion-mode"
+                    value="account-only"
+                    checked={mode === "account-only"}
+                    onChange={() => setMode("account-only")}
+                    className="mt-1"
+                  />
+                  <span className="flex flex-col">
+                    <span className="text-sm text-foreground">
+                      Delete my account and download my data
+                    </span>
+                    <span className="text-xs text-muted-foreground">
+                      Removes your account and its data from BuildInLime. You
+                      keep a downloaded copy.
+                    </span>
+                  </span>
+                </label>
+
+                <label className="flex items-start gap-3 rounded-lg border border-card-border p-3 cursor-pointer hover:bg-icon-chip transition-colors">
+                  <input
+                    type="radio"
+                    name="deletion-mode"
+                    value="account-and-collective"
+                    checked={mode === "account-and-collective"}
+                    onChange={() => setMode("account-and-collective")}
+                    className="mt-1"
+                  />
+                  <span className="flex flex-col">
+                    <span className="text-sm text-foreground">
+                      Delete my account, download my data, and delete my data
+                      from the Mozilla Data Collective
+                    </span>
+                    <span className="text-xs text-muted-foreground">
+                      Everything above, and additionally requests removal of
+                      your data from the Mozilla Data Collective.
+                    </span>
+                  </span>
+                </label>
+              </fieldset>
+
+              {/* Reason */}
+              <div className="flex flex-col gap-2">
+                <label
+                  htmlFor="reason"
+                  className="text-sm font-medium text-foreground"
+                >
+                  Reason for deletion
+                </label>
+                <textarea
+                  id="reason"
+                  value={reason}
+                  onChange={(e) => setReason(e.target.value)}
+                  rows={4}
+                  placeholder="Tell us why you're leaving (optional)"
+                  className="w-full rounded-lg border border-card-border bg-white px-3 py-2 text-sm text-foreground placeholder:text-muted-foreground focus:outline-none focus:ring-2 focus:ring-ring/50"
+                />
+              </div>
+
+              {/* Actions */}
+              <div className="flex items-center gap-3">
+                <button
+                  type="submit"
+                  disabled={loading}
+                  className="inline-flex items-center gap-2 rounded-md bg-destructive px-4 py-2 text-sm font-medium text-white hover:bg-destructive/90 disabled:opacity-60 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-destructive/50 transition-colors"
+                >
+                  {loading ? (
+                    <Loader2 className="w-4 h-4 animate-spin" />
+                  ) : (
+                    <Trash2 className="w-4 h-4" />
+                  )}
+                  Delete account &amp; data
+                </button>
+                <button
+                  type="button"
+                  onClick={() => downloadAccountData(user)}
+                  className="inline-flex items-center gap-2 rounded-md border border-card-border px-4 py-2 text-sm font-medium text-foreground hover:bg-icon-chip transition-colors"
+                >
+                  <Download className="w-4 h-4" />
+                  Download my data
+                </button>
+              </div>
+            </form>
+          )}
+        </div>
+      </main>
+    </div>
+  );
+}
+
+export default DeleteAccountPage;

--- a/web-app/code/src/presentation/pages/PrivacyPage.tsx
+++ b/web-app/code/src/presentation/pages/PrivacyPage.tsx
@@ -1,0 +1,38 @@
+import { Header, HeaderLoggedIn, Footer, PageHeading, ProseSection } from "../components/buildInlime";
+import { PRIVACY_INTRO, PRIVACY_SECTIONS, PRIVACY_EFFECTIVE_DATE } from "../content/privacy";
+import { signOutAndDispose, useRequireAuth } from "../../infrastructure/auth/client";
+
+export default function PrivacyPage() {
+  const { user } = useRequireAuth();
+  const loggedIn = !!user;
+
+  const handleSignOut = async () => {
+    await signOutAndDispose();
+    window.location.href = "/";
+  };
+
+  return (
+    <div className="bg-white flex flex-col items-start min-h-screen">
+      {loggedIn ? <HeaderLoggedIn onSignOut={handleSignOut} /> : <Header />}
+
+      <PageHeading title="Privacy Policy" description={PRIVACY_INTRO} />
+
+      <section className="w-full px-[120px] pt-[8px]">
+        <div className="max-w-[788px] mx-auto">
+          <p
+            className="font-['Instrument_Sans',sans-serif] text-[14px] leading-[20px] text-muted-foreground"
+            style={{ fontVariationSettings: "'wdth' 100" }}
+          >
+            Effective date: {PRIVACY_EFFECTIVE_DATE}
+          </p>
+        </div>
+      </section>
+
+      {PRIVACY_SECTIONS.map((section) => (
+        <ProseSection key={section.title} section={section} />
+      ))}
+
+      <Footer compact />
+    </div>
+  );
+}

--- a/web-app/code/src/presentation/pages/SupportPage.tsx
+++ b/web-app/code/src/presentation/pages/SupportPage.tsx
@@ -1,0 +1,47 @@
+import { Header, HeaderLoggedIn, Footer, PageHeading } from "../components/buildInlime";
+import { signOutAndDispose, useRequireAuth } from "../../infrastructure/auth/client";
+
+export default function SupportPage() {
+  const { user } = useRequireAuth();
+  const loggedIn = !!user;
+
+  const handleSignOut = async () => {
+    await signOutAndDispose();
+    window.location.href = "/";
+  };
+
+  return (
+    <div className="bg-white flex flex-col items-start min-h-screen">
+      {loggedIn ? <HeaderLoggedIn onSignOut={handleSignOut} /> : <Header />}
+
+      <PageHeading
+        title="Support"
+        description="Need a hand with BuildInLime? We're happy to help."
+      />
+
+      <section className="w-full px-[120px] py-[20px]">
+        <div className="max-w-[788px] mx-auto flex flex-col gap-[12px]">
+          <h2 className="font-['Inria_Sans',sans-serif] font-bold text-[22px] leading-[31px] text-foreground">
+            Contact us
+          </h2>
+          <p
+            className="font-['Instrument_Sans',sans-serif] text-[16px] leading-[26px] text-black"
+            style={{ fontVariationSettings: "'wdth' 100" }}
+          >
+            For anything related to the application — questions, issues, feature
+            requests, or account help — reach us at{" "}
+            <a
+              href="mailto:support@buildinlime.com"
+              className="text-primary hover:underline"
+            >
+              support@buildinlime.com
+            </a>
+            . We'll get back to you as soon as we can.
+          </p>
+        </div>
+      </section>
+
+      <Footer compact />
+    </div>
+  );
+}

--- a/web-app/code/src/presentation/routeTree.gen.ts
+++ b/web-app/code/src/presentation/routeTree.gen.ts
@@ -9,12 +9,15 @@
 // Additionally, you should also exclude this file from your linter and/or formatter to prevent it from being checked or modified.
 
 import { Route as rootRouteImport } from './routes/__root'
+import { Route as SupportRouteImport } from './routes/support'
 import { Route as ResourcesRouteImport } from './routes/resources'
+import { Route as PrivacyRouteImport } from './routes/privacy'
 import { Route as PricingRouteImport } from './routes/pricing'
 import { Route as LoginRouteImport } from './routes/login'
 import { Route as GetStartedRouteImport } from './routes/get-started'
 import { Route as FeaturesRouteImport } from './routes/features'
 import { Route as DocumentationRouteImport } from './routes/documentation'
+import { Route as ContactRouteImport } from './routes/contact'
 import { Route as BlogRouteImport } from './routes/blog'
 import { Route as AboutRouteImport } from './routes/about'
 import { Route as AuthenticatedRouteImport } from './routes/_authenticated'
@@ -36,6 +39,7 @@ import { Route as ApiChannelMembersRouteImport } from './routes/api/channel-memb
 import { Route as ApiBuildunitsRouteImport } from './routes/api/buildunits'
 import { Route as AuthenticatedMyTasksRouteImport } from './routes/_authenticated/my-tasks'
 import { Route as AuthenticatedInboxRouteImport } from './routes/_authenticated/inbox'
+import { Route as AuthenticatedDeleteAccountRouteImport } from './routes/_authenticated/delete-account'
 import { Route as AuthenticatedAccountRouteImport } from './routes/_authenticated/account'
 import { Route as AuthenticatedProjectsIndexRouteImport } from './routes/_authenticated/projects/index'
 import { Route as ApiTrpcSplatRouteImport } from './routes/api/trpc/$'
@@ -50,9 +54,19 @@ import { Route as AuthenticatedProjectsProjectIdBuildUnitNameChannelNameRouteImp
 import { Route as AuthenticatedProjectsProjectIdBuildUnitNameChannelNameIndexRouteImport } from './routes/_authenticated/projects/$projectId/$buildUnitName/$channelName/index'
 import { Route as AuthenticatedProjectsProjectIdBuildUnitNameChannelNameTaskNameRouteImport } from './routes/_authenticated/projects/$projectId/$buildUnitName/$channelName/$taskName'
 
+const SupportRoute = SupportRouteImport.update({
+  id: '/support',
+  path: '/support',
+  getParentRoute: () => rootRouteImport,
+} as any)
 const ResourcesRoute = ResourcesRouteImport.update({
   id: '/resources',
   path: '/resources',
+  getParentRoute: () => rootRouteImport,
+} as any)
+const PrivacyRoute = PrivacyRouteImport.update({
+  id: '/privacy',
+  path: '/privacy',
   getParentRoute: () => rootRouteImport,
 } as any)
 const PricingRoute = PricingRouteImport.update({
@@ -78,6 +92,11 @@ const FeaturesRoute = FeaturesRouteImport.update({
 const DocumentationRoute = DocumentationRouteImport.update({
   id: '/documentation',
   path: '/documentation',
+  getParentRoute: () => rootRouteImport,
+} as any)
+const ContactRoute = ContactRouteImport.update({
+  id: '/contact',
+  path: '/contact',
   getParentRoute: () => rootRouteImport,
 } as any)
 const BlogRoute = BlogRouteImport.update({
@@ -184,6 +203,12 @@ const AuthenticatedInboxRoute = AuthenticatedInboxRouteImport.update({
   path: '/inbox',
   getParentRoute: () => AuthenticatedRoute,
 } as any)
+const AuthenticatedDeleteAccountRoute =
+  AuthenticatedDeleteAccountRouteImport.update({
+    id: '/delete-account',
+    path: '/delete-account',
+    getParentRoute: () => AuthenticatedRoute,
+  } as any)
 const AuthenticatedAccountRoute = AuthenticatedAccountRouteImport.update({
   id: '/account',
   path: '/account',
@@ -269,13 +294,17 @@ export interface FileRoutesByFullPath {
   '/': typeof IndexRoute
   '/about': typeof AboutRoute
   '/blog': typeof BlogRoute
+  '/contact': typeof ContactRoute
   '/documentation': typeof DocumentationRoute
   '/features': typeof FeaturesRoute
   '/get-started': typeof GetStartedRoute
   '/login': typeof LoginRoute
   '/pricing': typeof PricingRoute
+  '/privacy': typeof PrivacyRoute
   '/resources': typeof ResourcesRoute
+  '/support': typeof SupportRoute
   '/account': typeof AuthenticatedAccountRoute
+  '/delete-account': typeof AuthenticatedDeleteAccountRoute
   '/inbox': typeof AuthenticatedInboxRoute
   '/my-tasks': typeof AuthenticatedMyTasksRoute
   '/api/buildunits': typeof ApiBuildunitsRoute
@@ -310,13 +339,17 @@ export interface FileRoutesByTo {
   '/': typeof IndexRoute
   '/about': typeof AboutRoute
   '/blog': typeof BlogRoute
+  '/contact': typeof ContactRoute
   '/documentation': typeof DocumentationRoute
   '/features': typeof FeaturesRoute
   '/get-started': typeof GetStartedRoute
   '/login': typeof LoginRoute
   '/pricing': typeof PricingRoute
+  '/privacy': typeof PrivacyRoute
   '/resources': typeof ResourcesRoute
+  '/support': typeof SupportRoute
   '/account': typeof AuthenticatedAccountRoute
+  '/delete-account': typeof AuthenticatedDeleteAccountRoute
   '/inbox': typeof AuthenticatedInboxRoute
   '/my-tasks': typeof AuthenticatedMyTasksRoute
   '/api/buildunits': typeof ApiBuildunitsRoute
@@ -350,13 +383,17 @@ export interface FileRoutesById {
   '/_authenticated': typeof AuthenticatedRouteWithChildren
   '/about': typeof AboutRoute
   '/blog': typeof BlogRoute
+  '/contact': typeof ContactRoute
   '/documentation': typeof DocumentationRoute
   '/features': typeof FeaturesRoute
   '/get-started': typeof GetStartedRoute
   '/login': typeof LoginRoute
   '/pricing': typeof PricingRoute
+  '/privacy': typeof PrivacyRoute
   '/resources': typeof ResourcesRoute
+  '/support': typeof SupportRoute
   '/_authenticated/account': typeof AuthenticatedAccountRoute
+  '/_authenticated/delete-account': typeof AuthenticatedDeleteAccountRoute
   '/_authenticated/inbox': typeof AuthenticatedInboxRoute
   '/_authenticated/my-tasks': typeof AuthenticatedMyTasksRoute
   '/api/buildunits': typeof ApiBuildunitsRoute
@@ -393,13 +430,17 @@ export interface FileRouteTypes {
     | '/'
     | '/about'
     | '/blog'
+    | '/contact'
     | '/documentation'
     | '/features'
     | '/get-started'
     | '/login'
     | '/pricing'
+    | '/privacy'
     | '/resources'
+    | '/support'
     | '/account'
+    | '/delete-account'
     | '/inbox'
     | '/my-tasks'
     | '/api/buildunits'
@@ -434,13 +475,17 @@ export interface FileRouteTypes {
     | '/'
     | '/about'
     | '/blog'
+    | '/contact'
     | '/documentation'
     | '/features'
     | '/get-started'
     | '/login'
     | '/pricing'
+    | '/privacy'
     | '/resources'
+    | '/support'
     | '/account'
+    | '/delete-account'
     | '/inbox'
     | '/my-tasks'
     | '/api/buildunits'
@@ -473,13 +518,17 @@ export interface FileRouteTypes {
     | '/_authenticated'
     | '/about'
     | '/blog'
+    | '/contact'
     | '/documentation'
     | '/features'
     | '/get-started'
     | '/login'
     | '/pricing'
+    | '/privacy'
     | '/resources'
+    | '/support'
     | '/_authenticated/account'
+    | '/_authenticated/delete-account'
     | '/_authenticated/inbox'
     | '/_authenticated/my-tasks'
     | '/api/buildunits'
@@ -516,12 +565,15 @@ export interface RootRouteChildren {
   AuthenticatedRoute: typeof AuthenticatedRouteWithChildren
   AboutRoute: typeof AboutRoute
   BlogRoute: typeof BlogRoute
+  ContactRoute: typeof ContactRoute
   DocumentationRoute: typeof DocumentationRoute
   FeaturesRoute: typeof FeaturesRoute
   GetStartedRoute: typeof GetStartedRoute
   LoginRoute: typeof LoginRoute
   PricingRoute: typeof PricingRoute
+  PrivacyRoute: typeof PrivacyRoute
   ResourcesRoute: typeof ResourcesRoute
+  SupportRoute: typeof SupportRoute
   ApiBuildunitsRoute: typeof ApiBuildunitsRoute
   ApiChannelMembersRoute: typeof ApiChannelMembersRoute
   ApiChannelsRoute: typeof ApiChannelsRoute
@@ -543,11 +595,25 @@ export interface RootRouteChildren {
 
 declare module '@tanstack/react-router' {
   interface FileRoutesByPath {
+    '/support': {
+      id: '/support'
+      path: '/support'
+      fullPath: '/support'
+      preLoaderRoute: typeof SupportRouteImport
+      parentRoute: typeof rootRouteImport
+    }
     '/resources': {
       id: '/resources'
       path: '/resources'
       fullPath: '/resources'
       preLoaderRoute: typeof ResourcesRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/privacy': {
+      id: '/privacy'
+      path: '/privacy'
+      fullPath: '/privacy'
+      preLoaderRoute: typeof PrivacyRouteImport
       parentRoute: typeof rootRouteImport
     }
     '/pricing': {
@@ -583,6 +649,13 @@ declare module '@tanstack/react-router' {
       path: '/documentation'
       fullPath: '/documentation'
       preLoaderRoute: typeof DocumentationRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/contact': {
+      id: '/contact'
+      path: '/contact'
+      fullPath: '/contact'
+      preLoaderRoute: typeof ContactRouteImport
       parentRoute: typeof rootRouteImport
     }
     '/blog': {
@@ -730,6 +803,13 @@ declare module '@tanstack/react-router' {
       path: '/inbox'
       fullPath: '/inbox'
       preLoaderRoute: typeof AuthenticatedInboxRouteImport
+      parentRoute: typeof AuthenticatedRoute
+    }
+    '/_authenticated/delete-account': {
+      id: '/_authenticated/delete-account'
+      path: '/delete-account'
+      fullPath: '/delete-account'
+      preLoaderRoute: typeof AuthenticatedDeleteAccountRouteImport
       parentRoute: typeof AuthenticatedRoute
     }
     '/_authenticated/account': {
@@ -882,6 +962,7 @@ const AuthenticatedProjectsProjectIdRouteWithChildren =
 
 interface AuthenticatedRouteChildren {
   AuthenticatedAccountRoute: typeof AuthenticatedAccountRoute
+  AuthenticatedDeleteAccountRoute: typeof AuthenticatedDeleteAccountRoute
   AuthenticatedInboxRoute: typeof AuthenticatedInboxRoute
   AuthenticatedMyTasksRoute: typeof AuthenticatedMyTasksRoute
   AuthenticatedProjectsProjectIdRoute: typeof AuthenticatedProjectsProjectIdRouteWithChildren
@@ -890,6 +971,7 @@ interface AuthenticatedRouteChildren {
 
 const AuthenticatedRouteChildren: AuthenticatedRouteChildren = {
   AuthenticatedAccountRoute: AuthenticatedAccountRoute,
+  AuthenticatedDeleteAccountRoute: AuthenticatedDeleteAccountRoute,
   AuthenticatedInboxRoute: AuthenticatedInboxRoute,
   AuthenticatedMyTasksRoute: AuthenticatedMyTasksRoute,
   AuthenticatedProjectsProjectIdRoute:
@@ -920,12 +1002,15 @@ const rootRouteChildren: RootRouteChildren = {
   AuthenticatedRoute: AuthenticatedRouteWithChildren,
   AboutRoute: AboutRoute,
   BlogRoute: BlogRoute,
+  ContactRoute: ContactRoute,
   DocumentationRoute: DocumentationRoute,
   FeaturesRoute: FeaturesRoute,
   GetStartedRoute: GetStartedRoute,
   LoginRoute: LoginRoute,
   PricingRoute: PricingRoute,
+  PrivacyRoute: PrivacyRoute,
   ResourcesRoute: ResourcesRoute,
+  SupportRoute: SupportRoute,
   ApiBuildunitsRoute: ApiBuildunitsRoute,
   ApiChannelMembersRoute: ApiChannelMembersRoute,
   ApiChannelsRoute: ApiChannelsRoute,

--- a/web-app/code/src/presentation/routes/_authenticated/delete-account.tsx
+++ b/web-app/code/src/presentation/routes/_authenticated/delete-account.tsx
@@ -1,0 +1,8 @@
+import { createFileRoute } from '@tanstack/react-router'
+import { DeleteAccountPage } from '../../pages/DeleteAccountPage'
+import { RoutePendingComponent } from '../../components/buildInlime'
+
+export const Route = createFileRoute('/_authenticated/delete-account')({
+  component: DeleteAccountPage,
+  pendingComponent: RoutePendingComponent,
+})

--- a/web-app/code/src/presentation/routes/contact.tsx
+++ b/web-app/code/src/presentation/routes/contact.tsx
@@ -1,0 +1,9 @@
+import { createFileRoute } from '@tanstack/react-router'
+import ContactPage from '../pages/ContactPage'
+
+export const Route = createFileRoute('/contact')({
+  head: () => ({
+    meta: [{ title: 'Contact - BuildInLime' }],
+  }),
+  component: ContactPage,
+})

--- a/web-app/code/src/presentation/routes/privacy.tsx
+++ b/web-app/code/src/presentation/routes/privacy.tsx
@@ -1,0 +1,9 @@
+import { createFileRoute } from '@tanstack/react-router'
+import PrivacyPage from '../pages/PrivacyPage'
+
+export const Route = createFileRoute('/privacy')({
+  head: () => ({
+    meta: [{ title: 'Privacy Policy - BuildInLime' }],
+  }),
+  component: PrivacyPage,
+})

--- a/web-app/code/src/presentation/routes/support.tsx
+++ b/web-app/code/src/presentation/routes/support.tsx
@@ -1,0 +1,9 @@
+import { createFileRoute } from '@tanstack/react-router'
+import SupportPage from '../pages/SupportPage'
+
+export const Route = createFileRoute('/support')({
+  head: () => ({
+    meta: [{ title: 'Support - BuildInLime' }],
+  }),
+  component: SupportPage,
+})


### PR DESCRIPTION
## Summary

Adds the landing-page legal/support surface and turns the account-deletion entry into a real (email-based) request, as part of finalising the privacy policy for the Play Store submission.

### Footer
- Removed the dead **Careers** anchor.
- **Support** and **Contact** now link to real pages instead of `#` anchors.
- New **Legal** column linking to **Privacy**.

### New public pages
- **/privacy** — finalised policy from `content/privacy.ts`: DataConscientious LLP (RoC Vijayawada), 30-day post-deletion retention, India governing law, effective date. Public for logged-out users.
- **/support** — directs users to `support@buildinlime.com`.
- **/contact** — notes the app is built by [barefootprogrammers.in](https://barefootprogrammers.in) and wires a name/email/message form to `trpc.contact.send`, emailing `parthasarathi.edupally@barefootprogrammers.in` via Resend (reply-to = submitter).

### Account deletion
- Entry point moved to the **Account page**, below the user details.
- Submitting now calls `trpc.account.requestDeletion` (**authed** — identity from the server session, never client input), which emails `support@buildinlime.com` for manual action within 30 days, and downloads a client-side data snapshot.
- No automated backend purge/export yet — tracked in ARCHITECTURE.md §12.11.

### Notes
- Resend senders (`sendContactEmail`, `sendDeletionRequestEmail`) are lazily constructed so importing the `appRouter` stays side-effect-free — keeps the contract-router parity test green.
- `contact` / `account` are web-only procedures, deliberately not mirrored in `@buildinlime/contracts`.
- ARCHITECTURE.md §9/§12.11/appendix updated.
- `*.pdf` added to `.gitignore` (generated privacy PDF is not tracked).

## Testing
- `pnpm typecheck` — passes
- Contract-router parity test — passes
- Lint — no new findings in changed files
- `contact.send` / `account.requestDeletion` endpoints verified reachable and validating input

> ⚠️ Email delivery to real recipients requires a **verified Resend domain**; the dev env currently uses the `onboarding@resend.dev` test sender (owner-only delivery). This affects OTP login too.

🤖 Generated with [Claude Code](https://claude.com/claude-code)