### PR TITLE
fix(deploy): stop needrestart bouncing the network plane

### DIFF
--- a/agentGuides/deploymentPlan.md
+++ b/agentGuides/deploymentPlan.md
@@ -1482,15 +1482,57 @@ The reason to prefer this over just disabling the timer: patch deployments suppo
 started after — turning the exact failure above into a controlled restart. It also gives
 patch-compliance reporting, which a disabled timer does not.
 
-**Interim — keep unattended-upgrades but stop it restarting services.** Ubuntu 24.04
-restarts services via `needrestart` after library upgrades. Set list-only mode and
-blacklist systemd, **in `deploy/vm-bootstrap.sh`** so a rebuilt VM inherits it:
+**Interim — IMPLEMENTED** in `vm-bootstrap.sh` as
+`/etc/needrestart/conf.d/90-buildinlime.conf`, and installed on the live VM.
 
-```bash
-echo "\$nrconf{restart} = 'l';" | sudo tee /etc/needrestart/conf.d/90-no-restart.conf
-# /etc/apt/apt.conf.d/50unattended-upgrades
-Unattended-Upgrade::Package-Blacklist { "systemd"; "systemd-networkd"; "udev"; };
+**First, what the mechanism is NOT.** The obvious guess — a `systemd` package upgrade
+whose postinst restarts its own units — is wrong. `/var/log/apt/history.log` for the
+06:10 run shows `krb5-*`, `rsyslog`, `gawk`, `libpam*` and `tar`; **systemd was never
+upgraded.** The restart cascade begins at 06:10:53, two seconds after the libpam upgrade
+completes at 06:10:51. This is `needrestart` (3.6, installed, with no explicit restart
+mode, which on Ubuntu Server means fully automatic) restarting every daemon linked
+against the upgraded library. Consequently:
+
+- `Unattended-Upgrade::Package-Blacklist { "systemd"; }` would have prevented **nothing**.
+- Blacklisting `libpam` instead is not on the table; it is security-critical.
+
+So keep needrestart in automatic mode — ssh, cron and the rest *should* still restart
+after a library fix — and carve out only the network plane:
+
+```perl
+# /etc/needrestart/conf.d/90-buildinlime.conf
+$nrconf{override_rc}{qr(^systemd-networkd\.service$)} = 0;
+$nrconf{override_rc}{qr(^systemd-resolved\.service$)} = 0;
+$nrconf{override_rc}{qr(^containerd\.service$)}       = 0;
+1;
 ```
+
+`docker` is already covered by stock `qr(^docker)`; `containerd` is not.
+
+> **Two traps, both found by measuring rather than reasoning.**
+>
+> **1. Use per-key assignment, never `$nrconf{override_rc} = {...}`.** conf.d is parsed
+> *after* the defaults and the README says files "override or modify any previously set
+> config option" — a whole-hash assignment **replaces** it. Measured on this VM: the
+> assigning form cut `override_rc` from **43 keys to 4**, silently dropping `^dbus`,
+> `^systemd-logind`, `^getty@`, `^docker`, `^network` and the rest. That is *worse than
+> stock* — it would cause more restarts, not fewer. The per-key form yields 46.
+>
+> **2. `override_rc => 0` means "do not restart", not "do not list".** The service is
+> still detected and still appears in `needrestart -r l -b` output, so **that listing
+> cannot be used to verify the override**. Stock config ships `qr(^dbus) => 0` and dbus
+> is still listed — yet dbus was demonstrably *not* restarted on 2026-07-24, while
+> `systemd-networkd`, which had no override, was. Verify by dumping the parsed hash:
+>
+> ```bash
+> sudo perl -e 'our %nrconf; do "/etc/needrestart/needrestart.conf";
+>   print scalar(keys %{$nrconf{override_rc}}), "\n";'   # expect 46, not 4
+> ```
+
+**The trade-off, stated explicitly:** those three services keep running against the old
+library until something restarts them, and this VM does not reboot on its own — uptime
+was 6 days at the time of the incident. That deferral is only acceptable if patching is
+actually completed on a schedule, which is the argument for the VM Manager form above.
 
 Do **not** simply `systemctl mask apt-daily-upgrade.timer` and stop there — that trades
 a sync outage for an unpatched internet-facing host. The journal already shows constant

--- a/deploy/vm-bootstrap.sh
+++ b/deploy/vm-bootstrap.sh
@@ -62,6 +62,57 @@ else
 fi
 
 # ---------------------------------------------------------------------------
+step "needrestart — protect the network plane (§13.2 fix 1)"
+# unattended-upgrades runs needrestart, which restarts every daemon linked against
+# an upgraded library. On 2026-07-24 a routine libpam security update did exactly
+# that and took systemd-networkd with it, bouncing docker0 and every container
+# veth. Electric's replication socket went half-open and never recovered: 30 hours
+# of silent sync outage, 24 GB of pinned WAL (§13.1).
+#
+# EVIDENCE, because the obvious guess is wrong: /var/log/apt/history.log shows the
+# 06:10 run upgraded krb5, rsyslog, gawk, libpam* and tar — NOT systemd. So this is
+# needrestart restarting libpam consumers, not a systemd package postinst, and
+# blacklisting `systemd` in unattended-upgrades would have prevented nothing.
+# Blacklisting libpam instead is not on the table; it is security-critical.
+#
+# So: keep needrestart in automatic mode — ssh, cron and the rest SHOULD still be
+# restarted after a library fix — and carve out only the network plane.
+mkdir -p /etc/needrestart/conf.d
+cat >/etc/needrestart/conf.d/90-buildinlime.conf <<'EOF'
+# Managed by deploy/vm-bootstrap.sh — see deploymentPlan.md §13.2.
+#
+# Never auto-restart the network plane. A restart severs Electric's logical
+# replication connection as a HALF-OPEN socket: no FIN, no RST, so Electric gets
+# no error, logs nothing and never retries (§13.1).
+#
+# 0 = deselect for restart. The service is still DETECTED and still listed by
+# `needrestart -r l`; it is simply not restarted. (Stock config ships qr(^dbus)
+# => 0 for exactly this reason, and dbus was indeed not restarted on 2026-07-24
+# while systemd-networkd, which had no override, was.)
+#
+# PER-KEY assignment, NOT `$nrconf{override_rc} = {...}`. conf.d is parsed AFTER
+# the defaults, so a whole-hash assignment REPLACES them — measured on this VM:
+# it cut override_rc from 43 keys to 4, silently dropping dbus, systemd-logind,
+# getty@, docker, network and the rest, which would cause MORE restarts than
+# stock. Add keys; never assign the hash.
+#
+# docker is already covered by the stock qr(^docker). containerd is not.
+$nrconf{override_rc}{qr(^systemd-networkd\.service$)} = 0;
+$nrconf{override_rc}{qr(^systemd-resolved\.service$)} = 0;
+$nrconf{override_rc}{qr(^containerd\.service$)}       = 0;
+1;
+EOF
+
+# TRADE-OFF, stated explicitly: these four keep running against the OLD library
+# until something restarts them, and this VM does not reboot on its own (uptime
+# was 6 days at the time of the incident). That deferral is accepted because a
+# silent replication outage is worse than a delayed restart — but it is only safe
+# if patching is actually completed on a schedule. Pair this with a deliberate
+# reboot/patch window; the GCP-native form is a VM Manager patch deployment with
+# pre/post scripts that stop and start Electric cleanly (§13.2).
+echo "  network plane exempted from needrestart auto-restart"
+
+# ---------------------------------------------------------------------------
 step "Electric data disk → ${ELECTRIC_MNT}"
 if [[ ! -e "$ELECTRIC_DEV" ]]; then
   echo "  !! ${ELECTRIC_DEV} not found — was the disk attached with"


### PR DESCRIPTION
Follow-up to #73. That PR added the **watchdog**, which bounds how long an Electric replication outage lasts (~5 min instead of 30 h). This one addresses the **trigger**, so it stops happening.

## The mechanism — and why the obvious guess is wrong

On 2026-07-24, `needrestart` (run by unattended-upgrades) restarted `systemd-networkd`, bouncing `docker0` and every container veth, severing Electric's replication socket as a half-open connection it never noticed (#73, §13.1).

The intuitive culprit would be a `systemd` package upgrade whose postinst restarts its own units. **The evidence says otherwise.** `/var/log/apt/history.log` for the 06:10 run:

```
Start-Date: 2026-07-24  06:10:48
Commandline: /usr/bin/unattended-upgrade
Upgrade: libpam-runtime, libpam-modules, libpam-modules-bin, libpam0g
End-Date: 2026-07-24  06:10:51
```

`krb5-*`, `rsyslog`, `gawk`, `libpam*`, `tar` — **systemd was never upgraded.** The restart cascade begins at 06:10:53, two seconds after the libpam upgrade completes, and reaches `systemd-networkd` at 06:10:58. This is needrestart restarting every daemon linked against the upgraded library. Therefore:

- `Unattended-Upgrade::Package-Blacklist { "systemd"; }` would have prevented **nothing**.
- Blacklisting `libpam` instead is not on the table — it's security-critical.

## The fix

Keep needrestart in automatic mode — ssh, cron and the rest *should* still restart after a library fix — and exempt only the network plane:

```perl
# /etc/needrestart/conf.d/90-buildinlime.conf
$nrconf{override_rc}{qr(^systemd-networkd\.service$)} = 0;
$nrconf{override_rc}{qr(^systemd-resolved\.service$)} = 0;
$nrconf{override_rc}{qr(^containerd\.service$)}       = 0;
1;
```

`docker` is already covered by stock `qr(^docker)`; `containerd` is not.

## Two traps, both found by measuring rather than reasoning

**1. Per-key assignment is required — never `$nrconf{override_rc} = {...}`.**

conf.d is parsed *after* the defaults, and the shipped README says files "override or modify any previously set config option" — a whole-hash assignment **replaces** it. Measured on the live VM:

| form | `override_rc` keys |
|---|---|
| stock | 43 |
| whole-hash assignment (my first draft) | **4** |
| per-key assignment (this PR) | 46 |

The assigning form silently dropped `^dbus`, `^systemd-logind`, `^getty@`, `^docker`, `^network` and the rest — **worse than stock**, causing more restarts, not fewer.

**2. `override_rc => 0` means "do not restart", not "do not list".**

The service is still detected and still appears in `needrestart -r l -b`, so **that listing cannot be used to verify the override** — an attempt to verify it that way gave a false negative and nearly sent me down the wrong path. Stock ships `qr(^dbus) => 0` and dbus is still listed, yet dbus was demonstrably *not* restarted on Jul 24 while `systemd-networkd`, which had no override, was.

Verify by dumping the parsed hash instead:

```bash
sudo perl -e 'our %nrconf; do "/etc/needrestart/needrestart.conf";
  print scalar(keys %{$nrconf{override_rc}}), "\n";'   # expect 46, not 4
```

## Trade-off, accepted deliberately

Those three services keep running against the old library until something restarts them, and this VM does not reboot on its own — uptime was 6 days at the time of the incident. **That deferral is only acceptable if patching actually completes on a schedule**, which is the argument for the VM Manager patch-deployment form still open in §13.2.

Not doing `systemctl mask apt-daily-upgrade.timer` — that would trade a sync outage for an unpatched internet-facing host, and the journal shows constant SSH brute-force against this VM.

## Verified on the live VM

| test | result |
|---|---|
| `override_rc` after fix | 46 keys, `dbus` + `systemd-logind` preserved |
| my three entries present | `systemd-networkd`, `systemd-resolved`, `containerd` |
| `needrestart -r l -b` | parses clean, exit 0 |

## Deployment note

`vm-bootstrap.sh` runs at provisioning, not in `deploy.sh`. Merging changes nothing on the running VM — the drop-in is already installed there (14:57 UTC). This commit ensures a rebuilt VM inherits it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BzFXLvAdGTqEMDcGxKLAFw
