### PR TITLE
fix(channels): let a soft-deleted channel release its name

### DIFF
--- a/web-app/code/src/infrastructure/trpc/routers/channels.ts
+++ b/web-app/code/src/infrastructure/trpc/routers/channels.ts
@@ -39,12 +39,25 @@ export const channelsRouter = router({
         throw new TRPCError({ code: `FORBIDDEN`, message: `Only project owners can create channels` })
       }
 
-      // Prevent duplicate channel names within the same build unit
+      // Prevent duplicate channel names within the same build unit.
+      //
+      // isNull(deleted_at) is load-bearing: a SOFT-DELETED channel must RELEASE its
+      // name. Without it, deleting a channel permanently burns that name for the
+      // build unit — the row still matches here, so the create is rejected with
+      // "already exists" while the user can see no such channel anywhere (the
+      // channels shape filters deleted_at IS NULL, so it is not even synced to them).
+      // That is an unrecoverable dead end from the user's side.
+      //
+      // Same predicate, same reason as the tasks table's partial unique index
+      // `(channel_id, lower(name)) WHERE deleted_at IS NULL` — see ARCHITECTURE §4,
+      // which calls that WHERE clause out explicitly for letting a deleted task
+      // release its name.
       const [duplicate] = await ctx.db
         .select({ id: channelsTable.id })
         .from(channelsTable)
         .where(and(
           eq(channelsTable.buildunit_id, input.buildunit_id),
+          isNull(channelsTable.deleted_at),
           sql`CAST(${channelsTable.name} AS text) = ${JSON.stringify(input.name)}`
         ))
       if (duplicate) {


### PR DESCRIPTION
## The bug

Deleting a channel **permanently burned its name** for that build unit. Recreating a channel of the same type failed with `CONFLICT — A <name> channel already exists in this build unit`.

The duplicate check in `channels.create` matched any row with the same `name` + `buildunit_id`, including soft-deleted ones:

```js
.where(and(
  eq(channelsTable.buildunit_id, input.buildunit_id),
  sql`CAST(${channelsTable.name} AS text) = ${JSON.stringify(input.name)}`
))
```

## Why it was worse than it looks

From the user's side this is an **unrecoverable dead end, and an invisible one**. The channels shape filters `deleted_at IS NULL`, so the blocking row is never synced to any client. The app insists a channel already exists while showing no such channel anywhere, and there is nothing in the UI that can clear it — the only channel you could delete to free the name is the one already deleted.

## The fix

Add `isNull(channelsTable.deleted_at)` to the check.

This is the same predicate, for the same reason, as the tasks table's partial unique index `(channel_id, lower(name)) WHERE deleted_at IS NULL`. ARCHITECTURE §4 calls that `WHERE` clause out explicitly:

> The `WHERE deleted_at IS NULL` predicate lets a deleted task release its name.

Channels got the soft-delete (`deleted_at`, `deleted_by_id`, cascade to tasks and resources) but never the matching predicate on the uniqueness check.

## Scope

`channels.update` has **no** duplicate check at all, so a rename can still collide. Left alone deliberately — it's a separate pre-existing gap, and unreachable from the UI today since the create form is the only place a channel name is chosen.

## Verification

- `npx tsc --noEmit` — clean
- `npx vitest run --dir tests/unit` — 141 passed, 5 skipped

Manual check: delete a channel, then create one of the same type in the same build unit. Previously `CONFLICT`; now succeeds. Creating a duplicate of a *live* channel still correctly conflicts.

## Not included

A follow-up was scoped and dropped: allowing arbitrary custom channel names. Decision was to keep the fixed seven and add names on request, which preserves the closed `ChannelName` union, the exhaustive `CHANNEL_ICONS` map, and URL safety (on web the channel name *is* the route segment).

Worth flagging for whoever does add a name: **the seven names exist in four places** and only one is canonical — `packages/domain-types/src/shared.ts`, a second independent copy in `schema/organization-tables.ts:63`, and two more hardcoded in `NewChannelButton.tsx` (the form type and the dropdown array). Adding a name to `domain-types` alone will **not** make it appear in the picker, and only the icon map would produce a compile error. Single-sourcing those is worth doing before the first request, not after.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BzFXLvAdGTqEMDcGxKLAFw
