### PR TITLE
chore: gitignore mobile build artifacts at any depth

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -90,3 +90,15 @@ web-app/code/playwright-report/
 web-app/code/blob-report/
 web-app/code/playwright/.cache/
 web-app/code/tests/e2e/.auth/
+
+# Mobile build artifacts, ANYWHERE in the tree.
+#
+# mobile-app/.gitignore already covers these, but only within mobile-app/. Builds
+# downloaded from EAS land wherever the person downloading them puts them — usually
+# the repo root, which nothing was ignoring. A production .aab is ~69 MB, so a stray
+# `git add -A` commits it, and once pushed the only way out is a history rewrite.
+# EAS retains every artifact at its archive URL indefinitely, so there is never a
+# reason to commit one.
+*.apk
+*.aab
+*.ipa


### PR DESCRIPTION
One-line-ish safety net, prompted by a real near-miss.

`mobile-app/.gitignore` already covers `*.apk` / `*.aab` / `*.ipa` — but **only within `mobile-app/`**. Artifacts downloaded from EAS land wherever the person downloading them puts them, which in practice is the repo root. Nothing was ignoring that.

The production `.aab` is **69 MB**. Sitting untracked at the root, a stray `git add -A` commits it, and once pushed the only way out is a history rewrite. EAS retains every artifact at its archive URL indefinitely, so there is never a reason to commit one.

**Verified:** with the production `.aab` at the repo root, `git status` goes from `?? buildinlime-1.0.0-vc2.aab` to clean, `git check-ignore -v` resolves to `.gitignore:103:*.aab`, and the file stays on disk.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BzFXLvAdGTqEMDcGxKLAFw
