### PR TITLE
Make the marketing pages usable on mobile

### DIFF
--- a/web-app/code/package.json
+++ b/web-app/code/package.json
@@ -20,6 +20,8 @@
     "test:integration": "vitest run --project integration",
     "test:e2e": "playwright test",
     "test:e2e:ui": "playwright test --ui",
+    "test:responsive": "playwright test -c playwright.responsive.config.ts",
+    "test:responsive:ui": "playwright test -c playwright.responsive.config.ts --ui",
     "e2e:up": "docker compose -f docker-compose.e2e.yaml -p buildinlime-e2e up -d --wait",
     "e2e:down": "docker compose -f docker-compose.e2e.yaml -p buildinlime-e2e down -v",
     "typecheck": "tsc --noEmit",

--- a/web-app/code/playwright.responsive.config.ts
+++ b/web-app/code/playwright.responsive.config.ts
@@ -1,0 +1,82 @@
+import { defineConfig, devices } from "@playwright/test"
+
+// -----------------------------------------------------------------------------
+// Responsive / layout E2E for the PUBLIC marketing pages.
+//
+// Deliberately a separate config from playwright.config.ts rather than another
+// project inside it. That config's globalSetup seeds Postgres and signs a session
+// cookie, so every project under it inherits a hard dependency on `pnpm e2e:up`.
+// Nothing here is authenticated — these are the logged-out marketing routes — so
+// paying for a database to assert a page does not scroll sideways would mean the
+// check gets skipped locally, which is exactly when it needs to run.
+//
+// Run with: pnpm test:responsive
+// -----------------------------------------------------------------------------
+
+const BASE_URL = "http://localhost:3000"
+
+export default defineConfig({
+  testDir: "./tests/responsive",
+  fullyParallel: true,
+  forbidOnly: !!process.env.CI,
+  retries: process.env.CI ? 2 : 0,
+  timeout: 60_000,
+  expect: { timeout: 15_000 },
+  reporter: process.env.CI
+    ? [["github"], ["html", { open: "never" }]]
+    : [["list"], ["html", { open: "never" }]],
+  use: {
+    baseURL: BASE_URL,
+    trace: "retain-on-failure",
+    ignoreHTTPSErrors: true,
+  },
+  // The widths the layout has to survive: a phone and a tablet, both below the
+  // lg: breakpoint (1024px) where the mobile rules apply, and a desktop above it
+  // where the original design must be untouched.
+  //
+  // All Chromium. What these assert is layout at a given width and touch-target
+  // geometry, neither of which is engine-specific, and requiring WebKit would
+  // mean the suite does not run on a stock Linux checkout — `playwright install
+  // webkit` additionally needs system libraries behind sudo. Set PW_WEBKIT=1 to
+  // add a real Safari run, which is worth doing before a release: iOS is where
+  // the safe-area insets and the input-zoom behaviour actually differ.
+  projects: [
+    { name: "mobile", use: { ...devices["Pixel 7"] } },
+    {
+      name: "tablet",
+      // Explicit rather than devices["iPad Mini"], which is WebKit-only.
+      use: {
+        ...devices["Desktop Chrome"],
+        viewport: { width: 768, height: 1024 },
+        isMobile: true,
+        hasTouch: true,
+        deviceScaleFactor: 2,
+      },
+    },
+    { name: "desktop", use: { ...devices["Desktop Chrome"] } },
+    ...(process.env.PW_WEBKIT
+      ? [{ name: "mobile-ios", use: { ...devices["iPhone 13"] } }]
+      : []),
+  ],
+  webServer: {
+    command: "pnpm dev",
+    url: BASE_URL,
+    reuseExistingServer: true,
+    timeout: 180_000,
+    stdout: "pipe",
+    stderr: "pipe",
+    env: {
+      // The marketing routes never touch the database, but the server module
+      // graph is loaded eagerly and several modules construct clients at import
+      // time (Resend in sendEmailOtp.ts, notably). These keep boot from throwing
+      // on a machine with no .env and no docker stack running.
+      DATABASE_URL: "postgresql://postgres:password@localhost:54322/electric",
+      BETTER_AUTH_SECRET: "responsive-e2e-secret-min-32-chars-0001",
+      BETTER_AUTH_URL: BASE_URL,
+      RESEND_API_KEY: "re_responsive_dummy_not_used",
+      NODE_ENV: "development",
+      PORT: "3000",
+      DISABLE_CADDY: "true",
+    },
+  },
+})

--- a/web-app/code/src/presentation/components/buildInlime/ArticleList.tsx
+++ b/web-app/code/src/presentation/components/buildInlime/ArticleList.tsx
@@ -16,7 +16,7 @@ export type ArticleListProps = {
 
 export function ArticleList({ articles }: ArticleListProps) {
   return (
-    <div className="w-full px-[120px] pb-[40px]">
+    <div className="w-full px-6 lg:px-[120px] pb-[40px]">
       <div className="max-w-[788px] mx-auto flex flex-col">
         {articles.map((article) => (
           <article

--- a/web-app/code/src/presentation/components/buildInlime/ArticleList.tsx
+++ b/web-app/code/src/presentation/components/buildInlime/ArticleList.tsx
@@ -8,7 +8,7 @@
  */
 
 import { CategoryChip } from "./CategoryChip";
-import type { Article } from "../../content/articles";
+import { articleSlug, type Article } from "../../content/articles";
 
 export type ArticleListProps = {
   articles: Article[];
@@ -21,7 +21,10 @@ export function ArticleList({ articles }: ArticleListProps) {
         {articles.map((article) => (
           <article
             key={article.title}
-            className="flex flex-col gap-[12px] py-[40px] border-b border-border first:pt-0 last:border-b-0"
+            id={articleSlug(article)}
+            // scroll-mt keeps the heading clear of the top edge when a
+            // /resources link lands here via the URL hash.
+            className="flex flex-col gap-[12px] py-[40px] border-b border-border first:pt-0 last:border-b-0 scroll-mt-[24px]"
           >
             <h2
               className="font-['Instrument_Sans',sans-serif] font-semibold text-[22px] leading-[31px] text-black"

--- a/web-app/code/src/presentation/components/buildInlime/ArticleList.tsx
+++ b/web-app/code/src/presentation/components/buildInlime/ArticleList.tsx
@@ -8,7 +8,8 @@
  */
 
 import { CategoryChip } from "./CategoryChip";
-import { articleSlug, type Article } from "../../content/articles";
+import { articleSlug } from "../../content/articles";
+import type { Article } from "../../content/articles";
 
 export type ArticleListProps = {
   articles: Article[];

--- a/web-app/code/src/presentation/components/buildInlime/FeatureSection.tsx
+++ b/web-app/code/src/presentation/components/buildInlime/FeatureSection.tsx
@@ -22,7 +22,7 @@ function PlatformChip({ label }: { label: string }) {
 
 export function FeatureSection({ group }: { group: FeatureGroup }) {
   return (
-    <section className="w-full px-[120px] py-[28px]">
+    <section className="w-full px-6 lg:px-[120px] py-[28px]">
       <div className="max-w-[1270px] mx-auto flex flex-col gap-[20px]">
         {/* Section heading */}
         <div className="flex flex-col gap-[8px]">
@@ -37,7 +37,9 @@ export function FeatureSection({ group }: { group: FeatureGroup }) {
           </p>
         </div>
 
-        <ul className="grid grid-cols-2 gap-[20px]">
+        {/* Two columns of cards need roughly 600px each to keep the name and the
+            platform chip on one line; below lg: they stack. */}
+        <ul className="grid grid-cols-1 lg:grid-cols-2 gap-[20px]">
           {group.features.map((feature) => (
             <li
               key={feature.name}

--- a/web-app/code/src/presentation/components/buildInlime/FeaturesCarousel.tsx
+++ b/web-app/code/src/presentation/components/buildInlime/FeaturesCarousel.tsx
@@ -31,53 +31,71 @@ export function FeaturesCarousel() {
   };
 
   return (
-    <section className="w-full px-[120px] py-[40px]">
+    <section className="w-full px-6 lg:px-[120px] py-[40px]">
       <div className="max-w-[1271px] mx-auto">
         <div className="relative bg-white rounded-[5px] overflow-hidden border border-gray-100">
           {/* Content */}
-          <div className="px-[32px] py-[32px] h-[400px] flex flex-col">
+          {/*
+            min-h rather than h: the slide copy wraps to roughly twice the lines
+            on a phone, and a hard 400px clipped it behind the pagination
+            controls. The floor keeps the box from resizing as slides change,
+            which is what the fixed height was actually for. pb leaves room for
+            the absolutely-positioned controls below.
+          */}
+          <div className="px-[24px] lg:px-[32px] pt-[24px] lg:pt-[32px] pb-[96px] lg:pb-[32px] min-h-[400px] flex flex-col">
             <h2
-              className="font-['Instrument_Sans',sans-serif] font-semibold text-[30px] leading-[36px] text-black mb-[16px]"
+              className="font-['Instrument_Sans',sans-serif] font-semibold text-[24px] leading-[30px] lg:text-[30px] lg:leading-[36px] text-black mb-[16px]"
               style={{ fontVariationSettings: "'wdth' 100" }}
             >
               {slides[currentSlide].heading}
             </h2>
             <p
-              className="font-['Instrument_Sans',sans-serif] text-[18px] leading-[28px] text-muted-foreground max-w-[666px]"
+              className="font-['Instrument_Sans',sans-serif] text-[16px] leading-[26px] lg:text-[18px] lg:leading-[28px] text-muted-foreground max-w-[666px]"
               style={{ fontVariationSettings: "'wdth' 100" }}
             >
               {slides[currentSlide].description}
             </p>
           </div>
 
-          {/* Pagination Dots */}
-          <div className="absolute bottom-[32px] left-[32px] flex items-center gap-[8px]">
+          {/* Pagination Dots — the dot itself is 8px tall, far under a usable
+              touch target, so the visual moves into a span and the button
+              becomes a 44px-tall invisible hit area around it.
+
+              That padding is mouse-hostile rather than helpful, and it shifts
+              where the dots sit, so at lg: the button collapses back onto the
+              dot and the row is pixel-identical to the original design. */}
+          <div className="absolute bottom-[16px] lg:bottom-[32px] left-[12px] lg:left-[32px] flex items-center lg:gap-[8px]">
             {slides.map((_, index) => (
               <button
                 key={index}
                 onClick={() => setCurrentSlide(index)}
-                className={`h-[8px] rounded-full transition-all ${
-                  index === currentSlide
-                    ? "bg-primary w-[24px]"
-                    : "bg-secondary w-[8px]"
-                }`}
+                className="flex items-center justify-center h-[44px] w-[22px] lg:h-[8px] lg:w-auto"
                 aria-label={`Go to slide ${index + 1}`}
-              />
+                aria-current={index === currentSlide}
+              >
+                <span
+                  className={`block h-[8px] rounded-full transition-all ${
+                    index === currentSlide
+                      ? "bg-primary w-[24px]"
+                      : "bg-secondary w-[8px]"
+                  }`}
+                />
+              </button>
             ))}
           </div>
 
           {/* Navigation Buttons */}
-          <div className="absolute bottom-[32px] right-[32px] flex items-center gap-[8px]">
+          <div className="absolute bottom-[22px] lg:bottom-[32px] right-[24px] lg:right-[32px] flex items-center gap-[8px]">
             <button
               onClick={handlePrevSlide}
-              className="bg-white border-[0.917px] border-border w-[40px] h-[40px] rounded-full flex items-center justify-center hover:bg-card-surface transition-colors"
+              className="bg-white border-[0.917px] border-border w-[44px] h-[44px] lg:w-[40px] lg:h-[40px] rounded-full flex items-center justify-center hover:bg-card-surface transition-colors"
               aria-label="Previous slide"
             >
               <ChevronLeft className="w-4 h-4 text-primary" strokeWidth={2} />
             </button>
             <button
               onClick={handleNextSlide}
-              className="bg-white border-[0.917px] border-border w-[40px] h-[40px] rounded-full flex items-center justify-center hover:bg-card-surface transition-colors"
+              className="bg-white border-[0.917px] border-border w-[44px] h-[44px] lg:w-[40px] lg:h-[40px] rounded-full flex items-center justify-center hover:bg-card-surface transition-colors"
               aria-label="Next slide"
             >
               <ChevronRight className="w-4 h-4 text-primary" strokeWidth={2} />

--- a/web-app/code/src/presentation/components/buildInlime/Footer.tsx
+++ b/web-app/code/src/presentation/components/buildInlime/Footer.tsx
@@ -12,10 +12,15 @@ export function Footer({ compact = false }: { compact?: boolean } = {}) {
   }
 
   return (
-    <footer className="w-full px-[120px] py-[56px] border-t border-border mt-auto">
-      <div className="max-w-[1268px] mx-auto flex items-start gap-[60px]">
+    <footer className="w-full px-6 lg:px-[120px] py-[56px] border-t border-border mt-auto">
+      {/*
+        Five fixed-width columns (220px + 4×284.15px + gaps) come to well over
+        1400px, so below lg: they are a grid instead: one column on a phone, two
+        on a tablet. The widths only apply once the row can actually hold them.
+      */}
+      <div className="max-w-[1268px] mx-auto grid grid-cols-1 sm:grid-cols-2 lg:flex lg:items-start gap-[32px] lg:gap-[60px]">
         {/* Logo — links to the home page, with the copyright sitting under it */}
-        <div className="flex flex-col gap-[16px] shrink-0 w-[220px]">
+        <div className="flex flex-col gap-[16px] shrink-0 w-full sm:col-span-2 lg:col-span-1 lg:w-[220px]">
           <Link to="/" className="hover:opacity-80 transition-opacity w-fit">
             <img
               src={imgBrickPattern}
@@ -27,7 +32,7 @@ export function Footer({ compact = false }: { compact?: boolean } = {}) {
         </div>
 
         {/* Resources */}
-        <div className="flex flex-col gap-[16px] w-[284.15px]">
+        <div className="flex flex-col gap-[16px] w-full lg:w-[284.15px]">
           <h3
             className="font-['Instrument_Sans',sans-serif] font-medium text-[16px] leading-[24px] text-black"
             style={{ fontVariationSettings: "'wdth' 100" }}
@@ -57,7 +62,7 @@ export function Footer({ compact = false }: { compact?: boolean } = {}) {
         </div>
 
         {/* Product */}
-        <div className="flex flex-col gap-[16px] w-[284.15px]">
+        <div className="flex flex-col gap-[16px] w-full lg:w-[284.15px]">
           <h3
             className="font-['Instrument_Sans',sans-serif] font-medium text-[16px] leading-[24px] text-black"
             style={{ fontVariationSettings: "'wdth' 100" }}
@@ -96,7 +101,7 @@ export function Footer({ compact = false }: { compact?: boolean } = {}) {
         </div>
 
         {/* Company */}
-        <div className="flex flex-col gap-[16px] w-[284.15px]">
+        <div className="flex flex-col gap-[16px] w-full lg:w-[284.15px]">
           <h3
             className="font-['Instrument_Sans',sans-serif] font-medium text-[16px] leading-[24px] text-black"
             style={{ fontVariationSettings: "'wdth' 100" }}
@@ -126,7 +131,7 @@ export function Footer({ compact = false }: { compact?: boolean } = {}) {
         </div>
 
         {/* Legal */}
-        <div className="flex flex-col gap-[16px] w-[284.15px]">
+        <div className="flex flex-col gap-[16px] w-full lg:w-[284.15px]">
           <h3
             className="font-['Instrument_Sans',sans-serif] font-medium text-[16px] leading-[24px] text-black"
             style={{ fontVariationSettings: "'wdth' 100" }}
@@ -152,7 +157,7 @@ export function Footer({ compact = false }: { compact?: boolean } = {}) {
 
 function CompactFooter() {
   return (
-    <footer className="w-full px-[120px] py-[22px] border-t border-border mt-auto">
+    <footer className="w-full px-6 lg:px-[120px] py-[22px] border-t border-border mt-auto">
       <div className="max-w-[1268px] mx-auto flex items-center justify-center">
         <Copyright />
       </div>

--- a/web-app/code/src/presentation/components/buildInlime/Header.tsx
+++ b/web-app/code/src/presentation/components/buildInlime/Header.tsx
@@ -5,14 +5,17 @@ import {
   HEADER_LINK_STYLE,
 } from "./shared/HeaderShell";
 import { MarketingNav } from "./shared/MarketingNav";
+import { MarketingMobileMenu } from "./shared/MobileMenu";
 
 export function Header() {
   return (
     <HeaderShell>
       <MarketingNav />
 
-      {/* CTA Buttons */}
-      <div className="flex items-center gap-[16px]">
+      {/* CTA Buttons — the desktop pair. Hidden below `lg:`, where the same two
+          actions live inside the mobile menu (and route through the
+          desktop-recommended notice on the way to /login). */}
+      <div className="hidden lg:flex items-center gap-[16px]">
         {/* /login's validateSearch returns both fields, so Link requires both —
             it defaults them at runtime, and the validated URL carries them
             either way, so stating them here changes nothing but the types. */}
@@ -33,6 +36,8 @@ export function Header() {
           Sign up
         </Link>
       </div>
+
+      <MarketingMobileMenu />
     </HeaderShell>
   );
 }

--- a/web-app/code/src/presentation/components/buildInlime/Hero.tsx
+++ b/web-app/code/src/presentation/components/buildInlime/Hero.tsx
@@ -2,16 +2,19 @@ import { Link } from "@tanstack/react-router";
 
 export function Hero() {
   return (
-    <section className="w-full bg-gradient-to-b from-white to-muted px-[120px] pt-[80px] pb-[80px]">
+    <section className="w-full bg-gradient-to-b from-white to-muted px-6 lg:px-[120px] pt-[48px] lg:pt-[80px] pb-[48px] lg:pb-[80px]">
       <div className="max-w-[1270px] mx-auto flex flex-col items-center gap-[24px]">
         {/* Heading */}
-        <h1 className="font-['Inria_Sans',sans-serif] font-bold text-[48px] leading-[72px] text-foreground text-center max-w-[786px]">
+        {/* 48px/72px is a desktop display size; at 390px it wraps to five lines
+            and the 72px leading opens gaps wide enough to read as separate
+            paragraphs. The mobile step keeps the leading proportional. */}
+        <h1 className="font-['Inria_Sans',sans-serif] font-bold text-[32px] leading-[42px] lg:text-[48px] lg:leading-[72px] text-foreground text-center max-w-[786px]">
           Collaboration Platform to Build Natural Homes
         </h1>
 
         {/* Paragraph */}
         <p
-          className="font-['Instrument_Sans',sans-serif] text-[20px] leading-[30px] text-black text-center max-w-[788px]"
+          className="font-['Instrument_Sans',sans-serif] text-[17px] leading-[26px] lg:text-[20px] lg:leading-[30px] text-black text-center max-w-[788px]"
           style={{ fontVariationSettings: "'wdth' 100" }}
         >
           streamlined communication between client, architect and
@@ -19,18 +22,19 @@ export function Hero() {
           and realtime-tracking
         </p>
 
-        {/* CTA Buttons */}
-        <div className="flex items-start gap-[16px]">
+        {/* CTA Buttons — side by side once there is room, stacked full-width on
+            a phone so neither button ends up a cramped tap target. */}
+        <div className="flex flex-col sm:flex-row items-stretch sm:items-start gap-[16px] w-full sm:w-auto">
           <Link
             to="/projects"
-            className="bg-primary hover:bg-primary-hover text-white px-[32px] py-[16px] rounded-[10px] font-['Instrument_Sans',sans-serif] font-medium text-[18px] leading-[28px] transition-colors"
+            className="text-center bg-primary hover:bg-primary-hover text-white px-[32px] py-[16px] rounded-[10px] font-['Instrument_Sans',sans-serif] font-medium text-[18px] leading-[28px] transition-colors"
             style={{ fontVariationSettings: "'wdth' 100" }}
           >
             Start Building
           </Link>
           <Link
             to="/features"
-            className="bg-white border-[1.833px] border-border text-primary px-[33.833px] py-[17.833px] rounded-[10px] font-['Instrument_Sans',sans-serif] font-medium text-[18px] leading-[28px] hover:bg-card-surface transition-colors"
+            className="text-center bg-white border-[1.833px] border-border text-primary px-[33.833px] py-[17.833px] rounded-[10px] font-['Instrument_Sans',sans-serif] font-medium text-[18px] leading-[28px] hover:bg-card-surface transition-colors"
             style={{ fontVariationSettings: "'wdth' 100" }}
           >
             Learn More

--- a/web-app/code/src/presentation/components/buildInlime/LoginDecorativeImage.tsx
+++ b/web-app/code/src/presentation/components/buildInlime/LoginDecorativeImage.tsx
@@ -4,8 +4,11 @@ export function LoginDecorativeImage() {
   // No top margin here: LoginPage's flex row already applies pt-[63px] to both
   // columns. Carrying mt-[63px] as well pushed the image 63px below the form it
   // is meant to sit level with.
+  // Hidden below lg: rather than scaled down. It is decorative — it carries no
+  // information the form needs — and at phone width it would push the actual
+  // sign-in form a full screen height below the fold.
   return (
-    <div className="relative overflow-hidden w-[560px] ml-[110px] h-[657px]">
+    <div className="hidden lg:block relative overflow-hidden w-[560px] ml-[110px] h-[657px]">
       <img
         src={imgJhali}
         alt="Brick staircase architecture"

--- a/web-app/code/src/presentation/components/buildInlime/LoginHeader.tsx
+++ b/web-app/code/src/presentation/components/buildInlime/LoginHeader.tsx
@@ -11,7 +11,7 @@ export function LoginHeader() {
       {/* Back to Home Link */}
       <Link
         to="/"
-        className="flex items-center gap-2 text-muted-foreground hover:text-primary transition-colors"
+        className="flex items-center gap-2 shrink-0 whitespace-nowrap text-muted-foreground hover:text-primary transition-colors"
       >
         <ArrowLeft className="w-[15px] h-[15px]" strokeWidth={1.25} />
         <span

--- a/web-app/code/src/presentation/components/buildInlime/PageHeading.tsx
+++ b/web-app/code/src/presentation/components/buildInlime/PageHeading.tsx
@@ -12,13 +12,13 @@ export function PageHeading({
   description: string;
 }) {
   return (
-    <section className="w-full bg-gradient-to-b from-white to-muted px-[120px] pt-[40px] pb-[28px]">
+    <section className="w-full bg-gradient-to-b from-white to-muted px-6 lg:px-[120px] pt-[40px] pb-[28px]">
       <div className="max-w-[1270px] mx-auto flex flex-col items-center gap-[12px]">
-        <h1 className="font-['Inria_Sans',sans-serif] font-bold text-[26px] leading-[40px] text-foreground text-center max-w-[786px]">
+        <h1 className="font-['Inria_Sans',sans-serif] font-bold text-[22px] leading-[32px] lg:text-[26px] lg:leading-[40px] text-foreground text-center max-w-[786px]">
           {title}
         </h1>
         <p
-          className="font-['Instrument_Sans',sans-serif] text-[18px] leading-[26px] text-muted-foreground text-center max-w-[788px]"
+          className="font-['Instrument_Sans',sans-serif] text-[16px] leading-[24px] lg:text-[18px] lg:leading-[26px] text-muted-foreground text-center max-w-[788px]"
           style={{ fontVariationSettings: "'wdth' 100" }}
         >
           {description}

--- a/web-app/code/src/presentation/components/buildInlime/ProseSection.tsx
+++ b/web-app/code/src/presentation/components/buildInlime/ProseSection.tsx
@@ -9,7 +9,7 @@ import type { AboutSection } from "../../content/about";
 
 export function ProseSection({ section }: { section: AboutSection }) {
   return (
-    <section className="w-full px-[120px] py-[20px]">
+    <section className="w-full px-6 lg:px-[120px] py-[20px]">
       <div className="max-w-[788px] mx-auto flex flex-col gap-[12px]">
         <h2 className="font-['Inria_Sans',sans-serif] font-bold text-[22px] leading-[31px] text-foreground">
           {section.title}

--- a/web-app/code/src/presentation/components/buildInlime/ResourceSection.tsx
+++ b/web-app/code/src/presentation/components/buildInlime/ResourceSection.tsx
@@ -8,7 +8,7 @@
 
 import { Link } from "@tanstack/react-router";
 import { CategoryChip } from "./CategoryChip";
-import type { Article } from "../../content/articles";
+import { articleSlug, type Article } from "../../content/articles";
 
 export type { Article };
 
@@ -60,7 +60,13 @@ export function ResourceSection({ title, description, to, articles }: ResourceSe
               className="font-['Instrument_Sans',sans-serif] font-semibold text-[20px] leading-[29px] text-black"
               style={{ fontVariationSettings: "'wdth' 100" }}
             >
-              {latest.title}
+              <Link
+                to={to}
+                hash={articleSlug(latest)}
+                className="hover:text-primary transition-colors"
+              >
+                {latest.title}
+              </Link>
             </h3>
 
             <p
@@ -110,7 +116,13 @@ export function ResourceSection({ title, description, to, articles }: ResourceSe
                     className="font-['Instrument_Sans',sans-serif] font-medium text-[15px] leading-[22px] text-black"
                     style={{ fontVariationSettings: "'wdth' 100" }}
                   >
-                    {article.title}
+                    <Link
+                      to={to}
+                      hash={articleSlug(article)}
+                      className="hover:text-primary transition-colors"
+                    >
+                      {article.title}
+                    </Link>
                   </h4>
                   <div className="flex items-center gap-[12px]">
                     <span

--- a/web-app/code/src/presentation/components/buildInlime/ResourceSection.tsx
+++ b/web-app/code/src/presentation/components/buildInlime/ResourceSection.tsx
@@ -8,7 +8,8 @@
 
 import { Link } from "@tanstack/react-router";
 import { CategoryChip } from "./CategoryChip";
-import { articleSlug, type Article } from "../../content/articles";
+import { articleSlug } from "../../content/articles";
+import type { Article } from "../../content/articles";
 
 export type { Article };
 

--- a/web-app/code/src/presentation/components/buildInlime/ResourceSection.tsx
+++ b/web-app/code/src/presentation/components/buildInlime/ResourceSection.tsx
@@ -25,7 +25,7 @@ export function ResourceSection({ title, description, to, articles }: ResourceSe
   const [latest, ...history] = articles;
 
   return (
-    <section className="w-full px-[120px] py-[56px]">
+    <section className="w-full px-6 lg:px-[120px] py-[56px]">
       <div className="max-w-[1270px] mx-auto flex flex-col gap-[32px]">
         {/* Section heading */}
         <div className="flex flex-col gap-[8px]">

--- a/web-app/code/src/presentation/components/buildInlime/StepSection.tsx
+++ b/web-app/code/src/presentation/components/buildInlime/StepSection.tsx
@@ -39,7 +39,7 @@ function StepNumber({ n }: { n: number }) {
 
 export function StepSection({ id, title, description, steps, children }: StepSectionProps) {
   return (
-    <section id={id} className="w-full px-[120px] py-[56px]">
+    <section id={id} className="w-full px-6 lg:px-[120px] py-[56px]">
       <div className="max-w-[1270px] mx-auto flex flex-col gap-[32px]">
         {/* Section heading */}
         <div className="flex flex-col gap-[8px]">

--- a/web-app/code/src/presentation/components/buildInlime/admin/HeaderLoggedIn.tsx
+++ b/web-app/code/src/presentation/components/buildInlime/admin/HeaderLoggedIn.tsx
@@ -4,6 +4,7 @@ import {
   HEADER_LINK_STYLE,
 } from "../shared/HeaderShell";
 import { MarketingNav } from "../shared/MarketingNav";
+import { MobileMenu } from "../shared/MobileMenu";
 
 interface HeaderLoggedInProps {
   onSignOut?: () => void;
@@ -21,7 +22,7 @@ export function HeaderLoggedIn({ onSignOut }: HeaderLoggedInProps) {
       <MarketingNav />
 
       {/* CTA Buttons - Sign out only */}
-      <div className="flex items-center gap-[16px]">
+      <div className="hidden lg:flex items-center gap-[16px]">
         <button
           onClick={handleSignOut}
           className={HEADER_LINK_CLASS}
@@ -30,6 +31,23 @@ export function HeaderLoggedIn({ onSignOut }: HeaderLoggedInProps) {
           Sign out
         </button>
       </div>
+
+      {/* No desktop-recommended notice here: this header only renders for
+          someone already signed in, so there is no sign-in to intercept. */}
+      <MobileMenu
+        authSlot={(close) => (
+          <button
+            onClick={() => {
+              close();
+              handleSignOut();
+            }}
+            className="w-full min-h-[44px] flex items-center justify-center rounded-[10px] border border-border text-primary hover:bg-card-surface transition-colors font-['Instrument_Sans',sans-serif] font-medium text-[16px] px-[24px] py-[12px]"
+            style={HEADER_LINK_STYLE}
+          >
+            Sign out
+          </button>
+        )}
+      />
     </HeaderShell>
   );
 }

--- a/web-app/code/src/presentation/components/buildInlime/shared/DesktopRecommendedNotice.tsx
+++ b/web-app/code/src/presentation/components/buildInlime/shared/DesktopRecommendedNotice.tsx
@@ -1,0 +1,152 @@
+import { useEffect, useRef } from "react"
+import { Link } from "@tanstack/react-router"
+import { Monitor } from "lucide-react"
+
+/**
+ * Shown when someone taps Login or Sign up on a viewport narrower than `lg:`.
+ *
+ * The in-app experience below that width is the desktop three-column shell —
+ * sidebar, content, task rail — which has not been adapted for a phone. Rather
+ * than let people discover that after signing in, this says so up front.
+ *
+ * It is ADVISORY, not a wall. "Continue anyway" is a real link to /login and is
+ * the primary action; someone who wants to sign in on a phone always can. It
+ * also deliberately links nowhere else: there is no published mobile app to send
+ * people to yet (Android is built but unlisted, iOS is not shipping), and a
+ * store button that 404s would be worse than no button.
+ */
+
+/** Session-scoped, so a new tab asks again but the current visit does not nag. */
+const DISMISSED_KEY = `bil.desktop-notice.dismissed`
+
+export function hasDismissedDesktopNotice(): boolean {
+  try {
+    return window.sessionStorage.getItem(DISMISSED_KEY) === `1`
+  } catch {
+    // Safari in private mode throws on sessionStorage access rather than
+    // returning null. Treat that as "not dismissed": showing the notice once
+    // too often is a far smaller failure than the alternative, which is
+    // suppressing it for everyone whose browser locks storage down.
+    return false
+  }
+}
+
+function rememberDismissal() {
+  try {
+    window.sessionStorage.setItem(DISMISSED_KEY, `1`)
+  } catch {
+    // Non-fatal — the notice simply shows again next time.
+  }
+}
+
+export interface DesktopRecommendedNoticeProps {
+  open: boolean
+  onClose: () => void
+  /** Where "Continue anyway" lands — login or signup. */
+  mode: `login` | `signup`
+  /** Carried through to /login so the post-auth redirect is unaffected. */
+  returnTo: string
+}
+
+export function DesktopRecommendedNotice({
+  open,
+  onClose,
+  mode,
+  returnTo,
+}: DesktopRecommendedNoticeProps) {
+  const dialogRef = useRef<HTMLDivElement>(null)
+
+  // Escape closes, and focus moves into the dialog so the notice is announced
+  // and keyboard users are not left behind the backdrop.
+  useEffect(() => {
+    if (!open) return
+
+    const onKeyDown = (event: KeyboardEvent) => {
+      if (event.key === `Escape`) onClose()
+    }
+    document.addEventListener(`keydown`, onKeyDown)
+    dialogRef.current?.focus()
+
+    // The backdrop covers the page, so the content behind it must not scroll
+    // under the user's finger while the notice is up.
+    const previousOverflow = document.body.style.overflow
+    document.body.style.overflow = `hidden`
+
+    return () => {
+      document.removeEventListener(`keydown`, onKeyDown)
+      document.body.style.overflow = previousOverflow
+    }
+  }, [open, onClose])
+
+  if (!open) return null
+
+  const dismiss = () => {
+    rememberDismissal()
+    onClose()
+  }
+
+  return (
+    <div className="fixed inset-0 z-50 flex items-end sm:items-center justify-center">
+      <div className="absolute inset-0 bg-black/50" onClick={dismiss} />
+
+      <div
+        ref={dialogRef}
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby="desktop-notice-title"
+        aria-describedby="desktop-notice-body"
+        tabIndex={-1}
+        className="safe-pb relative bg-white w-full sm:max-w-[420px] rounded-t-[16px] sm:rounded-[16px] p-6 pb-8 sm:pb-6 shadow-xl outline-none"
+      >
+        <div className="flex flex-col items-center gap-[16px] text-center">
+          <span
+            className="flex items-center justify-center w-[48px] h-[48px] rounded-full bg-card-surface"
+            aria-hidden="true"
+          >
+            <Monitor className="w-[24px] h-[24px] text-primary" strokeWidth={1.5} />
+          </span>
+
+          <h2
+            id="desktop-notice-title"
+            className="font-['Inria_Sans',sans-serif] font-bold text-[20px] leading-[28px] text-foreground"
+          >
+            BuildInLime works best on a desktop
+          </h2>
+
+          <p
+            id="desktop-notice-body"
+            className="font-['Instrument_Sans',sans-serif] text-[15px] leading-[22px] text-muted-foreground"
+            style={{ fontVariationSettings: "'wdth' 100" }}
+          >
+            The project workspace uses a wide, three-column layout that is not
+            built for a phone screen yet. You can still sign in here, but you
+            will have a much better time on a larger screen.
+          </p>
+
+          <div className="flex flex-col gap-[8px] w-full mt-[8px]">
+            <Link
+              to="/login"
+              search={{ returnTo, mode }}
+              onClick={dismiss}
+              className="w-full text-center bg-primary hover:bg-primary-hover text-white px-[24px] py-[14px] rounded-[10px] font-['Instrument_Sans',sans-serif] font-medium text-[16px] leading-[24px] transition-colors"
+              style={{ fontVariationSettings: "'wdth' 100" }}
+            >
+              Continue anyway
+            </Link>
+
+            <button
+              type="button"
+              onClick={dismiss}
+              className="w-full min-h-[44px] text-center px-[24px] py-[12px] rounded-[10px] font-['Instrument_Sans',sans-serif] font-medium text-[16px] leading-[24px] text-muted-foreground hover:text-foreground hover:bg-card-surface transition-colors"
+              style={{ fontVariationSettings: "'wdth' 100" }}
+            >
+              Not now
+            </button>
+          </div>
+        </div>
+      </div>
+    </div>
+  )
+}
+
+export default DesktopRecommendedNotice

--- a/web-app/code/src/presentation/components/buildInlime/shared/DesktopRecommendedNotice.tsx
+++ b/web-app/code/src/presentation/components/buildInlime/shared/DesktopRecommendedNotice.tsx
@@ -27,29 +27,6 @@ import { useIsBelowLg } from "#/hooks/use-viewport"
  * of them and needs no interception logic.
  */
 
-/** Session-scoped, so a new tab asks again but the current visit does not nag. */
-const DISMISSED_KEY = `bil.desktop-notice.dismissed`
-
-function hasDismissed(): boolean {
-  try {
-    return window.sessionStorage.getItem(DISMISSED_KEY) === `1`
-  } catch {
-    // Safari in private mode throws on sessionStorage access rather than
-    // returning null. Treat that as "not dismissed": showing the notice once too
-    // often is a far smaller failure than suppressing it for everyone whose
-    // browser locks storage down.
-    return false
-  }
-}
-
-function rememberDismissal() {
-  try {
-    window.sessionStorage.setItem(DISMISSED_KEY, `1`)
-  } catch {
-    // Non-fatal — the notice simply shows again next time.
-  }
-}
-
 export interface DesktopRecommendedNoticeProps {
   /** Dismissed by the user; the page underneath takes over. */
   onDismiss: () => void
@@ -78,10 +55,7 @@ export function DesktopRecommendedNotice({ onDismiss }: DesktopRecommendedNotice
     }
   }, [onDismiss])
 
-  const dismiss = () => {
-    rememberDismissal()
-    onDismiss()
-  }
+  const dismiss = onDismiss
 
   return (
     <div className="fixed inset-0 z-50 flex items-end sm:items-center justify-center">
@@ -153,15 +127,19 @@ export function DesktopRecommendedNotice({ onDismiss }: DesktopRecommendedNotice
  * Decides whether the notice is due, and renders it if so.
  *
  * Split from the dialog itself so the dialog has no opinion about when it
- * appears, and so the width check and the dismissal check sit in one place next
- * to each other. Mounted by LoginPage.
+ * appears. Mounted by LoginPage.
+ *
+ * Dismissal is state on THIS component and is deliberately not persisted. It
+ * lasts exactly as long as the mount, so dismissing reveals the form for the
+ * current visit and a later return to /login asks again. An earlier version
+ * remembered the dismissal in sessionStorage, which meant one "Continue anyway"
+ * silenced it for the whole tab — including sign-in attempts hours later. Each
+ * attempt is its own decision point, and the notice is one tap to clear, so the
+ * cost of re-asking is far lower than the cost of never warning again.
  */
 export function DesktopRecommendedNoticeGate() {
   const isBelowLg = useIsBelowLg()
-  // Lazily initialised because `hasDismissed` touches sessionStorage, which does
-  // not exist during SSR. Safe to read on the first client render: useIsBelowLg
-  // is false until after mount, so nothing renders on that pass anyway.
-  const [dismissed, setDismissed] = useState(() => hasDismissed())
+  const [dismissed, setDismissed] = useState(false)
 
   if (!isBelowLg || dismissed) return null
   return <DesktopRecommendedNotice onDismiss={() => setDismissed(true)} />

--- a/web-app/code/src/presentation/components/buildInlime/shared/DesktopRecommendedNotice.tsx
+++ b/web-app/code/src/presentation/components/buildInlime/shared/DesktopRecommendedNotice.tsx
@@ -1,32 +1,43 @@
-import { useEffect, useRef } from "react"
+import { useEffect, useRef, useState } from "react"
 import { Link } from "@tanstack/react-router"
 import { Monitor } from "lucide-react"
+import { useIsBelowLg } from "#/hooks/use-viewport"
 
 /**
- * Shown when someone taps Login or Sign up on a viewport narrower than `lg:`.
+ * Shown over the sign-in page when it is opened on a viewport narrower than
+ * `lg:`.
  *
  * The in-app experience below that width is the desktop three-column shell —
  * sidebar, content, task rail — which has not been adapted for a phone. Rather
  * than let people discover that after signing in, this says so up front.
  *
- * It is ADVISORY, not a wall. "Continue anyway" is a real link to /login and is
- * the primary action; someone who wants to sign in on a phone always can. It
- * also deliberately links nowhere else: there is no published mobile app to send
+ * It is ADVISORY, not a wall. "Continue anyway" is the primary action and simply
+ * dismisses, revealing the sign-in form underneath; anyone who wants to sign in
+ * on a phone always can.
+ *
+ * It deliberately links nowhere else: there is no published mobile app to send
  * people to yet (Android is built but unlisted, iOS is not shipping), and a
  * store button that 404s would be worse than no button.
+ *
+ * WHY IT LIVES ON THE PAGE rather than on the Login button: /login is reached
+ * several ways that never touch that button — the hero's "Start Building" CTA
+ * points at /projects and is bounced here by the _authenticated guard, a expired
+ * session redirects here mid-visit, and people bookmark and type URLs. Hooking
+ * the button covered the least-used of those paths. Gating on arrival covers all
+ * of them and needs no interception logic.
  */
 
 /** Session-scoped, so a new tab asks again but the current visit does not nag. */
 const DISMISSED_KEY = `bil.desktop-notice.dismissed`
 
-export function hasDismissedDesktopNotice(): boolean {
+function hasDismissed(): boolean {
   try {
     return window.sessionStorage.getItem(DISMISSED_KEY) === `1`
   } catch {
     // Safari in private mode throws on sessionStorage access rather than
-    // returning null. Treat that as "not dismissed": showing the notice once
-    // too often is a far smaller failure than the alternative, which is
-    // suppressing it for everyone whose browser locks storage down.
+    // returning null. Treat that as "not dismissed": showing the notice once too
+    // often is a far smaller failure than suppressing it for everyone whose
+    // browser locks storage down.
     return false
   }
 }
@@ -40,35 +51,24 @@ function rememberDismissal() {
 }
 
 export interface DesktopRecommendedNoticeProps {
-  open: boolean
-  onClose: () => void
-  /** Where "Continue anyway" lands — login or signup. */
-  mode: `login` | `signup`
-  /** Carried through to /login so the post-auth redirect is unaffected. */
-  returnTo: string
+  /** Dismissed by the user; the page underneath takes over. */
+  onDismiss: () => void
 }
 
-export function DesktopRecommendedNotice({
-  open,
-  onClose,
-  mode,
-  returnTo,
-}: DesktopRecommendedNoticeProps) {
+export function DesktopRecommendedNotice({ onDismiss }: DesktopRecommendedNoticeProps) {
   const dialogRef = useRef<HTMLDivElement>(null)
 
   // Escape closes, and focus moves into the dialog so the notice is announced
   // and keyboard users are not left behind the backdrop.
   useEffect(() => {
-    if (!open) return
-
     const onKeyDown = (event: KeyboardEvent) => {
-      if (event.key === `Escape`) onClose()
+      if (event.key === `Escape`) onDismiss()
     }
     document.addEventListener(`keydown`, onKeyDown)
     dialogRef.current?.focus()
 
-    // The backdrop covers the page, so the content behind it must not scroll
-    // under the user's finger while the notice is up.
+    // The backdrop covers the page, so the form behind it must not scroll under
+    // the user's finger while the notice is up.
     const previousOverflow = document.body.style.overflow
     document.body.style.overflow = `hidden`
 
@@ -76,13 +76,11 @@ export function DesktopRecommendedNotice({
       document.removeEventListener(`keydown`, onKeyDown)
       document.body.style.overflow = previousOverflow
     }
-  }, [open, onClose])
-
-  if (!open) return null
+  }, [onDismiss])
 
   const dismiss = () => {
     rememberDismissal()
-    onClose()
+    onDismiss()
   }
 
   return (
@@ -124,29 +122,49 @@ export function DesktopRecommendedNotice({
           </p>
 
           <div className="flex flex-col gap-[8px] w-full mt-[8px]">
-            <Link
-              to="/login"
-              search={{ returnTo, mode }}
-              onClick={dismiss}
-              className="w-full text-center bg-primary hover:bg-primary-hover text-white px-[24px] py-[14px] rounded-[10px] font-['Instrument_Sans',sans-serif] font-medium text-[16px] leading-[24px] transition-colors"
-              style={{ fontVariationSettings: "'wdth' 100" }}
-            >
-              Continue anyway
-            </Link>
-
             <button
               type="button"
               onClick={dismiss}
-              className="w-full min-h-[44px] text-center px-[24px] py-[12px] rounded-[10px] font-['Instrument_Sans',sans-serif] font-medium text-[16px] leading-[24px] text-muted-foreground hover:text-foreground hover:bg-card-surface transition-colors"
+              className="w-full min-h-[44px] text-center bg-primary hover:bg-primary-hover text-white px-[24px] py-[14px] rounded-[10px] font-['Instrument_Sans',sans-serif] font-medium text-[16px] leading-[24px] transition-colors"
               style={{ fontVariationSettings: "'wdth' 100" }}
             >
-              Not now
+              Continue anyway
             </button>
+
+            {/* The way out, for someone who would rather come back on a laptop.
+                A real link, not a dismiss — there is nothing on this page for
+                them if they are not signing in. */}
+            <Link
+              to="/"
+              onClick={dismiss}
+              className="w-full min-h-[44px] flex items-center justify-center text-center px-[24px] py-[12px] rounded-[10px] font-['Instrument_Sans',sans-serif] font-medium text-[16px] leading-[24px] text-muted-foreground hover:text-foreground hover:bg-card-surface transition-colors"
+              style={{ fontVariationSettings: "'wdth' 100" }}
+            >
+              Back to home
+            </Link>
           </div>
         </div>
       </div>
     </div>
   )
+}
+
+/**
+ * Decides whether the notice is due, and renders it if so.
+ *
+ * Split from the dialog itself so the dialog has no opinion about when it
+ * appears, and so the width check and the dismissal check sit in one place next
+ * to each other. Mounted by LoginPage.
+ */
+export function DesktopRecommendedNoticeGate() {
+  const isBelowLg = useIsBelowLg()
+  // Lazily initialised because `hasDismissed` touches sessionStorage, which does
+  // not exist during SSR. Safe to read on the first client render: useIsBelowLg
+  // is false until after mount, so nothing renders on that pass anyway.
+  const [dismissed, setDismissed] = useState(() => hasDismissed())
+
+  if (!isBelowLg || dismissed) return null
+  return <DesktopRecommendedNotice onDismiss={() => setDismissed(true)} />
 }
 
 export default DesktopRecommendedNotice

--- a/web-app/code/src/presentation/components/buildInlime/shared/HeaderShell.tsx
+++ b/web-app/code/src/presentation/components/buildInlime/shared/HeaderShell.tsx
@@ -13,7 +13,10 @@ import imgBrickPattern from "../../../assets/brick-logo-brown.png";
  */
 export function HeaderShell({ children }: { children: ReactNode }) {
   return (
-    <header className="w-full bg-white py-[24px] border-b border-border">
+    // `relative` makes this the positioned ancestor MobileMenu's dropdown pins
+    // itself to (`top-full`), and z-50 keeps the header — and so the menu
+    // toggle — above that menu's backdrop.
+    <header className="relative z-50 w-full bg-white py-[16px] lg:py-[24px] border-b border-border">
       <div className="max-w-[1440px] mx-auto px-6 flex items-center gap-8">
         {/* Logo — links to the home page */}
         <Link

--- a/web-app/code/src/presentation/components/buildInlime/shared/MarketingNav.tsx
+++ b/web-app/code/src/presentation/components/buildInlime/shared/MarketingNav.tsx
@@ -4,19 +4,25 @@ import { HEADER_LINK_CLASS, HEADER_LINK_STYLE } from "./HeaderShell";
 /**
  * The marketing nav, byte-identical in Header and HeaderLoggedIn before this.
  *
- * Every item links to a real page.
+ * Every item links to a real page. Exported because MobileMenu renders the same
+ * destinations below the `lg:` breakpoint, and a second hand-written copy of
+ * this list is exactly how the two would drift apart.
  */
-const ITEMS = [
+export const MARKETING_NAV_ITEMS = [
   { label: "About", to: "/about" },
   { label: "Resources", to: "/resources" },
   { label: "Get Started", to: "/get-started" },
   { label: "Pricing", to: "/pricing" },
 ] as const;
 
+/**
+ * Hidden below `lg:`: four links plus the auth CTAs stop fitting beside the logo
+ * well before the breakpoint, and MobileMenu takes over there.
+ */
 export function MarketingNav() {
   return (
-    <nav className="flex items-center gap-8 ml-auto">
-      {ITEMS.map(({ label, to }) => (
+    <nav className="hidden lg:flex items-center gap-8 ml-auto">
+      {MARKETING_NAV_ITEMS.map(({ label, to }) => (
         <Link key={label} to={to} className={HEADER_LINK_CLASS} style={HEADER_LINK_STYLE}>
           {label}
         </Link>

--- a/web-app/code/src/presentation/components/buildInlime/shared/MobileMenu.tsx
+++ b/web-app/code/src/presentation/components/buildInlime/shared/MobileMenu.tsx
@@ -1,0 +1,191 @@
+import { useEffect, useState } from "react";
+import type { ReactNode } from "react";
+import { Link } from "@tanstack/react-router";
+import { Menu, X } from "lucide-react";
+import { MARKETING_NAV_ITEMS } from "./MarketingNav";
+import { DesktopRecommendedNotice, hasDismissedDesktopNotice } from "./DesktopRecommendedNotice";
+
+/**
+ * The sub-`lg:` half of the marketing header: a hamburger that opens a
+ * full-width panel with the nav destinations and the auth actions.
+ *
+ * A dropdown panel rather than a slide-in drawer because the header is not
+ * sticky — the panel only has to cover what is directly beneath it, and a drawer
+ * would need scroll-locking and focus-trapping machinery for a five-item menu.
+ *
+ * `authSlot` is a render prop rather than a plain node because what goes in it
+ * needs to be able to CLOSE the menu: the marketing version raises a modal on
+ * top of the page, and leaving the menu open behind it means the toggle is still
+ * showing "Close menu" when the modal goes away.
+ */
+export function MobileMenu({
+  authSlot,
+}: {
+  authSlot: (close: () => void) => ReactNode;
+}) {
+  const [open, setOpen] = useState(false);
+
+  // A menu left open across a navigation would cover the page the user just
+  // asked for. The links themselves close it, but this also covers back/forward
+  // and any programmatic navigation.
+  useEffect(() => {
+    if (!open) return;
+    const close = () => setOpen(false);
+    window.addEventListener("popstate", close);
+    return () => window.removeEventListener("popstate", close);
+  }, [open]);
+
+  return (
+    <div className="lg:hidden ml-auto">
+      <button
+        type="button"
+        onClick={() => setOpen((v) => !v)}
+        aria-label={open ? "Close menu" : "Open menu"}
+        aria-expanded={open}
+        // 44px square: the icon is 24px, the rest is hit area. `relative z-50`
+        // is load-bearing — the backdrop below is a positioned sibling inside
+        // this same stacking context, so without an explicit z-index the button
+        // (z-auto, earlier in the DOM) paints UNDER it and every tap to close
+        // the menu lands on the backdrop instead.
+        className="relative z-50 flex items-center justify-center w-[44px] h-[44px] -mr-[10px] rounded text-foreground hover:bg-card-surface transition-colors"
+      >
+        {open ? (
+          <X className="w-6 h-6" aria-hidden="true" />
+        ) : (
+          <Menu className="w-6 h-6" aria-hidden="true" />
+        )}
+      </button>
+
+      {open && (
+        <>
+          {/* Tapping anywhere off the panel closes it. Also stops stray taps
+              reaching links on the page behind the open menu. */}
+          <div
+            className="fixed inset-0 z-30 bg-black/20"
+            onClick={() => setOpen(false)}
+            aria-hidden="true"
+          />
+
+          {/* top-full pins the panel to the bottom edge of the header, which is
+              the positioned ancestor (HeaderShell is `relative`). */}
+          <nav
+            aria-label="Mobile menu"
+            className="absolute top-full left-0 right-0 z-40 bg-white border-b border-border shadow-lg px-6 py-4 flex flex-col"
+          >
+            {MARKETING_NAV_ITEMS.map(({ label, to }) => (
+              <Link
+                key={label}
+                to={to}
+                onClick={() => setOpen(false)}
+                className="font-['Instrument_Sans',sans-serif] text-[16px] text-black hover:text-primary transition-colors py-[12px] min-h-[44px] flex items-center border-b border-border"
+                style={{ fontVariationSettings: "'wdth' 100" }}
+              >
+                {label}
+              </Link>
+            ))}
+
+            <div className="flex flex-col gap-[12px] pt-[16px]">
+              {authSlot(() => setOpen(false))}
+            </div>
+          </nav>
+        </>
+      )}
+    </div>
+  );
+}
+
+/**
+ * The logged-out marketing header's mobile menu: nav links plus Login / Sign up,
+ * with the desktop-recommended notice wired in.
+ *
+ * The notice is rendered as a SIBLING of the menu, not inside its panel. Inside,
+ * it would unmount the moment the menu closed — and the menu has to close, since
+ * the notice is a modal over the whole page.
+ */
+export function MarketingMobileMenu({ returnTo = "/" }: { returnTo?: string }) {
+  const [notice, setNotice] = useState<null | "login" | "signup">(null);
+
+  const actionClass =
+    "w-full text-center min-h-[44px] flex items-center justify-center rounded-[10px] font-['Instrument_Sans',sans-serif] font-medium text-[16px] px-[24px] py-[12px] transition-colors";
+
+  return (
+    <>
+      <MobileMenu
+        authSlot={(close) => (
+          <>
+            <AuthAction
+              mode="login"
+              returnTo={returnTo}
+              onIntercept={() => {
+                close();
+                setNotice("login");
+              }}
+              className={`${actionClass} border border-border text-primary hover:bg-card-surface`}
+            >
+              Login
+            </AuthAction>
+
+            <AuthAction
+              mode="signup"
+              returnTo={returnTo}
+              onIntercept={() => {
+                close();
+                setNotice("signup");
+              }}
+              className={`${actionClass} bg-primary hover:bg-primary-hover text-white`}
+            >
+              Sign up
+            </AuthAction>
+          </>
+        )}
+      />
+
+      <DesktopRecommendedNotice
+        open={notice !== null}
+        onClose={() => setNotice(null)}
+        mode={notice ?? "login"}
+        returnTo={returnTo}
+      />
+    </>
+  );
+}
+
+/**
+ * A /login link that first asks whether the user really wants the web app on
+ * this screen. Renders as a real anchor so it keeps link semantics, middle-click
+ * and "open in new tab"; the notice is raised by preventing the plain-click
+ * default only.
+ */
+function AuthAction({
+  mode,
+  returnTo,
+  onIntercept,
+  className,
+  children,
+}: {
+  mode: "login" | "signup";
+  returnTo: string;
+  onIntercept: () => void;
+  className: string;
+  children: ReactNode;
+}) {
+  return (
+    <Link
+      to="/login"
+      search={{ returnTo, mode }}
+      className={className}
+      style={{ fontVariationSettings: "'wdth' 100" }}
+      onClick={(event) => {
+        // Modified clicks are the user explicitly asking for a new tab/window —
+        // never swallow those.
+        if (event.metaKey || event.ctrlKey || event.shiftKey || event.button !== 0) return;
+        // Already told us they know; don't ask twice in one session.
+        if (hasDismissedDesktopNotice()) return;
+        event.preventDefault();
+        onIntercept();
+      }}
+    >
+      {children}
+    </Link>
+  );
+}

--- a/web-app/code/src/presentation/components/buildInlime/shared/MobileMenu.tsx
+++ b/web-app/code/src/presentation/components/buildInlime/shared/MobileMenu.tsx
@@ -3,7 +3,6 @@ import type { ReactNode } from "react";
 import { Link } from "@tanstack/react-router";
 import { Menu, X } from "lucide-react";
 import { MARKETING_NAV_ITEMS } from "./MarketingNav";
-import { DesktopRecommendedNotice, hasDismissedDesktopNotice } from "./DesktopRecommendedNotice";
 
 /**
  * The sub-`lg:` half of the marketing header: a hamburger that opens a
@@ -95,97 +94,44 @@ export function MobileMenu({
 }
 
 /**
- * The logged-out marketing header's mobile menu: nav links plus Login / Sign up,
- * with the desktop-recommended notice wired in.
+ * The logged-out marketing header's mobile menu: nav links plus Login / Sign up.
  *
- * The notice is rendered as a SIBLING of the menu, not inside its panel. Inside,
- * it would unmount the moment the menu closed — and the menu has to close, since
- * the notice is a modal over the whole page.
+ * These are plain links. The desktop-recommended notice used to be raised from
+ * here by intercepting the click, which covered only this one route to /login —
+ * the hero's "Start Building" CTA reaches it through the _authenticated
+ * redirect, and never touched this code. The notice now gates the /login page
+ * itself (see DesktopRecommendedNotice), which covers every route in and let
+ * this go back to being ordinary markup.
  */
 export function MarketingMobileMenu({ returnTo = "/" }: { returnTo?: string }) {
-  const [notice, setNotice] = useState<null | "login" | "signup">(null);
-
   const actionClass =
     "w-full text-center min-h-[44px] flex items-center justify-center rounded-[10px] font-['Instrument_Sans',sans-serif] font-medium text-[16px] px-[24px] py-[12px] transition-colors";
 
   return (
-    <>
-      <MobileMenu
-        authSlot={(close) => (
-          <>
-            <AuthAction
-              mode="login"
-              returnTo={returnTo}
-              onIntercept={() => {
-                close();
-                setNotice("login");
-              }}
-              className={`${actionClass} border border-border text-primary hover:bg-card-surface`}
-            >
-              Login
-            </AuthAction>
+    <MobileMenu
+      authSlot={(close) => (
+        <>
+          <Link
+            to="/login"
+            search={{ returnTo, mode: "login" }}
+            onClick={close}
+            className={`${actionClass} border border-border text-primary hover:bg-card-surface`}
+            style={{ fontVariationSettings: "'wdth' 100" }}
+          >
+            Login
+          </Link>
 
-            <AuthAction
-              mode="signup"
-              returnTo={returnTo}
-              onIntercept={() => {
-                close();
-                setNotice("signup");
-              }}
-              className={`${actionClass} bg-primary hover:bg-primary-hover text-white`}
-            >
-              Sign up
-            </AuthAction>
-          </>
-        )}
-      />
-
-      <DesktopRecommendedNotice
-        open={notice !== null}
-        onClose={() => setNotice(null)}
-        mode={notice ?? "login"}
-        returnTo={returnTo}
-      />
-    </>
-  );
-}
-
-/**
- * A /login link that first asks whether the user really wants the web app on
- * this screen. Renders as a real anchor so it keeps link semantics, middle-click
- * and "open in new tab"; the notice is raised by preventing the plain-click
- * default only.
- */
-function AuthAction({
-  mode,
-  returnTo,
-  onIntercept,
-  className,
-  children,
-}: {
-  mode: "login" | "signup";
-  returnTo: string;
-  onIntercept: () => void;
-  className: string;
-  children: ReactNode;
-}) {
-  return (
-    <Link
-      to="/login"
-      search={{ returnTo, mode }}
-      className={className}
-      style={{ fontVariationSettings: "'wdth' 100" }}
-      onClick={(event) => {
-        // Modified clicks are the user explicitly asking for a new tab/window —
-        // never swallow those.
-        if (event.metaKey || event.ctrlKey || event.shiftKey || event.button !== 0) return;
-        // Already told us they know; don't ask twice in one session.
-        if (hasDismissedDesktopNotice()) return;
-        event.preventDefault();
-        onIntercept();
-      }}
-    >
-      {children}
-    </Link>
+          <Link
+            to="/login"
+            search={{ returnTo, mode: "signup" }}
+            onClick={close}
+            className={`${actionClass} bg-primary hover:bg-primary-hover text-white`}
+            style={{ fontVariationSettings: "'wdth' 100" }}
+          >
+            Sign up
+          </Link>
+        </>
+      )}
+    />
   );
 }

--- a/web-app/code/src/presentation/content/articles.ts
+++ b/web-app/code/src/presentation/content/articles.ts
@@ -20,6 +20,20 @@ export type Article = {
   body: string[];
 };
 
+/**
+ * Stable anchor id for an article, derived from its title.
+ *
+ * /resources links to the full article on /blog or /documentation with this as
+ * the URL hash, and ArticleList stamps it as the `id` on the matching section —
+ * so both sides agree without an id needing to be written into the content.
+ */
+export function articleSlug(article: Pick<Article, "title">): string {
+  return article.title
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, "-")
+    .replace(/^-+|-+$/g, "");
+}
+
 export const BLOG_ARTICLES: Article[] = [
   {
     title: "Why we organize construction around BuildUnits",

--- a/web-app/code/src/presentation/hooks/use-viewport.ts
+++ b/web-app/code/src/presentation/hooks/use-viewport.ts
@@ -1,0 +1,41 @@
+import { useEffect, useState } from "react"
+
+/**
+ * The `lg:` breakpoint, in pixels. Tailwind v4's default, restated here because
+ * the desktop-recommended notice is decided in JS rather than CSS, and it must
+ * flip at exactly the width the classes do. If the theme ever overrides
+ * `--breakpoint-lg`, this is the other half of that change.
+ */
+export const LG_BREAKPOINT = 1024
+
+/**
+ * True while the viewport is narrower than `lg:`.
+ *
+ * Deliberately a WIDTH check and not a user-agent or touch check. What the
+ * caller actually cares about is whether the desktop layout fits, and that is a
+ * question about the viewport: a phone in landscape, a small window on a laptop
+ * and a tablet in portrait all want the same answer, while a touchscreen laptop
+ * at 1600px does not want the mobile treatment just for having a digitiser.
+ *
+ * Returns `false` during SSR and on the first client render, then corrects after
+ * mount. That default is deliberate: it makes the DESKTOP answer the one that
+ * renders when the width is not yet known, so the notice can never flash on a
+ * desktop browser — the failure mode of guessing wrong is asymmetric.
+ */
+export function useIsBelowLg(): boolean {
+  const [isBelow, setIsBelow] = useState(false)
+
+  useEffect(() => {
+    const query = window.matchMedia(`(max-width: ${LG_BREAKPOINT - 1}px)`)
+    // Set once on mount as well as on change — `change` only fires when the
+    // match FLIPS, so a page loaded on a phone would otherwise never hear about
+    // a state it was already in.
+    setIsBelow(query.matches)
+
+    const onChange = (event: MediaQueryListEvent) => setIsBelow(event.matches)
+    query.addEventListener(`change`, onChange)
+    return () => query.removeEventListener(`change`, onChange)
+  }, [])
+
+  return isBelow
+}

--- a/web-app/code/src/presentation/pages/BlogPage.tsx
+++ b/web-app/code/src/presentation/pages/BlogPage.tsx
@@ -12,9 +12,15 @@ export default function BlogPage() {
   };
 
   return (
-    // Fixed to the viewport: header, heading and footer stay put while the
-    // articles scroll in the middle.
-    <div className="bg-white flex flex-col h-screen overflow-hidden">
+    // Desktop pins the shell to the viewport: header, heading and footer stay
+    // put while the articles scroll in the middle.
+    //
+    // That inverts badly on a phone. An inner scroller inside a 100vh box means
+    // the document itself never scrolls, so the browser's own chrome never
+    // collapses — the address bar permanently eats a chunk of an already small
+    // screen — and overscroll rubber-bands the wrong element. Below lg: the page
+    // is therefore an ordinary document that scrolls as a whole.
+    <div className="bg-white flex flex-col min-h-screen lg:h-screen lg:overflow-hidden">
       <div className="shrink-0">
         {loggedIn ? <HeaderLoggedIn onSignOut={handleSignOut} /> : <Header />}
 
@@ -24,7 +30,7 @@ export default function BlogPage() {
         />
       </div>
 
-      <div className="flex-1 min-h-0 overflow-y-auto">
+      <div className="flex-1 min-h-0 lg:overflow-y-auto">
         <ArticleList articles={BLOG_ARTICLES} />
       </div>
 

--- a/web-app/code/src/presentation/pages/ContactPage.tsx
+++ b/web-app/code/src/presentation/pages/ContactPage.tsx
@@ -55,7 +55,7 @@ export default function ContactPage() {
         description="Have a question or want to work with us? Send us a message and we'll be in touch."
       />
 
-      <section className="w-full px-[120px] py-[20px]">
+      <section className="w-full px-6 lg:px-[120px] py-[20px]">
         <div className="max-w-[788px] mx-auto flex flex-col gap-[16px]">
           <p
             className="font-['Instrument_Sans',sans-serif] text-[16px] leading-[26px] text-black"

--- a/web-app/code/src/presentation/pages/DocumentationPage.tsx
+++ b/web-app/code/src/presentation/pages/DocumentationPage.tsx
@@ -12,9 +12,15 @@ export default function DocumentationPage() {
   };
 
   return (
-    // Fixed to the viewport: header, heading and footer stay put while the
-    // articles scroll in the middle.
-    <div className="bg-white flex flex-col h-screen overflow-hidden">
+    // Desktop pins the shell to the viewport: header, heading and footer stay
+    // put while the articles scroll in the middle.
+    //
+    // That inverts badly on a phone. An inner scroller inside a 100vh box means
+    // the document itself never scrolls, so the browser's own chrome never
+    // collapses — the address bar permanently eats a chunk of an already small
+    // screen — and overscroll rubber-bands the wrong element. Below lg: the page
+    // is therefore an ordinary document that scrolls as a whole.
+    <div className="bg-white flex flex-col min-h-screen lg:h-screen lg:overflow-hidden">
       <div className="shrink-0">
         {loggedIn ? <HeaderLoggedIn onSignOut={handleSignOut} /> : <Header />}
 
@@ -24,7 +30,7 @@ export default function DocumentationPage() {
         />
       </div>
 
-      <div className="flex-1 min-h-0 overflow-y-auto">
+      <div className="flex-1 min-h-0 lg:overflow-y-auto">
         <ArticleList articles={DOCUMENTATION_ARTICLES} />
       </div>
 

--- a/web-app/code/src/presentation/pages/GettingStartedPage.tsx
+++ b/web-app/code/src/presentation/pages/GettingStartedPage.tsx
@@ -170,7 +170,7 @@ export default function GettingStartedPage() {
       {loggedIn ? <HeaderLoggedIn onSignOut={handleSignOut} /> : <Header />}
 
       {/* Page heading */}
-      <section className="w-full bg-gradient-to-b from-white to-muted px-[120px] pt-[40px] pb-[28px]">
+      <section className="w-full bg-gradient-to-b from-white to-muted px-6 lg:px-[120px] pt-[40px] pb-[28px]">
         <div className="max-w-[1270px] mx-auto flex flex-col items-center gap-[12px]">
           <h1 className="font-['Inria_Sans',sans-serif] font-bold text-[26px] leading-[40px] text-foreground text-center max-w-[786px]">
             Getting Started

--- a/web-app/code/src/presentation/pages/LoginPage.tsx
+++ b/web-app/code/src/presentation/pages/LoginPage.tsx
@@ -1,8 +1,15 @@
 import { LoginHeader, LoginDecorativeImage , LoginForm , LoginTerms, Footer  } from "../components/buildInlime";
+import { DesktopRecommendedNoticeGate } from "../components/buildInlime/shared/DesktopRecommendedNotice";
 
 export default function LoginPage2() {
   return (
     <div className="bg-white flex flex-col min-h-screen">
+      {/* Gated on viewport width and a session flag — see the component. Mounted
+          here rather than on the Login button because /login is reached several
+          ways that never touch it (the hero CTA via the _authenticated redirect,
+          session expiry, bookmarks). */}
+      <DesktopRecommendedNoticeGate />
+
       <LoginHeader />
 
       <div className="flex-1 flex bg-white">

--- a/web-app/code/src/presentation/pages/LoginPage.tsx
+++ b/web-app/code/src/presentation/pages/LoginPage.tsx
@@ -6,11 +6,13 @@ export default function LoginPage2() {
       <LoginHeader />
 
       <div className="flex-1 flex bg-white">
-        <div className="max-w-[1440px] mx-auto w-full px-6 flex items-start gap-12 pt-[63px]">
+        <div className="max-w-[1440px] mx-auto w-full px-6 flex items-start gap-12 pt-[32px] lg:pt-[63px]">
           <LoginDecorativeImage />
 
           <div className="flex-1 flex justify-center">
-            <div className="w-[448px]">
+            {/* 448px is the form's design width, not a minimum — below it the
+                column just takes what the viewport gives. */}
+            <div className="w-full max-w-[448px]">
               <LoginForm />
               <LoginTerms />
             </div>

--- a/web-app/code/src/presentation/pages/PricingPage.tsx
+++ b/web-app/code/src/presentation/pages/PricingPage.tsx
@@ -12,9 +12,10 @@ export default function PricingPage() {
   };
 
   return (
-    // Same fixed-viewport shell as the other marketing pages: header and
-    // heading pinned, the middle scrolls, footer pinned.
-    <div className="bg-white flex flex-col h-screen overflow-hidden">
+    // Same shell as the other reading pages: pinned header/heading/footer with a
+    // scrolling middle at lg: and up, an ordinary scrolling document below it.
+    // See BlogPage for why the pinned version is wrong on a phone.
+    <div className="bg-white flex flex-col min-h-screen lg:h-screen lg:overflow-hidden">
       <div className="shrink-0">
         {loggedIn ? <HeaderLoggedIn onSignOut={handleSignOut} /> : <Header />}
 
@@ -24,8 +25,8 @@ export default function PricingPage() {
         />
       </div>
 
-      <div className="flex-1 min-h-0 overflow-y-auto">
-        <section className="px-[120px] py-[64px]">
+      <div className="flex-1 min-h-0 lg:overflow-y-auto">
+        <section className="px-6 lg:px-[120px] py-[64px]">
           <div className="max-w-[640px] mx-auto flex flex-col items-center gap-[16px] bg-icon-chip border border-card-border rounded-lg px-[40px] py-[48px]">
             <p
               className="font-['Instrument_Sans',sans-serif] font-medium text-[14px] leading-[20px] text-primary uppercase tracking-[0.08em]"

--- a/web-app/code/src/presentation/pages/PrivacyPage.tsx
+++ b/web-app/code/src/presentation/pages/PrivacyPage.tsx
@@ -17,7 +17,7 @@ export default function PrivacyPage() {
 
       <PageHeading title="Privacy Policy" description={PRIVACY_INTRO} />
 
-      <section className="w-full px-[120px] pt-[8px]">
+      <section className="w-full px-6 lg:px-[120px] pt-[8px]">
         <div className="max-w-[788px] mx-auto">
           <p
             className="font-['Instrument_Sans',sans-serif] text-[14px] leading-[20px] text-muted-foreground"

--- a/web-app/code/src/presentation/pages/SupportPage.tsx
+++ b/web-app/code/src/presentation/pages/SupportPage.tsx
@@ -19,7 +19,7 @@ export default function SupportPage() {
         description="Need a hand with BuildInLime? We're happy to help."
       />
 
-      <section className="w-full px-[120px] py-[20px]">
+      <section className="w-full px-6 lg:px-[120px] py-[20px]">
         <div className="max-w-[788px] mx-auto flex flex-col gap-[12px]">
           <h2 className="font-['Inria_Sans',sans-serif] font-bold text-[22px] leading-[31px] text-foreground">
             Contact us

--- a/web-app/code/src/presentation/routes/__root.tsx
+++ b/web-app/code/src/presentation/routes/__root.tsx
@@ -29,7 +29,11 @@ export const Route = createRootRouteWithContext<MyRouterContext>()({
       },
       {
         name: 'viewport',
-        content: 'width=device-width, initial-scale=1',
+        // viewport-fit=cover lets the page paint into the notch/home-indicator
+        // area on iOS; without it the PWA (display: standalone) letterboxes with
+        // white bands. Anything anchored to a screen edge must then pay for the
+        // inset itself — see the `safe-*` utilities in styles/index.css.
+        content: 'width=device-width, initial-scale=1, viewport-fit=cover',
       },
       {
         name: 'theme-color',

--- a/web-app/code/src/presentation/styles/index.css
+++ b/web-app/code/src/presentation/styles/index.css
@@ -2,3 +2,4 @@
 @import './fonts.css';
 @import './tailwind.css';
 @import './theme.css';
+@import './safe-area.css';

--- a/web-app/code/src/presentation/styles/safe-area.css
+++ b/web-app/code/src/presentation/styles/safe-area.css
@@ -1,0 +1,40 @@
+/*
+ * Safe-area handling, required by `viewport-fit=cover` on the viewport meta
+ * (routes/__root.tsx). That flag is what stops iOS letterboxing the standalone
+ * PWA with white bands, but it also lets the page paint UNDER the notch and the
+ * home indicator — in landscape the notch eats the left or right edge, so text
+ * pinned to the edge disappears behind it.
+ *
+ * The horizontal inset is applied globally on the root rather than per-component
+ * because every marketing section shares one gutter (`px-6 lg:px-[120px]`) and
+ * would otherwise each need to opt in. Vertical insets are NOT global: nothing
+ * in the marketing pages is fixed to the top or bottom edge, so a global
+ * padding-bottom would just add dead space above the fold. Components that do
+ * pin themselves to an edge use `.safe-pb` / `.safe-pt` below.
+ */
+
+:root {
+  --safe-top: env(safe-area-inset-top, 0px);
+  --safe-right: env(safe-area-inset-right, 0px);
+  --safe-bottom: env(safe-area-inset-bottom, 0px);
+  --safe-left: env(safe-area-inset-left, 0px);
+}
+
+html {
+  padding-left: var(--safe-left);
+  padding-right: var(--safe-right);
+  /* The insets narrow the viewport, so a child sized to 100vw would now overflow
+     by exactly the inset. box-sizing keeps that arithmetic honest. */
+  box-sizing: border-box;
+}
+
+/* For anything anchored to the top or bottom edge — a fixed bar, a bottom
+   sheet, the mobile nav panel. Additive, so it composes with existing padding
+   instead of replacing it. */
+.safe-pt {
+  padding-top: calc(var(--safe-top) + var(--safe-pt-extra, 0px));
+}
+
+.safe-pb {
+  padding-bottom: calc(var(--safe-bottom) + var(--safe-pb-extra, 0px));
+}

--- a/web-app/code/tests/responsive/layout.spec.ts
+++ b/web-app/code/tests/responsive/layout.spec.ts
@@ -1,0 +1,177 @@
+import { test, expect } from "@playwright/test"
+import type { Page } from "@playwright/test"
+
+// Every public marketing route. Kept as a literal list rather than derived from
+// the router so that adding a page is a deliberate decision to cover it.
+const MARKETING_ROUTES = [
+  "/",
+  "/about",
+  "/features",
+  "/pricing",
+  "/resources",
+  "/blog",
+  "/documentation",
+  "/get-started",
+  "/support",
+  "/contact",
+  "/privacy",
+  "/login?returnTo=%2F&mode=login",
+] as const
+
+// The single highest-value assertion in this file. Horizontal overflow is the
+// symptom of essentially every fixed-width regression — a stray `px-[120px]`, a
+// `w-[560px]` image, a `grid-cols-2` that never collapses — and unlike a visual
+// diff it has no false positives and needs no baseline to maintain.
+//
+// The 1px tolerance absorbs sub-pixel rounding at fractional device pixel
+// ratios, where scrollWidth rounds up and clientWidth rounds down on a layout
+// that genuinely fits.
+async function expectNoHorizontalOverflow(page: Page) {
+  const overflow = await page.evaluate(() => {
+    const el = document.documentElement
+    return {
+      scrollWidth: el.scrollWidth,
+      clientWidth: el.clientWidth,
+      // Naming the widest offender turns "the page overflows" into something
+      // directly actionable, which matters because the culprit is usually one
+      // element deep in a section that looks fine at desktop width.
+      widest: (() => {
+        let worst = { tag: "", cls: "", right: 0 }
+        for (const node of Array.from(document.querySelectorAll("*"))) {
+          const r = node.getBoundingClientRect()
+          if (r.right > worst.right) {
+            worst = {
+              tag: node.tagName.toLowerCase(),
+              // SVG elements carry an SVGAnimatedString here rather than a
+              // string, so this is stringified rather than read directly.
+              cls: String((node as HTMLElement).className).slice(0, 120),
+              right: Math.round(r.right),
+            }
+          }
+        }
+        return worst
+      })(),
+    }
+  })
+
+  expect(
+    overflow.scrollWidth,
+    `page scrolls horizontally (${overflow.scrollWidth}px content in a ` +
+      `${overflow.clientWidth}px viewport). Widest element: ` +
+      `<${overflow.widest.tag} class="${overflow.widest.cls}"> ` +
+      `reaching x=${overflow.widest.right}px`,
+  ).toBeLessThanOrEqual(overflow.clientWidth + 1)
+}
+
+for (const route of MARKETING_ROUTES) {
+  test(`${route} does not scroll horizontally`, async ({ page }) => {
+    await page.goto(route)
+    // Fonts change text metrics and can be what pushes a line past the edge, so
+    // measuring before they land would let a real overflow through.
+    await page.evaluate(() => document.fonts.ready)
+    await expectNoHorizontalOverflow(page)
+  })
+}
+
+test.describe("mobile-only behaviour", () => {
+  // The desktop project renders the full nav and no hamburger, so these would
+  // fail there for the right reason — skip rather than assert the inverse, which
+  // would duplicate the desktop-nav test below.
+  test.skip(
+    ({ isMobile }) => !isMobile,
+    "covers the sub-lg layout only",
+  )
+
+  test("marketing nav collapses into a menu that opens and closes", async ({
+    page,
+  }) => {
+    await page.goto("/")
+
+    const toggle = page.getByRole("button", { name: /open menu/i })
+    await expect(toggle).toBeVisible()
+
+    // Closed by default — the links must not be reachable before opening.
+    const panel = page.getByRole("navigation", { name: /mobile/i })
+    await expect(panel).toBeHidden()
+
+    await toggle.click()
+    await expect(panel).toBeVisible()
+    await expect(panel.getByRole("link", { name: "Pricing" })).toBeVisible()
+
+    await page.getByRole("button", { name: /close menu/i }).click()
+    await expect(panel).toBeHidden()
+  })
+
+  test("tapping Login shows the desktop-recommended notice instead of navigating", async ({
+    page,
+  }) => {
+    await page.goto("/")
+
+    await page.getByRole("button", { name: /open menu/i }).click()
+    await page.getByRole("navigation", { name: /mobile/i }).getByRole("link", { name: "Login" }).click()
+
+    const dialog = page.getByRole("dialog")
+    await expect(dialog).toBeVisible()
+    await expect(dialog).toContainText(/desktop/i)
+
+    // The notice is advisory, not a wall: continuing must still reach /login.
+    await dialog.getByRole("link", { name: /continue/i }).click()
+    await expect(page).toHaveURL(/\/login/)
+  })
+
+  test("the notice stays dismissed for the rest of the session", async ({
+    page,
+  }) => {
+    await page.goto("/")
+    await page.getByRole("button", { name: /open menu/i }).click()
+    await page
+      .getByRole("navigation", { name: /mobile/i })
+      .getByRole("link", { name: "Login" })
+      .click()
+
+    await page.getByRole("button", { name: /dismiss|not now/i }).click()
+    await expect(page.getByRole("dialog")).toBeHidden()
+
+    // Second attempt: the user already made the call, so do not ask again —
+    // go straight to /login.
+    await page.getByRole("button", { name: /open menu/i }).click()
+    await page
+      .getByRole("navigation", { name: /mobile/i })
+      .getByRole("link", { name: "Login" })
+      .click()
+    await expect(page).toHaveURL(/\/login/)
+  })
+
+  test("tap targets on the header meet the 44px minimum", async ({ page }) => {
+    await page.goto("/")
+
+    const toggle = page.getByRole("button", { name: /open menu/i })
+    const box = await toggle.boundingBox()
+    expect(box, "menu toggle has no layout box").not.toBeNull()
+    expect(box!.height).toBeGreaterThanOrEqual(44)
+    expect(box!.width).toBeGreaterThanOrEqual(44)
+  })
+})
+
+test.describe("desktop is unchanged", () => {
+  test.skip(({ isMobile }) => isMobile, "covers the lg: and up layout only")
+
+  test("the full nav is visible and there is no hamburger", async ({ page }) => {
+    await page.goto("/")
+
+    for (const label of ["About", "Resources", "Get Started", "Pricing"]) {
+      await expect(page.getByRole("link", { name: label }).first()).toBeVisible()
+    }
+    await expect(page.getByRole("button", { name: /open menu/i })).toBeHidden()
+  })
+
+  test("tapping Login navigates straight through, with no notice", async ({
+    page,
+  }) => {
+    await page.goto("/")
+    await page.getByRole("link", { name: "Login" }).first().click()
+
+    await expect(page).toHaveURL(/\/login/)
+    await expect(page.getByRole("dialog")).toBeHidden()
+  })
+})

--- a/web-app/code/tests/responsive/layout.spec.ts
+++ b/web-app/code/tests/responsive/layout.spec.ts
@@ -102,7 +102,7 @@ test.describe("mobile-only behaviour", () => {
     await expect(panel).toBeHidden()
   })
 
-  test("tapping Login shows the desktop-recommended notice instead of navigating", async ({
+  test("the menu's Login link reaches /login and raises the notice there", async ({
     page,
   }) => {
     await page.goto("/")
@@ -110,36 +110,51 @@ test.describe("mobile-only behaviour", () => {
     await page.getByRole("button", { name: /open menu/i }).click()
     await page.getByRole("navigation", { name: /mobile/i }).getByRole("link", { name: "Login" }).click()
 
+    await expect(page).toHaveURL(/\/login/)
     const dialog = page.getByRole("dialog")
     await expect(dialog).toBeVisible()
     await expect(dialog).toContainText(/desktop/i)
 
-    // The notice is advisory, not a wall: continuing must still reach /login.
-    await dialog.getByRole("link", { name: /continue/i }).click()
+    // Advisory, not a wall: continuing must reveal the sign-in form.
+    await dialog.getByRole("button", { name: /continue/i }).click()
+    await expect(dialog).toBeHidden()
+    await expect(page.getByRole("textbox").first()).toBeVisible()
+  })
+
+  // The regression this whole gate exists for. "Start Building" points at
+  // /projects, which the _authenticated guard bounces to /login — a route into
+  // sign-in that never touches the header, and that an interception on the Login
+  // button missed entirely.
+  test("the hero CTA lands on /login with the notice shown", async ({ page }) => {
+    await page.goto("/")
+
+    await page.getByRole("link", { name: "Start Building" }).click()
+
     await expect(page).toHaveURL(/\/login/)
+    await expect(page.getByRole("dialog")).toBeVisible()
+  })
+
+  test("arriving at /login directly shows the notice", async ({ page }) => {
+    await page.goto("/login?returnTo=%2F&mode=login")
+    await expect(page.getByRole("dialog")).toBeVisible()
   })
 
   test("the notice stays dismissed for the rest of the session", async ({
     page,
   }) => {
-    await page.goto("/")
-    await page.getByRole("button", { name: /open menu/i }).click()
+    await page.goto("/login?returnTo=%2F&mode=login")
+    // Scoped to the dialog: LoginHeader carries its own "Back to home" link, so
+    // an unscoped query matches two elements.
     await page
-      .getByRole("navigation", { name: /mobile/i })
-      .getByRole("link", { name: "Login" })
+      .getByRole("dialog")
+      .getByRole("link", { name: /back to home/i })
       .click()
-
-    await page.getByRole("button", { name: /dismiss|not now/i }).click()
     await expect(page.getByRole("dialog")).toBeHidden()
 
-    // Second attempt: the user already made the call, so do not ask again —
-    // go straight to /login.
-    await page.getByRole("button", { name: /open menu/i }).click()
-    await page
-      .getByRole("navigation", { name: /mobile/i })
-      .getByRole("link", { name: "Login" })
-      .click()
-    await expect(page).toHaveURL(/\/login/)
+    // Second arrival: the user already made the call, so do not ask again.
+    await page.goto("/login?returnTo=%2F&mode=login")
+    await expect(page.getByRole("textbox").first()).toBeVisible()
+    await expect(page.getByRole("dialog")).toBeHidden()
   })
 
   test("tap targets on the header meet the 44px minimum", async ({ page }) => {
@@ -170,6 +185,16 @@ test.describe("desktop is unchanged", () => {
   }) => {
     await page.goto("/")
     await page.getByRole("link", { name: "Login" }).first().click()
+
+    await expect(page).toHaveURL(/\/login/)
+    await expect(page.getByRole("dialog")).toBeHidden()
+  })
+
+  // The width check is what gates the notice, so a desktop arriving at /login by
+  // any route — including the hero CTA's redirect — must never see it.
+  test("the hero CTA reaches /login with no notice", async ({ page }) => {
+    await page.goto("/")
+    await page.getByRole("link", { name: "Start Building" }).click()
 
     await expect(page).toHaveURL(/\/login/)
     await expect(page.getByRole("dialog")).toBeHidden()

--- a/web-app/code/tests/responsive/layout.spec.ts
+++ b/web-app/code/tests/responsive/layout.spec.ts
@@ -139,7 +139,25 @@ test.describe("mobile-only behaviour", () => {
     await expect(page.getByRole("dialog")).toBeVisible()
   })
 
-  test("the notice stays dismissed for the rest of the session", async ({
+  test("dismissing reveals the form and does not re-prompt during that visit", async ({
+    page,
+  }) => {
+    await page.goto("/login?returnTo=%2F&mode=login")
+    await page.getByRole("dialog").getByRole("button", { name: /continue/i }).click()
+
+    await expect(page.getByRole("dialog")).toBeHidden()
+    await expect(page.getByRole("textbox").first()).toBeVisible()
+
+    // Still on /login, still dismissed — typing in the form must not bring it
+    // back mid sign-in.
+    await page.getByRole("textbox").first().fill("someone@example.com")
+    await expect(page.getByRole("dialog")).toBeHidden()
+  })
+
+  // Each sign-in attempt is its own decision point. Dismissing once must not
+  // silence the notice for the rest of the tab, which is what persisting the
+  // dismissal to sessionStorage used to do.
+  test("the notice returns on a later login attempt in the same session", async ({
     page,
   }) => {
     await page.goto("/login?returnTo=%2F&mode=login")
@@ -149,12 +167,13 @@ test.describe("mobile-only behaviour", () => {
       .getByRole("dialog")
       .getByRole("link", { name: /back to home/i })
       .click()
+    await expect(page).toHaveURL(/\/$|\/#/)
     await expect(page.getByRole("dialog")).toBeHidden()
 
-    // Second arrival: the user already made the call, so do not ask again.
-    await page.goto("/login?returnTo=%2F&mode=login")
-    await expect(page.getByRole("textbox").first()).toBeVisible()
-    await expect(page.getByRole("dialog")).toBeHidden()
+    // Same tab, same session, second attempt — via the hero CTA this time.
+    await page.getByRole("link", { name: "Start Building" }).click()
+    await expect(page).toHaveURL(/\/login/)
+    await expect(page.getByRole("dialog")).toBeVisible()
   })
 
   test("tap targets on the header meet the 44px minimum", async ({ page }) => {


### PR DESCRIPTION
Phase 1 of the web app's mobile-accessibility work, scoped to the **logged-out marketing pages**. The authenticated app shell is deliberately untouched — phone users are pointed at a desktop instead.

## Why

The marketing pages were a fixed desktop canvas: **12 responsive utilities across 146 components**, and a uniform `px-[120px]` gutter that ate 240px of a 390px phone. Every public route scrolled sideways.

## What changed

- **Gutter** `px-[120px]` → `px-6 lg:px-[120px]` across 14 files. The single change that fixes most of the overflow.
- **Header** collapses into a menu below `lg:`; nav items lifted into one shared list so the two navs can't drift.
- **Footer's** five fixed columns (220px + 4×284px ≈ 1400px) become a 1→2 column grid.
- **`FeatureSection`** grid, **Hero** CTAs, and the login page's 560px decorative image stack or drop.
- **Blog/Docs/Pricing** were `h-screen overflow-hidden` with an inner scroller — that stops mobile browser chrome from ever collapsing and rubber-bands the wrong element. They're ordinary scrolling documents below `lg:`.
- **`viewport-fit=cover`** plus safe-area insets, so the standalone PWA stops letterboxing on notched devices.

`lg:` (1024px) is the split, so tablets get the mobile layout rather than a third one to maintain.

## Desktop-recommended notice

A dismissable notice on `/login` below `lg:`, since the in-app shell isn't phone-ready:

> **BuildInLime works best on a desktop**
> The project workspace uses a wide, three-column layout that is not built for a phone screen yet. You can still sign in here, but you will have a much better time on a larger screen.
> **[ Continue anyway ]**   [ Back to home ]

No store links — Android is built but unlisted and iOS isn't shipping, so a button that 404s would be worse than none.

**It gates on arrival at `/login`, not on the Login button.** An earlier revision intercepted button clicks and missed the most prominent path on the site: "Start Building" points at `/projects` and is bounced to `/login` by the `_authenticated` guard without ever touching the header. Session-expiry redirects and bookmarks missed it for the same reason. Gating on arrival covers every route in and deleted the interception logic.

**It re-prompts on every sign-in attempt.** Dismissal is component state, not persisted. An earlier revision wrote it to `sessionStorage`, which meant one "Continue anyway" silenced the notice for the whole tab — someone returning to sign in later in the same session was never warned again. Each attempt is its own decision point, and clearing the notice is one tap, so re-asking costs less than never warning again.

## Tests

New `tests/responsive/` suite under its own Playwright config — the existing config's `globalSetup` needs Postgres, which a layout assertion shouldn't. **53 tests** across phone/tablet/desktop widths:

- All 12 marketing routes asserted free of horizontal overflow (names the widest offending element on failure)
- Menu open/close, 44px tap targets
- All three routes into `/login` (menu link, hero CTA, direct URL), dismissal behaviour, re-prompt on a later attempt, plus the desktop counterparts

Run with `pnpm test:responsive`. Chromium-only by default so it runs on a stock checkout; `PW_WEBKIT=1` adds a real Safari pass, worth doing before release since iOS is where safe-area and input-zoom actually differ.

## Verification

- 53/53 responsive tests pass; 124 unit tests pass
- `pnpm typecheck` clean
- Lint at **155 problems — exactly the `main` baseline**, zero added
- **Desktop is pixel-identical to `main`** on `/`, `/features` and `/login` (0 differing pixels, ImageMagick diff)

## Notes for the reviewer

**This branch contains `feat/resources-article-links`** (cherry-picked as `1c6e84f`, since it touched `ArticleList.tsx` which this PR also modifies). Close that branch rather than merging it separately. Its one commit arrived with 2 lint errors that were already failing on its own branch; fixed in `c0c1f1b`, kept separate so the original stays byte-identical.

**`pnpm test:responsive` is not wired into CI.** It needs no database, so it's a cheap job to add — worth doing, since the overflow guard is exactly the kind of regression that returns silently. Left out of this PR as a separate decision.

**Known label collision:** `/login` on mobile has two "Back to home" links — one in `LoginHeader`, one in the notice. Harmless in use (the header's sits behind the backdrop), but future automation against that page needs scoping.

## Not included

Phases 2–4 (app shell drawer, table/modal density, full a11y pass) are unscoped — roughly 5–7 days, and they largely rebuild in the browser what the Expo app already does natively. Phase 2 is the gate: 3 and 4 operate on screens only reachable through the shell.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
