### PR TITLE
fix: strip the two things that actually leak into production builds

### DIFF
--- a/mobile-app/app/(tabs)/offline-debug.tsx
+++ b/mobile-app/app/(tabs)/offline-debug.tsx
@@ -7,11 +7,24 @@ import {
   TouchableOpacity,
   View,
 } from "react-native"
+import { Redirect } from "expo-router"
 import type { OfflineTransaction } from "@tanstack/offline-transactions"
 import { getOfflineExecutor } from "@/src/infrastructure/offline/executor"
 import { colors } from "@/src/presentation/shared/colors"
 
-export default function OfflineDebugScreen() {
+/**
+ * The drawer only OFFERS this screen in dev (see DrawerContent), but expo-router
+ * registers routes by file presence, so in a release build
+ * `buildinlimemobile:///offline-debug` still reaches it — and "Clear outbox" below
+ * discards pending offline mutations. The nav gate is not a reachability gate, so
+ * refuse here too. Split in two so the inner component's hooks stay unconditional.
+ */
+export default function OfflineDebugRoute() {
+  if (!__DEV__) return <Redirect href="/(tabs)" />
+  return <OfflineDebugScreen />
+}
+
+function OfflineDebugScreen() {
   const [outbox, setOutbox] = useState<Array<OfflineTransaction>>([])
   const [online, setOnline] = useState(true)
   const [pending, setPending] = useState(0)

--- a/web-app/code/src/infrastructure/lib/utils/sendContactEmail.ts
+++ b/web-app/code/src/infrastructure/lib/utils/sendContactEmail.ts
@@ -66,7 +66,9 @@ export async function sendContactEmail({
       return { success: false, error: error.message };
     }
 
-    console.log(`Contact email delivered to ${CONTACT_TO} (from ${email})`);
+    // CONTACT_TO is our own config, not PII; the sender's address is, and this runs
+    // server-side in production. Drop it from the log line.
+    console.log(`Contact email delivered to ${CONTACT_TO}`);
     return { success: true };
   } catch (err) {
     console.error("Failed to send contact email:", err);

--- a/web-app/code/src/infrastructure/lib/utils/sendDeletionRequestEmail.ts
+++ b/web-app/code/src/infrastructure/lib/utils/sendDeletionRequestEmail.ts
@@ -84,7 +84,9 @@ export async function sendDeletionRequestEmail({
       return { success: false, error: error.message };
     }
 
-    console.log(`Deletion request delivered to ${DELETION_TO} for ${email}`);
+    // DELETION_TO is our own config, not PII; the requester's address is, and this
+    // runs server-side in production. Drop it from the log line.
+    console.log(`Deletion request delivered to ${DELETION_TO}`);
     return { success: true };
   } catch (err) {
     console.error("Failed to send deletion request:", err);

--- a/web-app/code/src/infrastructure/lib/utils/sendEmailOtp.ts
+++ b/web-app/code/src/infrastructure/lib/utils/sendEmailOtp.ts
@@ -59,7 +59,9 @@ export async function sendVerificationOtp({
       return { success: false, error: error.message };
     }
 
-    console.log(`OTP email sent to ${email} (type: ${type})`);
+    // No address in the log line — this runs server-side in production, and the
+    // recipient is PII. The delivery signal is what's useful operationally.
+    console.log(`OTP email sent (type: ${type})`);
     return { success: true };
   } catch (err) {
     console.error("Failed to send verification OTP:", err);


### PR DESCRIPTION
An audit of diagnostic instrumentation across the tree turned up two things that
genuinely reach a production build. Everything else that *looked* like leftover
debugging is build-time eliminated and was left alone — see "What was deliberately
not touched" below.

## 1. The offline-debug screen shipped to production and was reachable

`DrawerContent` gates the *nav item* on `__DEV__`, which reads as sufficient but isn't:
expo-router registers routes by **file presence**, and the `Drawer.Screen` declaration in
`(tabs)/_layout.tsx` is unconditional. With `"scheme": "buildinlimemobile"` in `app.json`,
`buildinlimemobile:///offline-debug` opened the screen in a release build — including its
destructive **Clear outbox** button, which discards pending offline mutations.

Verified against real production Hermes bundles (`expo export --platform android`,
`NODE_ENV=production`), before vs. after:

| string in shipped bundle | before | after |
|---|---|---|
| `Clear outbox` | 1 | **0** |
| `Force drain` | 1 | **0** |
| `No pending transactions` | 1 | **0** |
| `Outbox (` | 1 | **0** |

The fix does more than block navigation. Because the inner component is now only
referenced past a branch that is statically unreachable in production, Metro drops the
entire ~240-line screen from the bundle instead of merely hiding it.

Implemented as a wrapper + inner component on purpose: a bare `if (!__DEV__) return` ahead
of the existing `useState` calls would put hooks behind a conditional and trip
`react-hooks/rules-of-hooks`.

## 2. User email addresses written to production server logs

Three send-mail helpers logged the address on the success path. Unlike every other log
line in the codebase these are **not** DEV-guarded and they run server-side, so each wrote
PII into production logs on every OTP request, contact submission, and deletion request.

The address is dropped from all three; the delivery signal stays, since it is genuinely
useful operationally. `CONTACT_TO`/`DELETION_TO` are our own config constants, not PII, so
they remain. A DEV guard would have been the wrong fix — all three strings are present in
`dist/server` after `vite build`, i.e. the log *is* wanted in production, just not the
address.

## What was deliberately not touched

The `[rows]` row-count probes in `collections/init.ts` — the diagnostics flagged for
removal before the EAS release — do **not** leak. Neither does any of the
`[SQLite]`/`[collections]`/`[layout]`/`[OPFS]` lifecycle logging. `__DEV__` and
`import.meta.env.DEV` are statically replaced and their branches dead-code eliminated;
confirmed by 0 occurrences of `[rows]`, `scope for project`, `[SQLite]`, and `[collections]`
in the production Hermes bundle, and 0 `[OPFS]` strings in the web `dist/`.

Surviving log strings in both bundles are deliberate `console.error` failure reporting
(`[layout] Bootstrap failed:`, `[uploads] hydrate failed:`, `[collections] Init failed:`)
and carry no PII. Stripping the `[rows]` probes is still worth doing as cleanup — the
investigation they served is resolved — but it is not a release concern and is out of
scope here.

## Verification

- `pnpm typecheck` — passes clean for both web and mobile
- All four changed files lint clean. The 155 pre-existing web-app lint errors are
  unrelated: identical count with these changes stashed.
- Production builds exercised for both apps (`vite build`, `expo export`) as described above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015tAyVaJSQjWUbuJYCt7Zuy