### PR TITLE
feat(mobile): hand off to web signup when the email has no account

### DIFF
--- a/mobile-app/app/(auth)/login.tsx
+++ b/mobile-app/app/(auth)/login.tsx
@@ -3,6 +3,7 @@ import {
   ActivityIndicator,
   Image,
   KeyboardAvoidingView,
+  Linking,
   Platform,
   Text,
   TextInput,
@@ -11,6 +12,7 @@ import {
 } from "react-native"
 import { useRouter } from "expo-router"
 import { authClient } from "@/src/infrastructure/auth/client"
+import { signupUrl, signupBaseUrl } from "@/src/infrastructure/auth/signup-url"
 import { trpc } from "@/src/infrastructure/trpc/client"
 import { colors } from "@/src/presentation/shared/colors"
 
@@ -25,14 +27,22 @@ export default function LoginScreen() {
   const [otp, setOtp] = useState("")
   const [loading, setLoading] = useState(false)
   const [error, setError] = useState<string | null>(null)
+  // The address checkEmail found no account for. Held separately from `error`
+  // because this is the one failure with somewhere to GO — there is no signup in
+  // the mobile app, so the only way forward is the web one, and a plain error
+  // string left people at a dead end with no hint that an account could be made
+  // at all. Cleared on any edit to the field, so correcting a typo takes the
+  // offer away with it.
+  const [unregisteredEmail, setUnregisteredEmail] = useState<string | null>(null)
 
   async function handleContinue() {
     setError(null)
+    setUnregisteredEmail(null)
     setLoading(true)
     try {
       const result = await trpc.users.checkEmail.query({ email })
       if (!result?.exists) {
-        setError("No account found for this email address.")
+        setUnregisteredEmail(email.trim())
         setLoading(false)
         return
       }
@@ -50,6 +60,18 @@ export default function LoginScreen() {
       setError(e instanceof Error ? e.message : "Something went wrong.")
     } finally {
       setLoading(false)
+    }
+  }
+
+  async function handleCreateAccount() {
+    const target = unregisteredEmail ?? email
+    try {
+      await Linking.openURL(signupUrl(target))
+    } catch {
+      // openURL rejects when no handler can take the URL (no browser installed,
+      // or a scheme the OS will not route). Surfacing the address is the useful
+      // fallback — it is the one thing the user cannot reconstruct themselves.
+      setError(`Could not open the browser. Visit ${signupBaseUrl} to sign up.`)
     }
   }
 
@@ -114,6 +136,33 @@ export default function LoginScreen() {
           </View>
         )}
 
+        {/* No account for this address. Not styled as destructive: nothing has
+            gone wrong, the person simply has not signed up yet, and the offer
+            below is the point of the block rather than the message. Signup is
+            web-only for now, so this hands off to the browser. */}
+        {unregisteredEmail && view === "email" && (
+          <View className="bg-muted border border-border rounded-lg px-4 py-4 mb-6">
+            <Text className="text-foreground text-sm font-sans-medium mb-1">
+              No account found
+            </Text>
+            <Text className="text-muted-foreground text-sm mb-4">
+              {`We couldn't find an account for ${unregisteredEmail}. You can create one on the web, then come back here to sign in.`}
+            </Text>
+            <TouchableOpacity
+              onPress={handleCreateAccount}
+              className="bg-primary rounded-lg py-3 items-center mb-2"
+              accessibilityRole="button"
+            >
+              <Text className="text-primary-foreground font-sans-medium text-sm">
+                Create an account
+              </Text>
+            </TouchableOpacity>
+            <Text className="text-muted-foreground text-xs text-center">
+              Opens in your browser. Mistyped it? Edit the address above.
+            </Text>
+          </View>
+        )}
+
         {view === "email" ? (
           <>
             <TextInput
@@ -124,7 +173,14 @@ export default function LoginScreen() {
               autoCapitalize="none"
               autoCorrect={false}
               value={email}
-              onChangeText={setEmail}
+              // Editing the address retracts the signup offer: it was about the
+              // OLD value, and leaving it up next to a changed field would
+              // suggest the new one is unregistered too, which has not been
+              // checked yet.
+              onChangeText={(next) => {
+                setEmail(next)
+                if (unregisteredEmail) setUnregisteredEmail(null)
+              }}
               editable={!loading}
             />
             <TouchableOpacity

--- a/mobile-app/src/infrastructure/auth/signup-url.ts
+++ b/mobile-app/src/infrastructure/auth/signup-url.ts
@@ -1,0 +1,29 @@
+// Same origin the tRPC and auth clients use — the web app IS the API server, so
+// the signup page is served from it. Read the same way as every other consumer
+// in this app (trpc/client.ts, auth/client.ts, media-source.ts, …).
+const API_URL = process.env.EXPO_PUBLIC_API_URL ?? "http://10.0.2.2:3000"
+
+/** Where sign-up lives. Exported for the fallback message when no browser opens. */
+export const signupBaseUrl = `${API_URL}/login`
+
+/**
+ * The web signup page, carrying the address already typed on the mobile sign-in
+ * screen so it does not have to be entered twice.
+ *
+ * There is no signup in the mobile app — accounts are made on the web — so a
+ * failed `users.checkEmail` lookup has nowhere to go inside the app. This builds
+ * the handoff target for that case.
+ *
+ * `mode=signup` is what the web /login route's validateSearch reads to open the
+ * form in signup rather than sign-in; `email` is a PREFILL only, and the web form
+ * validates and submits it like any other input.
+ *
+ * Lives here rather than inline in the screen so the encoding is testable: an
+ * address containing `+` (Gmail's tag separator, and legal in the local part)
+ * would otherwise ride through as a space and prefill the wrong address.
+ */
+export function signupUrl(email: string): string {
+  const trimmed = email.trim()
+  if (!trimmed) return `${signupBaseUrl}?mode=signup`
+  return `${signupBaseUrl}?mode=signup&email=${encodeURIComponent(trimmed)}`
+}

--- a/mobile-app/tests/signup-url.test.ts
+++ b/mobile-app/tests/signup-url.test.ts
@@ -1,0 +1,53 @@
+import { describe, it, expect } from "vitest"
+import { signupUrl, signupBaseUrl } from "@/src/infrastructure/auth/signup-url"
+
+// The mobile app has no signup screen — accounts are made on the web — so a
+// failed users.checkEmail lookup hands off to the browser. These cover the
+// handoff URL, which is the whole of that contract with the web /login route:
+// `mode=signup` selects the form, `email` prefills it.
+
+describe("signupUrl", () => {
+  it("selects the signup form and carries the address", () => {
+    const url = new URL(signupUrl("someone@example.com"))
+    expect(url.pathname).toBe("/login")
+    expect(url.searchParams.get("mode")).toBe("signup")
+    expect(url.searchParams.get("email")).toBe("someone@example.com")
+  })
+
+  // The reason this is a module and not an inline template literal. `+` is legal
+  // in a local part and is what Gmail's tag addressing uses; unencoded it decodes
+  // as a SPACE on the web side, silently prefilling a different address than the
+  // one the user typed and was told had no account.
+  it("encodes a + in the local part rather than letting it decode as a space", () => {
+    const url = signupUrl("someone+build@example.com")
+    expect(url).toContain("email=someone%2Bbuild%40example.com")
+    expect(new URL(url).searchParams.get("email")).toBe("someone+build@example.com")
+  })
+
+  it("encodes the other characters that would break the query string", () => {
+    const url = new URL(signupUrl("a&b=c@example.com"))
+    expect(url.searchParams.get("email")).toBe("a&b=c@example.com")
+    // The & must not have split the query into an extra parameter.
+    expect([...url.searchParams.keys()].sort()).toEqual(["email", "mode"])
+  })
+
+  it("trims surrounding whitespace, which a phone keyboard readily adds", () => {
+    expect(new URL(signupUrl("  someone@example.com ")).searchParams.get("email")).toBe(
+      "someone@example.com",
+    )
+  })
+
+  // Defensive: the screen only offers the handoff once checkEmail has answered
+  // for a non-empty address, but an empty `email=` would prefill the web form
+  // with nothing while looking deliberate. Omit the parameter instead.
+  it("omits the email parameter entirely when there is no address", () => {
+    const url = new URL(signupUrl("   "))
+    expect(url.searchParams.has("email")).toBe(false)
+    expect(url.searchParams.get("mode")).toBe("signup")
+  })
+
+  it("points at the same origin the API clients use", () => {
+    expect(signupUrl("someone@example.com").startsWith(signupBaseUrl)).toBe(true)
+    expect(signupBaseUrl.endsWith("/login")).toBe(true)
+  })
+})

--- a/web-app/code/src/presentation/components/buildInlime/LoginForm.tsx
+++ b/web-app/code/src/presentation/components/buildInlime/LoginForm.tsx
@@ -14,7 +14,11 @@ export function LoginForm() {
 
   const [view, setView] = useState<AuthView>("otp");
   const [name, setName] = useState("");
-  const [email, setEmail] = useState("");
+  // Seeded from ?email= so the mobile handoff does not ask for the address a
+  // second time. Initial value only — this is ordinary form state afterwards, so
+  // typing over it works and the mode toggles below (which preserve `email`)
+  // keep whatever is in the field.
+  const [email, setEmail] = useState(search.email || "");
   const [otp, setOtp] = useState("");
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState("");
@@ -158,10 +162,13 @@ export function LoginForm() {
             <div className="p-3 bg-red-50 border border-red-200 rounded-[10px]">
               <p className="font-['Instrument_Sans',sans-serif] text-[14px] text-red-600">{error}</p>
             </div>
+            {/* Carries `email` so the address survives the mode switch even if
+                the route change remounts this form — this button appears
+                precisely when one has just been typed and not found. */}
             {showSignupPrompt && (
               <button
                 type="button"
-                onClick={() => router.navigate({ to: '/login', search: { mode: 'signup', returnTo } })}
+                onClick={() => router.navigate({ to: '/login', search: { mode: 'signup', returnTo, email } })}
                 className="mt-2 w-full bg-white hover:bg-card-surface border border-primary text-primary rounded-[10px] h-[44px] font-['Instrument_Sans',sans-serif] font-medium text-[15px] flex items-center justify-center gap-2 transition-colors"
                 style={{ fontVariationSettings: "'wdth' 100" }}
               >
@@ -250,7 +257,7 @@ export function LoginForm() {
               <div className="text-center">
                 <button
                   type="button"
-                  onClick={() => router.navigate({ to: '/login', search: { mode: 'login', returnTo } })}
+                  onClick={() => router.navigate({ to: '/login', search: { mode: 'login', returnTo, email } })}
                   className="font-['Instrument_Sans',sans-serif] text-[14px] text-muted-foreground hover:text-foreground flex items-center justify-center gap-1 mx-auto"
                 >
                   <ArrowLeft className="w-4 h-4" />

--- a/web-app/code/src/presentation/routes/login.tsx
+++ b/web-app/code/src/presentation/routes/login.tsx
@@ -7,9 +7,22 @@ export const Route = createFileRoute('/login')({
   head: () => ({
     meta: [{ title: 'Login - BuildInLime' }],
   }),
-  validateSearch: (search: Record<string, unknown>) => ({
+  // `email` is OPTIONAL, and the return type says so explicitly. Inferring it as
+  // a required string would make every existing Link to /login a type error for
+  // omitting it — the header, the mobile menu, and the _authenticated bounce all
+  // navigate here with only returnTo + mode, and none of them has an address to
+  // offer.
+  validateSearch: (
+    search: Record<string, unknown>,
+  ): { returnTo: string; mode: 'signup' | 'login'; email?: string } => ({
     returnTo: (search.returnTo as string) || '/',
     mode: (search.mode as string) === 'signup' ? 'signup' : 'login',
+    // Carried over by the mobile app when its sign-in finds no account for the
+    // address (mobile-app/app/(auth)/login.tsx) — signup is web-only, so the
+    // handoff brings the address across rather than making it be typed twice.
+    // Prefill only: the form still validates and submits it like any other
+    // input, so a hand-crafted value gets no special treatment.
+    ...((search.email as string) ? { email: search.email as string } : {}),
   }),
   component: LoginRoute,
 })

--- a/web-app/code/tests/responsive/login-prefill.spec.ts
+++ b/web-app/code/tests/responsive/login-prefill.spec.ts
@@ -1,0 +1,82 @@
+import { test, expect } from "@playwright/test"
+
+// -----------------------------------------------------------------------------
+// The web half of the mobile signup handoff.
+//
+// The mobile app has no signup screen, so when its sign-in finds no account for
+// an address it sends the user here with ?mode=signup&email=… (see
+// mobile-app/src/infrastructure/auth/signup-url.ts, which owns the encoding and
+// is unit-tested there). What is left to prove is the receiving end: that the
+// route accepts the parameter and the form is actually prefilled with it.
+//
+// Lives in the responsive suite because it needs no database — /login is
+// unauthenticated and this never submits — which is what that config is for.
+// The assertions run at every viewport, so the handoff is covered on the phone
+// widths a mobile user is most likely to land on.
+// -----------------------------------------------------------------------------
+
+const emailField = "input[type=email]"
+
+// NOTE ON VIEWPORTS. Below `lg`, the desktop-recommended notice renders over
+// /login as a modal backdrop, so anything that CLICKS the form is intercepted by
+// it — and dismissing does not help, because the mode toggle re-navigates, which
+// remounts the page and re-raises the notice (its dismissal is mount-scoped by
+// design). `fill` is unaffected: it sets the value through DOM focus rather than
+// a pointer, so it reaches the field behind the backdrop.
+//
+// The one click-driven case is therefore desktop-only. What it checks — that the
+// mode toggle carries `email` in the search params — has nothing to do with
+// viewport, so nothing is lost by not repeating it at phone widths.
+
+test.describe("signup handoff from the mobile app", () => {
+  test("?mode=signup&email= opens the signup form with the address filled in", async ({
+    page,
+  }) => {
+    await page.goto("/login?mode=signup&email=someone%40example.com")
+
+    await expect(page.locator(emailField)).toHaveValue("someone@example.com")
+
+    // mode=signup, not sign-in: the name field is the signup-only input, so its
+    // presence is what distinguishes the two forms.
+    await expect(page.getByRole("textbox", { name: /name/i })).toBeVisible()
+  })
+
+  // The case the mobile unit tests encode for: a + in the local part must arrive
+  // as a +, not the space it decodes to when unescaped.
+  test("a plus-addressed email survives the round trip", async ({ page }) => {
+    await page.goto("/login?mode=signup&email=someone%2Bbuild%40example.com")
+
+    await expect(page.locator(emailField)).toHaveValue("someone+build@example.com")
+  })
+
+  test("the field stays editable — prefill is a starting point, not a lock", async ({
+    page,
+  }) => {
+    await page.goto("/login?mode=signup&email=typo%40example.com")
+
+    const field = page.locator(emailField)
+    await field.fill("corrected@example.com")
+    await expect(field).toHaveValue("corrected@example.com")
+  })
+
+  test("omitting the parameter leaves the form empty, as before", async ({ page }) => {
+    await page.goto("/login?mode=signup")
+
+    await expect(page.locator(emailField)).toHaveValue("")
+  })
+
+  test.describe("mode toggle", () => {
+    // See the viewport note above: the sub-lg notice intercepts the click.
+    test.skip(({ isMobile }) => !!isMobile, "click-driven; covered at desktop width")
+
+    test("the address survives switching signup -> sign in", async ({ page }) => {
+      await page.goto("/login?mode=signup&email=someone%40example.com")
+
+      // The "Back to login" toggle re-navigates with a new mode; it carries
+      // `email` so the address is not lost if the form remounts.
+      await page.getByRole("button", { name: /back to login/i }).click()
+
+      await expect(page.locator(emailField)).toHaveValue("someone@example.com")
+    })
+  })
+})


### PR DESCRIPTION
## Problem

Signing in on mobile with an unregistered address showed "No account found for this email address." and stopped there. That is a dead end: the mobile app has no signup screen, accounts are made on the web, and nothing on that screen said so — the one user who most needs direction got none.

## What changed

**Mobile** — the error becomes a block that offers a way forward: a "Create an account" button that opens the web signup page in the browser, plus a line pointing back at the address field for the other likely cause, a typo. It is an offer rather than an automatic redirect precisely because a mistyped address is the common case, and being thrown out of the app is an expensive way to find that out. Editing the field retracts the offer, since it was about the old value.

The address is carried across as `?email=` so it is not typed twice. The URL builder lives in `mobile-app/src/infrastructure/auth/signup-url.ts` rather than inline so the encoding is testable — a `+` in the local part (Gmail tag addressing, and legal regardless) decodes as a SPACE if it rides through unescaped, silently prefilling a different address than the one just reported as unregistered.

**Web** — `/login`'s `validateSearch` accepts `email` and `LoginForm` seeds its state from it. The parameter is optional and the return type says so explicitly: inferring it as required makes every existing `Link` to `/login` a type error for omitting it, and the header, the mobile menu and the `_authenticated` bounce all navigate here with only `returnTo` + `mode`.

Prefill only — the form validates and submits it like any other input, so a hand-crafted value gets no special treatment. Both mode toggles now carry `email`, so the address survives a switch between signup and sign-in.

## Tests

- `mobile-app/tests/signup-url.test.ts` (6 cases) — the handoff URL: `+` encoding, `&`/`=` in the local part, trimming, and omitting an empty parameter rather than sending `email=`. Mobile vitest is a node environment with component rendering out of scope, which is why the builder is a module.
- `web-app/code/tests/responsive/login-prefill.spec.ts` (5 cases) — the receiving end. One case is desktop-only and says why inline: below `lg` the desktop-recommended notice covers `/login` as a modal backdrop so a *click* is intercepted, and dismissing does not help because the mode toggle re-navigates and remounts the notice. `fill` goes through DOM focus rather than a pointer, so the read and edit cases still run at every viewport.

## Review notes

- No new dependencies, no schema or API changes.
- Signup remains web-only; this only adds the route to it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Q1sxnNGgxti7Vh1kgJR8SK
